### PR TITLE
Support scripted updates: modes and policy flags

### DIFF
--- a/agents/skills/migrations.md
+++ b/agents/skills/migrations.md
@@ -148,6 +148,10 @@ current_relative_target="../../../../.local/state/omarchy/current/theme/neovim.l
 ln -sfn "$current_relative_target" "$theme_link"
 ```
 
+### Unattended updates
+
+Migrations must not prompt during unattended updates (`OMARCHY_UPDATE_UNATTENDED=1`, set by `-y`/`--yes`/`--non-interactive`). When a migration cannot finish without a human answer, print an actionable message to stderr and exit nonzero: the migration stays pending, the queue stops, and the login notifier re-prompts until `omarchy-migrate` is run interactively. See `migrations/1786643346.sh` for the browser-open deferral pattern. Migrations whose installer would run external work behind a skipped category (for example mise) must also honor `OMARCHY_UPDATE_STRICT=1` plus that category policy and defer explicitly instead of silently installing partially or marking complete; see `migrations/1787760281.sh` for the strict-plus-`OMARCHY_UPDATE_MISE` guard pattern.
+
 ## Testing migrations
 
 Run a migration against a temporary home when possible:

--- a/bin/omarchy-update
+++ b/bin/omarchy-update
@@ -1,11 +1,269 @@
 #!/bin/bash
 
 # omarchy:summary=Update Omarchy and system packages
-# omarchy:args=[-y]
-# omarchy:examples=omarchy update | omarchy update -y
+# omarchy:args=[--yes|-y|--non-interactive] [--hooks=run|skip] [--aur=run|skip] [--mise=run|skip] [--orphans=ask|keep|remove] [--reboot=ask|never|if-needed] [--restarts=run|skip]
+# omarchy:examples=omarchy update | omarchy update --yes --orphans=keep --reboot=never | omarchy update --non-interactive --mise=run
 # omarchy:requires-sudo=true
 
-set -e
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: omarchy update [--yes|-y|--non-interactive] [--hooks=run|skip] [--aur=run|skip] [--mise=run|skip] [--orphans=ask|keep|remove] [--reboot=ask|never|if-needed] [--restarts=run|skip]
+
+Update Omarchy and system packages.
+
+Modes:
+  (no flags)        Interactive. Defaults: hooks/aur/mise/restarts=run, orphans=ask, reboot=ask.
+  -y, --yes         Unattended first-party full pipeline. Defaults: hooks/aur/mise/restarts=run, orphans=keep, reboot=never.
+                    Cooperative/best-effort for user hooks and external execution, not a universal no-prompt guarantee.
+  --non-interactive Unattended strict mode. Defaults: hooks/aur/mise=skip, restarts=run, orphans=keep, reboot=never.
+                    Built-in operations are nonprompting or fail; skipped optional steps are reported.
+                    Not an adversarial sandbox; arbitrary privileged hooks/package scripts are outside the guarantee.
+
+Policies (exact --name=value only, override mode defaults, order-independent):
+  --hooks=run|skip
+  --aur=run|skip
+  --mise=run|skip
+  --orphans=ask|keep|remove
+  --reboot=ask|never|if-needed
+  --restarts=run|skip
+
+Rules:
+  Repeating the same policy with the same value is allowed; contradictory repeats fail (exit 2).
+  -y, --yes and --non-interactive may combine; strict wins regardless of order.
+  ask with either unattended mode fails (exit 2) regardless of flag order.
+  Unknown args, missing/invalid values, and positional args fail (exit 2) before any transcript, lock, or side effects.
+  If -h/--help is present anywhere, this usage is printed (exit 0) without validating other args or running any steps.
+
+Destructive policies:
+  --orphans=remove authorizes removing current orphan packages without confirmation (existing recursive semantics).
+  --reboot=if-needed authorizes reboot only after all required work succeeds and update-owned inhibitors are released.
+  Automatic reboot can close unsaved applications; it never reboots midway or after failure.
+
+Examples:
+  omarchy update
+  omarchy update --yes
+  omarchy update --non-interactive
+  omarchy update --non-interactive --mise=run
+  omarchy update --yes --orphans=keep --reboot=never
+
+Exit codes:
+  0  selected mandatory work completed (deliberately skipped optional work is reported)
+  2  CLI misuse
+  nonzero  required step failure; downstream destructive work is not run
+USAGE
+}
+
+cli_error() {
+  echo "omarchy update: $1" >&2
+  exit 2
+}
+
+for arg in "$@"; do
+  if [[ $arg == "-h" || $arg == "--help" ]]; then
+    usage
+    exit 0
+  fi
+done
+
+has_yes=0
+has_strict=0
+declare -A seen_policy=()
+hooks_val=""
+aur_val=""
+mise_val=""
+orphans_val=""
+reboot_val=""
+restarts_val=""
+
+for arg in "$@"; do
+  if [[ $arg == "-y" || $arg == "--yes" ]]; then
+    has_yes=1
+  elif [[ $arg == "--non-interactive" ]]; then
+    has_strict=1
+  elif [[ $arg == --hooks=* || $arg == --aur=* || $arg == --mise=* || $arg == --orphans=* || $arg == --reboot=* || $arg == --restarts=* ]]; then
+    name="${arg%%=*}"
+    name="${name#--}"
+    value="${arg#*=}"
+    if [[ -z $value ]]; then
+      cli_error "missing value for --$name (exact --$name=value required)"
+    fi
+    case "$name" in
+      hooks|aur|mise)
+        if [[ $value != "run" && $value != "skip" ]]; then
+          cli_error "invalid value for --$name: $value (expected run|skip)"
+        fi
+        ;;
+      orphans)
+        if [[ $value != "ask" && $value != "keep" && $value != "remove" ]]; then
+          cli_error "invalid value for --orphans: $value (expected ask|keep|remove)"
+        fi
+        ;;
+      reboot)
+        if [[ $value != "ask" && $value != "never" && $value != "if-needed" ]]; then
+          cli_error "invalid value for --reboot: $value (expected ask|never|if-needed)"
+        fi
+        ;;
+      restarts)
+        if [[ $value != "run" && $value != "skip" ]]; then
+          cli_error "invalid value for --restarts: $value (expected run|skip)"
+        fi
+        ;;
+    esac
+    if [[ -n ${seen_policy[$name]:-} ]]; then
+      if [[ ${seen_policy[$name]} != "$value" ]]; then
+        cli_error "contradictory values for --$name: ${seen_policy[$name]} vs $value"
+      fi
+    else
+      seen_policy[$name]="$value"
+    fi
+    case "$name" in
+      hooks)
+        hooks_val="$value"
+        ;;
+      aur)
+        aur_val="$value"
+        ;;
+      mise)
+        mise_val="$value"
+        ;;
+      orphans)
+        orphans_val="$value"
+        ;;
+      reboot)
+        reboot_val="$value"
+        ;;
+      restarts)
+        restarts_val="$value"
+        ;;
+    esac
+  elif [[ $arg == --* || $arg == -* ]]; then
+    cli_error "unknown argument: $arg"
+  else
+    cli_error "unexpected positional argument: $arg"
+  fi
+done
+
+mode="interactive"
+if (( has_strict )); then
+  mode="strict"
+elif (( has_yes )); then
+  mode="full"
+fi
+
+if [[ -z $hooks_val ]]; then
+  if [[ $mode == "strict" ]]; then
+    hooks_val="skip"
+  else
+    hooks_val="run"
+  fi
+fi
+if [[ -z $aur_val ]]; then
+  if [[ $mode == "strict" ]]; then
+    aur_val="skip"
+  else
+    aur_val="run"
+  fi
+fi
+if [[ -z $mise_val ]]; then
+  if [[ $mode == "strict" ]]; then
+    mise_val="skip"
+  else
+    mise_val="run"
+  fi
+fi
+if [[ -z $orphans_val ]]; then
+  if [[ $mode == "interactive" ]]; then
+    orphans_val="ask"
+  else
+    orphans_val="keep"
+  fi
+fi
+if [[ -z $reboot_val ]]; then
+  if [[ $mode == "interactive" ]]; then
+    reboot_val="ask"
+  else
+    reboot_val="never"
+  fi
+fi
+if [[ -z $restarts_val ]]; then
+  restarts_val="run"
+fi
+
+if [[ $mode != "interactive" ]]; then
+  if [[ $orphans_val == "ask" ]]; then
+    cli_error "--orphans=ask cannot be used with --yes/--non-interactive"
+  fi
+  if [[ $reboot_val == "ask" ]]; then
+    cli_error "--reboot=ask cannot be used with --yes/--non-interactive"
+  fi
+fi
+
+if [[ $mode == "interactive" ]]; then
+  unset OMARCHY_UPDATE_UNATTENDED || true
+  unset OMARCHY_UPDATE_STRICT || true
+elif [[ $mode == "full" ]]; then
+  export OMARCHY_UPDATE_UNATTENDED=1
+  unset OMARCHY_UPDATE_STRICT || true
+else
+  export OMARCHY_UPDATE_UNATTENDED=1
+  export OMARCHY_UPDATE_STRICT=1
+fi
+export OMARCHY_UPDATE_HOOKS="$hooks_val"
+export OMARCHY_UPDATE_AUR="$aur_val"
+export OMARCHY_UPDATE_MISE="$mise_val"
+export OMARCHY_UPDATE_ORPHANS="$orphans_val"
+export OMARCHY_UPDATE_REBOOT="$reboot_val"
+export OMARCHY_UPDATE_RESTARTS="$restarts_val"
+
+if [[ ${OMARCHY_UPDATE_UNATTENDED:-} == "1" ]]; then
+  if [[ -z ${OMARCHY_PATH:-} ]]; then
+    echo "omarchy update: OMARCHY_PATH is not set" >&2
+    exit 1
+  fi
+  adapter_dir="$OMARCHY_PATH/default/omarchy/update-bin"
+  expected_sudo="$adapter_dir/sudo"
+  need_runner=0
+  if [[ ${OMARCHY_UPDATE_ENV_READY:-} != "1" ]]; then
+    need_runner=1
+  else
+    resolved_sudo=$(type -P sudo 2>/dev/null || true)
+    if [[ $resolved_sudo != "$expected_sudo" ]]; then
+      canonical_resolved=$(readlink -f "$resolved_sudo" 2>/dev/null || true)
+      canonical_expected=$(readlink -f "$expected_sudo" 2>/dev/null || true)
+      if [[ -z $canonical_resolved || -z $canonical_expected || $canonical_resolved != "$canonical_expected" ]]; then
+        need_runner=1
+      fi
+    fi
+    if (( need_runner == 0 )); then
+      real_sudo="${OMARCHY_UPDATE_REAL_SUDO:-}"
+      if [[ -z $real_sudo || $real_sudo != /* ]]; then
+        need_runner=1
+      elif [[ ! -x $real_sudo ]]; then
+        need_runner=1
+      elif [[ $real_sudo == "$adapter_dir/"* ]]; then
+        need_runner=1
+      else
+        canonical_real=$(readlink -f "$real_sudo" 2>/dev/null || true)
+        canonical_sudo=$(readlink -f "$expected_sudo" 2>/dev/null || true)
+        canonical_dir=$(readlink -f "$adapter_dir" 2>/dev/null || true)
+        if [[ -n $canonical_real && -n $canonical_sudo && $canonical_real == "$canonical_sudo" ]]; then
+          need_runner=1
+        elif [[ -n $canonical_real && -n $canonical_dir && $canonical_real == "$canonical_dir/"* ]]; then
+          need_runner=1
+        fi
+      fi
+    fi
+  fi
+  if (( need_runner )); then
+    if [[ ${OMARCHY_UPDATE_RUN_REEXEC:-} == "1" ]]; then
+      echo "omarchy update: privilege environment is not ready and re-entry failed; refusing to continue" >&2
+      exit 1
+    fi
+    exec env OMARCHY_UPDATE_RUN_REEXEC=1 omarchy-update-run "$0" "$@"
+  fi
+fi
 
 if [[ -z ${OMARCHY_UPDATE_LOGGED:-} ]]; then
   script_command=$(printf '%q ' "$0" "$@")
@@ -21,11 +279,21 @@ trap 'omarchy-update-stay-awake stop' EXIT
 
 omarchy-update-requires-free-space
 
-# -y is a promise not to ask anything. Steps that would need an answer report
-# and move on instead of waiting on a prompt nobody is here to give.
-[[ ${1:-} != "-y" ]] || export OMARCHY_UPDATE_UNATTENDED=1
+if [[ ${OMARCHY_UPDATE_UNATTENDED:-} == "1" ]]; then
+  if [[ ${OMARCHY_UPDATE_STRICT:-} == "1" ]]; then
+    echo "Unattended update (strict): hooks=$OMARCHY_UPDATE_HOOKS, aur=$OMARCHY_UPDATE_AUR, mise=$OMARCHY_UPDATE_MISE, orphans=$OMARCHY_UPDATE_ORPHANS, reboot=$OMARCHY_UPDATE_REBOOT, restarts=$OMARCHY_UPDATE_RESTARTS"
+  else
+    echo "Unattended update (full): hooks=$OMARCHY_UPDATE_HOOKS, aur=$OMARCHY_UPDATE_AUR, mise=$OMARCHY_UPDATE_MISE, orphans=$OMARCHY_UPDATE_ORPHANS, reboot=$OMARCHY_UPDATE_REBOOT, restarts=$OMARCHY_UPDATE_RESTARTS"
+  fi
+  if [[ $OMARCHY_UPDATE_ORPHANS == "remove" ]]; then
+    echo "Orphan policy: remove -- orphaned packages will be removed without confirmation"
+  fi
+  if [[ $OMARCHY_UPDATE_REBOOT == "if-needed" ]]; then
+    echo "Reboot policy: if-needed -- system will reboot automatically when required (may close unsaved applications)"
+  fi
+fi
 
-if [[ ${1:-} == "-y" ]] || omarchy-update-confirm; then
+if [[ ${OMARCHY_UPDATE_UNATTENDED:-} == "1" ]] || omarchy-update-confirm; then
   # Before the snapshot: the cache is on the snapshotted subvolume, so pruning
   # after it frees nothing until that snapshot ages out.
   omarchy-update-pkg-prune
@@ -46,9 +314,34 @@ if [[ ${1:-} == "-y" ]] || omarchy-update-confirm; then
   # takes the update with it rather than migrating against what is still on disk.
   omarchy-update-system-pkgs
   omarchy-migrate
-  omarchy-hook post-update
-  omarchy-update-aur-pkgs
-  omarchy-update-mise
+
+  if [[ $OMARCHY_UPDATE_HOOKS == "skip" ]]; then
+    echo "Skipping post-update hooks (--hooks=skip)"
+  else
+    if [[ ${OMARCHY_UPDATE_STRICT:-} == "1" ]]; then
+      echo "Warning: --hooks=run in strict mode relaxes the non-interactive guarantee; arbitrary hook code may prompt" >&2
+    fi
+    omarchy-hook post-update
+  fi
+
+  if [[ $OMARCHY_UPDATE_AUR == "skip" ]]; then
+    echo "Skipping AUR package updates (--aur=skip)"
+  else
+    if [[ ${OMARCHY_UPDATE_STRICT:-} == "1" ]]; then
+      echo "Warning: --aur=run in strict mode relaxes the non-interactive guarantee; arbitrary AUR code may prompt" >&2
+    fi
+    omarchy-update-aur-pkgs
+  fi
+
+  if [[ $OMARCHY_UPDATE_MISE == "skip" ]]; then
+    echo "Skipping mise updates (--mise=skip)"
+  else
+    if [[ ${OMARCHY_UPDATE_STRICT:-} == "1" ]]; then
+      echo "Warning: --mise=run in strict mode relaxes the non-interactive guarantee; arbitrary mise code may prompt" >&2
+    fi
+    omarchy-update-mise
+  fi
+
   omarchy-update-orphan-pkgs
 
   omarchy-update-analyze-logs

--- a/bin/omarchy-update-available
+++ b/bin/omarchy-update-available
@@ -9,6 +9,16 @@ updates=()
 if [[ $OMARCHY_PATH != "/usr/share/omarchy" ]]; then
   upstream=$(git -C "$OMARCHY_PATH" rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || true)
   if [[ -n $upstream ]]; then
+    if [[ ${OMARCHY_UPDATE_UNATTENDED:-} == "1" ]]; then
+      # Unattended fetch must never prompt (terminal/askpass/SSH). GIT_ASKPASS=
+      # (empty) falls back to terminal prompts, which GIT_TERMINAL_PROMPT=0 disables,
+      # so auth failures fail closed. GIT_SSH_COMMAND env wins over core.sshCommand,
+      # so a custom sshCommand program is never executed unattended; an explicit
+      # GIT_SSH_COMMAND in the environment is preserved.
+      export GIT_TERMINAL_PROMPT=0
+      export GIT_ASKPASS=
+      export GIT_SSH_COMMAND="${GIT_SSH_COMMAND:-ssh -oBatchMode=yes}"
+    fi
     GIT_TERMINAL_PROMPT=0 timeout 10 git -C "$OMARCHY_PATH" fetch --quiet 2>/dev/null || true
 
     behind=$(git -C "$OMARCHY_PATH" rev-list --count "HEAD..$upstream" 2>/dev/null || echo 0)

--- a/bin/omarchy-update-dev
+++ b/bin/omarchy-update-dev
@@ -18,4 +18,14 @@ if [[ -z $upstream ]]; then
 fi
 
 echo -e "\e[32m\nUpdate Omarchy dev checkout\e[0m"
+if [[ ${OMARCHY_UPDATE_UNATTENDED:-} == "1" ]]; then
+  # Unattended git must never prompt (terminal/askpass/SSH). GIT_ASKPASS=
+  # (empty) makes git fall back to terminal prompts, which GIT_TERMINAL_PROMPT=0
+  # then disables, so auth failures fail closed instead of hanging. GIT_SSH_COMMAND
+  # env wins over core.sshCommand, so a user's custom sshCommand program is never
+  # executed unattended; an explicit GIT_SSH_COMMAND in the environment is preserved.
+  export GIT_TERMINAL_PROMPT=0
+  export GIT_ASKPASS=
+  export GIT_SSH_COMMAND="${GIT_SSH_COMMAND:-ssh -oBatchMode=yes}"
+fi
 git -C "$OMARCHY_PATH" pull --ff-only

--- a/bin/omarchy-update-keyring
+++ b/bin/omarchy-update-keyring
@@ -3,6 +3,15 @@
 # omarchy:summary=Ensure the Omarchy and Arch keyring packages are installed and populated
 # omarchy:requires-sudo=true
 
+set -euo pipefail
+
+if [[ ${OMARCHY_UPDATE_UNATTENDED:-} == "1" ]]; then
+  if ! sudo -n true 2>/dev/null; then
+    echo "omarchy-update-keyring: unattended update cannot authenticate with sudo (sudo -n failed); run interactively or refresh sudo credentials before retrying" >&2
+    exit 1
+  fi
+fi
+
 if omarchy-pkg-missing omarchy-keyring || ! sudo pacman-key --list-keys 40DFB630FF42BCFFB047046CF0134EE680CAC571 &>/dev/null; then
   sudo pacman-key --recv-keys 40DFB630FF42BCFFB047046CF0134EE680CAC571 --keyserver keys.openpgp.org
   sudo pacman-key --lsign-key 40DFB630FF42BCFFB047046CF0134EE680CAC571

--- a/bin/omarchy-update-orphan-pkgs
+++ b/bin/omarchy-update-orphan-pkgs
@@ -5,12 +5,46 @@
 
 set -e
 
+policy="${OMARCHY_UPDATE_ORPHANS:-}"
+if [[ -z $policy ]]; then
+  if [[ ${OMARCHY_UPDATE_UNATTENDED:-} == "1" ]]; then
+    policy="keep"
+  else
+    policy="ask"
+  fi
+fi
+
+if [[ $policy != "ask" && $policy != "keep" && $policy != "remove" ]]; then
+  echo "omarchy-update-orphan-pkgs: invalid OMARCHY_UPDATE_ORPHANS: $policy (expected ask|keep|remove)" >&2
+  exit 2
+fi
+
 mapfile -t orphans < <(pacman -Qtdq 2>/dev/null || true)
 (( ${#orphans[@]} )) || exit 0
 
 echo -e "\e[32m\nOrphan system packages\e[0m"
 printf '  %s\n' "${orphans[@]}"
 echo
+
+if [[ $policy == "keep" ]]; then
+  echo "Keeping orphaned packages."
+  echo "${#orphans[@]} orphaned package(s) found. Re-run omarchy-update-orphan-pkgs in a terminal to review/remove them."
+  echo
+  exit 0
+fi
+
+if [[ $policy == "remove" ]]; then
+  echo -e "\e[32m\nRemoving orphan system packages\e[0m"
+  sudo pacman -Rns --noconfirm "${orphans[@]}"
+  echo
+  exit 0
+fi
+
+if [[ ${OMARCHY_UPDATE_UNATTENDED:-} == "1" ]]; then
+  echo "${#orphans[@]} orphaned package(s) found. Re-run omarchy-update-orphan-pkgs in a terminal to review/remove them."
+  echo
+  exit 0
+fi
 
 if [[ ! -t 0 || ! -t 1 ]]; then
   echo "${#orphans[@]} orphaned package(s) found. Re-run omarchy-update-orphan-pkgs in a terminal to review/remove them."

--- a/bin/omarchy-update-restart
+++ b/bin/omarchy-update-restart
@@ -2,11 +2,37 @@
 
 # omarchy:summary=Prompt for required reboot or service restarts after updates
 
+set -e
+
+reboot_policy="${OMARCHY_UPDATE_REBOOT:-}"
+if [[ -z $reboot_policy ]]; then
+  if [[ ${OMARCHY_UPDATE_UNATTENDED:-} == "1" ]]; then
+    reboot_policy="never"
+  else
+    reboot_policy="ask"
+  fi
+fi
+
+restarts_policy="${OMARCHY_UPDATE_RESTARTS:-}"
+if [[ -z $restarts_policy ]]; then
+  restarts_policy="run"
+fi
+
+if [[ $reboot_policy != "ask" && $reboot_policy != "never" && $reboot_policy != "if-needed" ]]; then
+  echo "omarchy-update-restart: invalid OMARCHY_UPDATE_REBOOT: $reboot_policy (expected ask|never|if-needed)" >&2
+  exit 2
+fi
+
+if [[ $restarts_policy != "run" && $restarts_policy != "skip" ]]; then
+  echo "omarchy-update-restart: invalid OMARCHY_UPDATE_RESTARTS: $restarts_policy (expected run|skip)" >&2
+  exit 2
+fi
+
 echo
 
-confirm_reboot() {
-  gum confirm "$1" && { omarchy-system-reboot; exit 0; }
-}
+kernel_message="Linux kernel has been updated. Reboot?"
+marker_message="Updates require reboot. Ready?"
+hyprland_message="Hyprland has been updated. Reboot?"
 
 running_kernel=$(uname -r)
 kernel_updated=true
@@ -22,24 +48,86 @@ for kernel in /usr/lib/modules/*/vmlinuz; do
   fi
 done
 
+reboot_needs=()
 if [[ $kernel_updated == "true" ]]; then
-  confirm_reboot "Linux kernel has been updated. Reboot?"
-elif [[ -f $HOME/.local/state/omarchy/reboot-required ]]; then
-  confirm_reboot "Updates require reboot. Ready?"
+  reboot_needs+=("$kernel_message")
+fi
+if [[ -f $HOME/.local/state/omarchy/reboot-required ]]; then
+  reboot_needs+=("$marker_message")
 fi
 
-running_hyprland=$(readlink /proc/$(pgrep -x Hyprland)/exe 2>/dev/null)
+running_hyprland=$(readlink /proc/$(pgrep -x Hyprland)/exe 2>/dev/null || true)
 if [[ $running_hyprland == *"(deleted)"* ]]; then
-  confirm_reboot "Hyprland has been updated. Reboot?"
+  reboot_needs+=("$hyprland_message")
 fi
 
+if (( ${#reboot_needs[@]} > 0 )); then
+  if [[ $reboot_policy == "ask" ]]; then
+    if [[ ${OMARCHY_UPDATE_UNATTENDED:-} != "1" && -t 0 && -t 1 ]]; then
+      if gum confirm "${reboot_needs[0]}"; then
+        omarchy-system-reboot
+        exit 0
+      fi
+    else
+      for need in "${reboot_needs[@]}"; do
+        echo "Reboot required: $need"
+      done
+    fi
+  elif [[ $reboot_policy == "never" ]]; then
+    for need in "${reboot_needs[@]}"; do
+      echo "Reboot required: $need"
+    done
+  else
+    # if-needed: single nonprompting reboot on the final success path only.
+    # The caller releases update-owned inhibitors before invoking this helper,
+    # so this runs after all required work succeeds. Plain sudo so the
+    # unattended adapter prepends -n via PATH; interactive uses this same
+    # direct command. Never gum, omarchy-system-reboot, window-close, or OSD.
+    for need in "${reboot_needs[@]}"; do
+      echo "Reboot required: $need"
+    done
+    echo "Rebooting automatically (--reboot=if-needed)..."
+    if sudo systemctl --no-ask-password reboot --no-wall; then
+      echo "Reboot requested."
+      exit 0
+    else
+      reboot_status=$?
+      echo "omarchy-update-restart: automatic reboot failed (exit $reboot_status); reboot-required state retained" >&2
+      exit "$reboot_status"
+    fi
+  fi
+fi
+
+if [[ $restarts_policy == "skip" ]]; then
+  deferred=()
+  for file in "$HOME"/.local/state/omarchy/restart-*-required; do
+    if [[ -f $file ]]; then
+      deferred+=("$(basename "$file")")
+    fi
+  done
+  if (( ${#deferred[@]} > 0 )); then
+    echo "Skipping service restarts (--restarts=skip): ${#deferred[@]} service(s) deferred"
+    printf '  %s\n' "${deferred[@]}"
+  else
+    echo "Skipping service restarts (--restarts=skip): nothing deferred"
+  fi
+  echo "Shell restart deferred (--restarts=skip)"
+  exit 0
+fi
+
+restart_failed=0
 for file in "$HOME"/.local/state/omarchy/restart-*-required; do
   if [[ -f $file ]]; then
     filename=$(basename "$file")
     service=$(echo "$filename" | sed 's/restart-\(.*\)-required/\1/')
     echo "Restarting $service"
-    omarchy-state clear "$filename"
-    omarchy-restart-"$service"
+    if omarchy-restart-"$service"; then
+      omarchy-state clear "$filename"
+    else
+      service_status=$?
+      echo "omarchy-update-restart: failed to restart $service (exit $service_status); marker retained" >&2
+      restart_failed=1
+    fi
   fi
 done
 
@@ -49,3 +137,7 @@ done
 echo -e "\e[32m\nRestarting shell\e[0m"
 echo "All plugins have been reloaded"
 omarchy-restart-shell || true
+
+if (( restart_failed )); then
+  exit 1
+fi

--- a/bin/omarchy-update-run
+++ b/bin/omarchy-update-run
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+# omarchy:summary=Run a command with the unattended update privilege environment
+# omarchy:args=<command> [args...]
+# omarchy:hidden=true
+
+set -euo pipefail
+
+if (( $# == 0 )); then
+  echo "Usage: omarchy-update-run <command> [args...]" >&2
+  exit 2
+fi
+
+if [[ ${OMARCHY_UPDATE_UNATTENDED:-} != "1" ]]; then
+  exec "$@"
+fi
+
+adapter_dir="${OMARCHY_PATH:-/usr/share/omarchy}/default/omarchy/update-bin"
+adapter_sudo="$adapter_dir/sudo"
+adapter_pkexec="$adapter_dir/pkexec"
+
+if [[ ! -x $adapter_sudo ]]; then
+  echo "omarchy-update-run: sudo adapter is not installed/executable: $adapter_sudo" >&2
+  exit 1
+fi
+
+if [[ ! -x $adapter_pkexec ]]; then
+  echo "omarchy-update-run: pkexec adapter is not installed/executable: $adapter_pkexec" >&2
+  exit 1
+fi
+
+canonical_adapter_sudo=$(readlink -f "$adapter_sudo" 2>/dev/null || true)
+canonical_adapter_dir=$(readlink -f "$adapter_dir" 2>/dev/null || true)
+
+is_adapter_path() {
+  local candidate="$1"
+  local canonical_candidate=""
+
+  if [[ $candidate == "$adapter_sudo" ]]; then
+    return 0
+  fi
+  if [[ $candidate == "$adapter_dir/"* ]]; then
+    return 0
+  fi
+  canonical_candidate=$(readlink -f "$candidate" 2>/dev/null || true)
+  if [[ -n $canonical_candidate && -n $canonical_adapter_sudo ]]; then
+    if [[ $canonical_candidate == "$canonical_adapter_sudo" ]]; then
+      return 0
+    fi
+  fi
+  if [[ -n $canonical_candidate && -n $canonical_adapter_dir ]]; then
+    if [[ $canonical_candidate == "$canonical_adapter_dir/"* ]]; then
+      return 0
+    fi
+  fi
+  return 1
+}
+
+real_sudo="${OMARCHY_UPDATE_REAL_SUDO:-}"
+
+if [[ -n $real_sudo ]]; then
+  if [[ $real_sudo != /* ]]; then
+    echo "omarchy-update-run: OMARCHY_UPDATE_REAL_SUDO is not an absolute path: $real_sudo" >&2
+    exit 1
+  fi
+  if is_adapter_path "$real_sudo"; then
+    echo "omarchy-update-run: OMARCHY_UPDATE_REAL_SUDO points at the sudo adapter, refusing recursion: $real_sudo" >&2
+    exit 1
+  fi
+  if [[ ! -x $real_sudo ]]; then
+    echo "omarchy-update-run: OMARCHY_UPDATE_REAL_SUDO is not executable: $real_sudo" >&2
+    exit 1
+  fi
+else
+  real_sudo=$(type -P sudo 2>/dev/null || true)
+  if [[ -z $real_sudo ]]; then
+    echo "omarchy-update-run: no sudo found on PATH for unattended update" >&2
+    exit 1
+  fi
+  if [[ $real_sudo != /* ]]; then
+    echo "omarchy-update-run: captured sudo is not an absolute path: $real_sudo" >&2
+    exit 1
+  fi
+  if is_adapter_path "$real_sudo"; then
+    echo "omarchy-update-run: captured sudo resolves to the adapter itself, refusing recursion: $real_sudo" >&2
+    exit 1
+  fi
+  if [[ ! -x $real_sudo ]]; then
+    echo "omarchy-update-run: captured sudo is not executable: $real_sudo" >&2
+    exit 1
+  fi
+fi
+
+clean_path=":${PATH:-}:"
+clean_path="${clean_path//:$adapter_dir:/:}"
+clean_path="${clean_path#:}"
+clean_path="${clean_path%:}"
+if [[ -z $clean_path ]]; then
+  PATH="$adapter_dir"
+else
+  PATH="$adapter_dir:$clean_path"
+fi
+export PATH
+export OMARCHY_UPDATE_REAL_SUDO="$real_sudo"
+export OMARCHY_UPDATE_ENV_READY=1
+exec "$@"

--- a/bin/omarchy-update-stay-awake
+++ b/bin/omarchy-update-stay-awake
@@ -91,7 +91,10 @@ start() {
 
   if omarchy-cmd-present systemd-inhibit; then
     if (( EUID != 0 )); then
-      if [[ -t 0 ]]; then
+      if [[ ${OMARCHY_UPDATE_UNATTENDED:-} == "1" ]]; then
+        sudo -n -v 2>/dev/null || true
+        inhibit_runner=(sudo -n)
+      elif [[ -t 0 ]]; then
         sudo -v
         inhibit_runner=(sudo)
       else
@@ -115,9 +118,19 @@ start() {
         sleep infinity >/dev/null 2>&1 &
     fi
     inhibit_pid=$!
-    inhibit_start_time=$(process_start_time "$inhibit_pid" 2>/dev/null || true)
-    if [[ -n $inhibit_start_time ]]; then
-      printf '%s %s\n' "$inhibit_pid" "$inhibit_start_time" >"$inhibit_pid_file"
+    sleep 0.2 || true
+    if ! kill -0 "$inhibit_pid" 2>/dev/null || [[ $(process_state "$inhibit_pid" 2>/dev/null || true) == "Z" ]]; then
+      wait "$inhibit_pid" 2>/dev/null || true
+      echo "Warning: sleep inhibitor failed to start; continuing without sleep inhibition." >&2
+      rm -f "$inhibit_pid_file"
+    else
+      inhibit_start_time=$(process_start_time "$inhibit_pid" 2>/dev/null || true)
+      if [[ -n $inhibit_start_time ]]; then
+        printf '%s %s\n' "$inhibit_pid" "$inhibit_start_time" >"$inhibit_pid_file"
+      else
+        echo "Warning: sleep inhibitor failed to start; continuing without sleep inhibition." >&2
+        rm -f "$inhibit_pid_file"
+      fi
     fi
   fi
 

--- a/default/omarchy/update-bin/pkexec
+++ b/default/omarchy/update-bin/pkexec
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Unattended pkexec adapter, installed only on the PATH of omarchy-update-run
+# descendants. No nonprompting form is accepted by policy under unattended
+# updates, so fail closed with an actionable message and never
+# exec the real pkexec. Not a security sandbox: absolute-path, cleared-PATH,
+# or custom programs can bypass PATH adapters.
+
+set -euo pipefail
+
+echo "omarchy-update pkexec adapter: unattended auth cannot use graphical prompt (pkexec); run interactively or avoid the privileged step" >&2
+exit 1

--- a/default/omarchy/update-bin/sudo
+++ b/default/omarchy/update-bin/sudo
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+# Unattended sudo adapter, installed only on the PATH of omarchy-update-run
+# descendants. Always runs the captured real sudo with -n prepended (caller -n
+# duplicates are tolerated by sudo), so no password, askpass, or stdin-auth fallback can prompt.
+#
+# Supported safe surface: plain `sudo <command> [args...]`, `sudo env ...`,
+# `sudo tee/mv/mkdir/pacman/snapper/systemctl/...`, `sudo -n`, `sudo -v`,
+# `-E`, `-u/-g/-U/-r/-t/-C/-D/-R/-T` with values, long equivalents with
+# `=value` or a separate value, and the `--` separator.
+# Rejected before the command separator: -S/--stdin, -A/--askpass,
+# -p/--prompt (including combined short clusters like -Sn). Anything after
+# `--` or after the command name is a target-command argument and is passed
+# through untouched (e.g. `sudo -- printf '%s' --askpass` is allowed).
+# Never adds --preserve-env. Never reads stdin itself; stdin flows to the
+# real sudo child (e.g. `echo hi | sudo tee file`). Not a security sandbox:
+# absolute-path, cleared-PATH, or custom programs can bypass PATH adapters.
+
+set -euo pipefail
+
+if [[ -z ${OMARCHY_UPDATE_REAL_SUDO:-} ]]; then
+  echo "omarchy-update sudo adapter: OMARCHY_UPDATE_REAL_SUDO is not set; run through omarchy-update-run" >&2
+  exit 1
+fi
+
+real_sudo="$OMARCHY_UPDATE_REAL_SUDO"
+
+if [[ $real_sudo != /* ]]; then
+  echo "omarchy-update sudo adapter: OMARCHY_UPDATE_REAL_SUDO is not an absolute path: $real_sudo" >&2
+  exit 1
+fi
+
+if [[ ! -x $real_sudo ]]; then
+  echo "omarchy-update sudo adapter: real sudo is not executable: $real_sudo" >&2
+  exit 1
+fi
+
+self_path=$(readlink -f "${BASH_SOURCE[0]:-$0}" 2>/dev/null || printf '%s' "${BASH_SOURCE[0]:-$0}")
+self_dir=$(dirname "$self_path")
+canonical_real=$(readlink -f "$real_sudo" 2>/dev/null || true)
+if [[ -n $canonical_real && $canonical_real == "$self_path" ]]; then
+  echo "omarchy-update sudo adapter: real sudo points at the adapter itself, refusing recursion" >&2
+  exit 1
+fi
+if [[ -n $canonical_real && $canonical_real == "$self_dir/"* ]]; then
+  echo "omarchy-update sudo adapter: real sudo lives inside the adapter directory, refusing recursion: $real_sudo" >&2
+  exit 1
+fi
+if [[ $real_sudo == "$self_dir/"* ]]; then
+  echo "omarchy-update sudo adapter: real sudo lives inside the adapter directory, refusing recursion: $real_sudo" >&2
+  exit 1
+fi
+
+scan_args=()
+if (( $# > 0 )); then
+  scan_args=("$@")
+fi
+
+idx=0
+total=${#scan_args[@]}
+while (( idx < total )); do
+  token="${scan_args[$idx]}"
+  if [[ $token == "--" ]]; then
+    break
+  fi
+  if [[ $token == "-" ]]; then
+    break
+  fi
+  if [[ $token == --* ]]; then
+    name="${token%%=*}"
+    if [[ $name == "--stdin" || $name == "--askpass" || $name == "--prompt" ]]; then
+      echo "omarchy-update sudo adapter: refusing prompt-enabling option: $token" >&2
+      exit 1
+    fi
+    case "$name" in
+      --prompt|--user|--group|--other-user|--role|--type|--chdir|--chroot|--close-from|--command-timeout)
+        if [[ $token != *"="* ]]; then
+          idx=$((idx + 1))
+        fi
+        ;;
+    esac
+    idx=$((idx + 1))
+    continue
+  fi
+  if [[ $token == -* ]]; then
+    cluster="${token#-}"
+    pos=0
+    cluster_len=${#cluster}
+    while (( pos < cluster_len )); do
+      ch="${cluster:$pos:1}"
+      if [[ $ch == "S" || $ch == "A" || $ch == "p" ]]; then
+        echo "omarchy-update sudo adapter: refusing prompt-enabling option: -$ch in $token" >&2
+        exit 1
+      fi
+      if [[ $ch == "C" || $ch == "D" || $ch == "g" || $ch == "R" || $ch == "r" || $ch == "T" || $ch == "t" || $ch == "U" || $ch == "u" ]]; then
+        rest="${cluster:$((pos + 1))}"
+        if [[ -z $rest ]]; then
+          idx=$((idx + 1))
+        fi
+        break
+      fi
+      pos=$((pos + 1))
+    done
+    idx=$((idx + 1))
+    continue
+  fi
+  break
+done
+
+exec "$real_sudo" -n "$@"

--- a/docs/update-process.md
+++ b/docs/update-process.md
@@ -111,35 +111,40 @@ and restores the session's previous `misc.disable_autoreload` and
 High-level flow:
 
 ```text
-omarchy-update
+omarchy-update [--yes|-y|--non-interactive] [--hooks=run|skip] [--aur=run|skip] [--mise=run|skip] [--orphans=ask|keep|remove] [--reboot=ask|never|if-needed] [--restarts=run|skip]
+  ├─ parse/validate CLI flags (misuse exits 2 before transcript, lock, or side effects) and normalize/export unattended policy env
+  ├─ unattended only: re-exec through omarchy-update-run to install scoped privilege adapters (before transcript, lock, and free-space checks)
   ├─ ensure transcript logging through script(1) → /tmp/omarchy-update.log
   ├─ omarchy-update-lock
   │    └─ acquire the update lock and run omarchy-update inside it
   ├─ omarchy-update-requires-free-space
   │    └─ abort below the configured free-space threshold on /
-  ├─ confirm unless -y
+  ├─ interactive: omarchy-update-confirm; unattended: print Unattended update (full|strict) summary plus destructive-policy lines, no confirmation prompt
   ├─ omarchy-update-pkg-prune
-  │    └─ trim the pacman cache to two versions per package, deliberately
-  │       before the snapshot since the cache lives on the snapshotted subvolume
-  ├─ create snapper snapshot (skipped silently without snapper; snapper
-  │  installed but unconfigured fails the snapshot loudly, pointing at
-  │  install/config/snapper.sh, and the update continues without one)
+  │    └─ trim the pacman cache to two versions per package, deliberately before the snapshot since the cache lives on the snapshotted subvolume
+  ├─ create snapper snapshot (skipped silently without snapper; snapper installed but unconfigured fails the snapshot loudly, pointing at install/config/snapper.sh, and the update continues without one)
   ├─ omarchy-update-stay-awake start
-  ├─ run package updates, migrations, hooks, and log analysis
+  ├─ run package updates, migrations, policy-gated hooks/AUR/mise, orphan handling, and log analysis
   ├─ omarchy-update-status
   │    └─ refresh or clear the shell update indicator
   ├─ omarchy-update-stay-awake stop
-  │    └─ release the sleep inhibitor and restore shell idle state, if changed
-  └─ omarchy-update-restart
+  │    └─ release the sleep inhibitor and restore shell idle state, if changed (released before restart so an automatic reboot cannot strand it)
+  └─ omarchy-update-restart (policy-gated reboot and service/shell restarts)
 ```
 
 Important behavior:
 
 - In dev-link mode, `omarchy update` fast-forwards the active checkout from its
   configured upstream before changing system packages or running migrations.
-- `-y` exports `OMARCHY_UPDATE_UNATTENDED=1` — a promise not to ask anything.
-  Steps that would prompt (orphan removal, conflict handoff) report and skip
-  instead of blocking.
+- CLI contract: `omarchy update [--yes|-y|--non-interactive] [--hooks=run|skip] [--aur=run|skip] [--mise=run|skip] [--orphans=ask|keep|remove] [--reboot=ask|never|if-needed] [--restarts=run|skip]`. No arguments keeps current interactive behavior. `-y` and `--yes` are identical unattended first-party full-pipeline modes. `--non-interactive` is unattended strict mode. `-y`/`--yes` plus `--non-interactive` may combine; strict wins regardless of order. Only exact `--name=value` forms are accepted. Repeating the same policy with the same value is allowed; contradictory repeats fail with exit 2. `ask` with either unattended mode fails with exit 2 regardless of flag order. Unknown args, missing/invalid values, and positional args fail with exit 2 before any transcript, lock, or side effects. If `-h`/`--help` is present anywhere, usage is printed with exit 0 without validating other args or running any steps.
+- Mode defaults: interactive (no flags) uses hooks/aur/mise/restarts=run with orphans=ask and reboot=ask; `-y`/`--yes` (full) uses hooks/aur/mise/restarts=run with orphans=keep and reboot=never; `--non-interactive` (strict) uses hooks/aur/mise=skip with restarts=run, orphans=keep, and reboot=never. Explicit `--hooks`/`--aur`/`--mise`/`--orphans`/`--reboot`/`--restarts` values override the mode defaults order-independently.
+- Policy env (normalized from argv before transcript/lock/privilege/space work; public flags are authoritative and stale inherited policy values never leak): `OMARCHY_UPDATE_UNATTENDED=1` for either unattended mode and unset when interactive; `OMARCHY_UPDATE_STRICT=1` only for strict mode and unset otherwise; always-exported `OMARCHY_UPDATE_HOOKS`/`OMARCHY_UPDATE_AUR`/`OMARCHY_UPDATE_MISE` (`run|skip`), `OMARCHY_UPDATE_ORPHANS` (`ask|keep|remove`), `OMARCHY_UPDATE_REBOOT` (`ask|never|if-needed`), and `OMARCHY_UPDATE_RESTARTS` (`run|skip`). Helpers called directly with only `OMARCHY_UPDATE_UNATTENDED=1` keep safe defaults (`OMARCHY_UPDATE_ORPHANS` falls back to `keep`, `OMARCHY_UPDATE_REBOOT` falls back to `never`, `OMARCHY_UPDATE_RESTARTS` falls back to `run`).
+- Scoped privilege environment: unattended runs re-exec through hidden `bin/omarchy-update-run` (`omarchy-update-run <command> [args...]`) before transcript/lock work; interactive runs never touch the runner and inherited `OMARCHY_UPDATE_UNATTENDED`/`OMARCHY_UPDATE_ENV_READY` cannot turn an interactive invocation unattended. The runner captures the original real sudo absolute path from `PATH` before prepending `$OMARCHY_PATH/default/omarchy/update-bin`, exports `OMARCHY_UPDATE_REAL_SUDO` plus `OMARCHY_UPDATE_ENV_READY=1`, and execs the command argv without eval/shell interpolation. Re-entry uses `OMARCHY_UPDATE_RUN_REEXEC=1` and refuses to continue when the environment is still not ready. Missing/unusable adapter installs or sudo paths fail nonzero with an actionable message. The `sudo` adapter execs the captured real sudo as `exec "$real_sudo" -n "$@"`, preserves stdin/stdout/stderr and the child exit status, rejects prompt-enabling options (`-S`/`--stdin`, `-A`/`--askpass`, `-p`/`--prompt`, including combined short clusters), never adds password/askpass/stdin-auth fallbacks, and never consumes piped data meant for the child. The `pkexec` adapter always fails closed with exit 1 and never execs the real pkexec, so no graphical auth dialog can appear. The adapter directory is subprocess-scoped `PATH` prepend only: it is not installed as system `sudo`, it covers only normal `PATH` resolution, and it is explicitly not a security boundary. Absolute-path sudo, cleared-`PATH` callers, custom credential programs, package-maintainer hooks, and other arbitrary scripts bypass it.
+- Policy-gated steps: `OMARCHY_UPDATE_HOOKS=skip` prints `Skipping post-update hooks (--hooks=skip)` instead of running `omarchy-hook post-update`; `OMARCHY_UPDATE_AUR=skip` prints `Skipping AUR package updates (--aur=skip)` instead of running `omarchy-update-aur-pkgs`; `OMARCHY_UPDATE_MISE=skip` prints `Skipping mise updates (--mise=skip)` instead of running `omarchy-update-mise`. Opting into external execution in strict mode still runs but first prints a guarantee-relaxation warning to stderr (`Warning: --hooks=run in strict mode relaxes the non-interactive guarantee; arbitrary hook code may prompt`, and the matching `--aur=run`/`--mise=run` lines). Unattended runs print `Unattended update (full): hooks=..., aur=..., mise=..., orphans=..., reboot=..., restarts=...` (or the `(strict)` form), plus `Orphan policy: remove -- orphaned packages will be removed without confirmation` when `--orphans=remove` and `Reboot policy: if-needed -- system will reboot automatically when required (may close unsaved applications)` when `--reboot=if-needed`. Migrations stay compulsory and ordered; a deferred/failed migration exits nonzero, stays pending, and stops later migrations/steps/reboot. Package-vs-package conflicts exit nonzero with `This upgrade needs an answer. Run omarchy update interactively to give it.` when unattended or headless instead of prompting.
+- Keyring unattended precheck: `omarchy-update-keyring` runs `sudo -n true` first when `OMARCHY_UPDATE_UNATTENDED=1`; when that probe fails it prints `omarchy-update-keyring: unattended update cannot authenticate with sudo (sudo -n failed); run interactively or refresh sudo credentials before retrying` and exits 1 before privileged work. Required-operation failures propagate (`set -euo pipefail`); `Keys are correct` prints only on success.
+- Inhibitor: `omarchy-update-stay-awake start` uses `sudo -n` (with a best-effort `sudo -n -v` probe) when `OMARCHY_UPDATE_UNATTENDED=1` and never selects `pkexec` unattended, even with a PTY. Background inhibitor startup is observed with `kill -0` plus zombie rejection; when acquisition fails it prints `Warning: sleep inhibitor failed to start; continuing without sleep inhibition.`, removes the pid file, and continues with exit 0 rather than recording a stale success. PID ownership, lock-FD closure, cancellation/cleanup, and interactive behavior are unchanged.
+- Git unattended env: `omarchy-update-dev` (before `pull --ff-only`) and `omarchy-update-available` (before `fetch --quiet`) export `GIT_TERMINAL_PROMPT=0`, empty `GIT_ASKPASS=`, and `GIT_SSH_COMMAND="${GIT_SSH_COMMAND:-ssh -oBatchMode=yes}"` when `OMARCHY_UPDATE_UNATTENDED=1`. Empty `GIT_ASKPASS` falls back to terminal prompts, which `GIT_TERMINAL_PROMPT=0` then disables, so auth failures fail closed instead of hanging; `GIT_SSH_COMMAND` in env wins over `core.sshCommand`, so a user custom `sshCommand` program is never executed unattended while an explicit `GIT_SSH_COMMAND` is preserved. No new host keys are auto-accepted (`BatchMode` fails closed on unknown hosts). User credential helpers remain an external-execution boundary.
+- Exit codes: `0` means selected mandatory work completed while deliberately skipped optional work was reported (it does not mean every possible component updated). `2` means CLI misuse (unknown/missing/invalid/positional args, contradictory repeats, `ask` under unattended, invalid helper policy values). Other nonzero means a required update/migration/explicit-removal/explicit-reboot step failed; downstream destructive work is not run and existing transaction failure codes propagate where possible. Optional prune/snapshot keep warn-and-continue behavior. Interactive no-argument behavior is otherwise unchanged.
 - The free-space requirement uses a 10 GiB threshold and stops the update before
   confirmation when it is not met. If free space cannot be determined, the
   check is silently skipped. Set `OMARCHY_UPDATE_FORCE=1` to bypass the check.
@@ -283,7 +288,7 @@ scripts.
 | `omarchy-update-available` | Update checker for shell widget and post-update refresh. | **Keep.** Could eventually be renamed `omarchy-update-check`, but current name matches widget semantics. |
 | `omarchy-update-aur-pkgs` | Updates AUR packages with `yay -Sua` if foreign packages exist and AUR is reachable. | **Question.** Omarchy is package-backed now, but users may still install AUR packages. Keep for now. |
 | `omarchy-update-mise` | Runs `MISE_MINIMUM_RELEASE_AGE=0 mise up` for mise-managed tools — the override of mise's release-age cooldown is the point. | **Keep.** Mise-managed tools are intentionally part of the blessed update path. |
-| `omarchy-update-orphan-pkgs` | Lists orphans and prompts before removal; noninteractive mode never removes. | **Keep for now.** Safe because it is prompt-only. |
+| `omarchy-update-orphan-pkgs` | Lists orphans and applies the orphan policy: `ask` prompts interactively, `keep` lists and retains, `remove` removes without confirmation via `sudo pacman -Rns --noconfirm`. | **Keep for now.** Safe because unattended defaults to `keep` and removal requires explicit `--orphans=remove`. |
 | `omarchy-update-analyze-logs` | Scans `/tmp/omarchy-update.log` for known failure patterns, currently initramfs generation. | **Keep/expand.** Useful safety net; should grow only for high-signal checks. |
 | `omarchy-update-restart` | Prompts for reboot after kernel/Hyprland updates, restarts components with `restart-*-required` markers, and always restarts the shell. | **Keep.** Important final step; may eventually include service-restart checks. |
 | `omarchy-update-firmware` | Manual firmware update command using fwupd. Not part of the normal update pipeline. | **Keep separate.** Firmware is not a routine system update step. |
@@ -309,7 +314,7 @@ scripts.
    - `omarchy-update-mise` intentionally runs as part of `omarchy update`.
 
 5. **Orphan cleanup stays in the update path for now**
-   - It is prompt-only and never removes packages noninteractively.
+   - Interactive `ask` still prompts before removal; unattended modes default to `keep`, and only explicit `--orphans=remove` removes without confirmation.
 
 6. **Direct pacman user follow-up is based on actual migration state**
    - Direct `sudo pacman -Syu` no longer uses a fake user-update marker.

--- a/manual/30-updates.md
+++ b/manual/30-updates.md
@@ -28,6 +28,38 @@ Your packages aren't the only thing that goes stale. Many laptops and peripheral
 
 If you're already familiar with Arch, you might be tempted to just run `pacman -Syu` or `yay -Syu` yourself, but if you do that, you'll miss the snapshot, migrations, and configuration updates that Omarchy runs together with new packages. That's why Omarchy will actually stop a direct system upgrade and point you to `omarchy update` instead. (If you really know what you're doing, the guard will tell you how to bypass it for a single transaction.)
 
+### Non-interactive updates
+
+Running `omarchy update` with no flags stays interactive and asks before orphan removal and reboot. For scripting, `-y` and `--yes` mean the same unattended full pipeline, while `--non-interactive` means unattended strict mode with external steps skipped by default. Every policy flag uses the exact `--name=value` form and overrides its mode default.
+
+| Flag | Values | No flags (interactive) | `-y` / `--yes` (full) | `--non-interactive` (strict) |
+| --- | --- | --- | --- | --- |
+| `--hooks` | `run`, `skip` | `run` | `run` | `skip` |
+| `--aur` | `run`, `skip` | `run` | `run` | `skip` |
+| `--mise` | `run`, `skip` | `run` | `run` | `skip` |
+| `--orphans` | `ask`, `keep`, `remove` | `ask` | `keep` | `keep` |
+| `--reboot` | `ask`, `never`, `if-needed` | `ask` | `never` | `never` |
+| `--restarts` | `run`, `skip` | `run` | `run` | `run` |
+
+```bash
+omarchy update --yes
+omarchy update --non-interactive
+omarchy update --non-interactive --mise=run
+omarchy update --yes --orphans=keep --reboot=never
+```
+
+Unattended updates need sudo authorization already in place (a cached sudo ticket or NOPASSWD). Without it the update fails promptly instead of opening a password or graphical dialog, starting with the keyring check. Repeating a policy with the same value is fine, but contradictory repeats, `ask` combined with an unattended mode, unknown flags, and positional arguments all fail immediately with exit code 2 before anything changes.
+
+What runs and what is only reported depends on the policy. Skipped hooks, AUR, and mise steps are reported (for example `Skipping mise updates (--mise=skip)`), kept orphans are listed and retained, and a needed-but-unperformed reboot is reported per trigger (for example `Reboot required: ...`) without rebooting. Exit code 0 means the selected mandatory work finished and any skipped work was reported; it does not mean every optional component was updated.
+
+> **Warning: `--orphans=remove` removes packages without confirmation.** It authorizes removing the currently detected orphan packages with recursive semantics. Only use it when you mean it.
+
+> **Warning: `--reboot=if-needed` reboots automatically and can close unsaved applications.** It reboots only after the whole pipeline succeeds and update-owned inhibitors are released; it never reboots midway or after a failure.
+
+Scripted mode is cooperative, not a sandbox. User hooks, AUR package scripts, mise backends, and git credential helpers are external code that can still prompt, so `-y`/`--yes` is best-effort there rather than a universal no-prompt guarantee. Strict mode skips hooks, AUR, and mise by default for this reason; adding `--hooks=run`, `--aur=run`, or `--mise=run` opts back in per step with a warning that the non-interactive guarantee is relaxed for that component. `--restarts=skip` defers service and shell restarts while keeping restart markers, and `--reboot=never` reports reboot need without rebooting.
+
+Required migrations still run in order and cannot be skipped by these flags. A migration that cannot finish unattended (for example one needing a browser closed) exits nonzero, stays pending, and stops what follows; the login notifier keeps prompting until `omarchy-migrate` is run interactively. A package conflict that needs a human answer also exits nonzero with instructions to rerun `omarchy update` interactively instead of guessing.
+
 ### Rolling back bad updates
 
 If you ever have a problem after doing an update, you can rollback your system to the snapshot taken before the update. Just restart and pick the snapshot in the boot loading menu from before you started the update.

--- a/migrations/1786643346.sh
+++ b/migrations/1786643346.sh
@@ -167,6 +167,11 @@ fi
 # pending, and the login notifier keeps prompting until a rerun goes through
 # with the affected profiles closed.
 while affected_profile_open; do
+  if [[ ${OMARCHY_UPDATE_UNATTENDED:-} == "1" ]]; then
+    echo "Cannot repair the Copy URL shortcut unattended while a browser is open." >&2
+    echo "Close the browser windows, then run: omarchy-migrate" >&2
+    exit 1
+  fi
   if ! gum confirm "Close the browser windows to repair the Copy URL shortcut, then continue"; then
     echo "A running browser would undo the Copy URL shortcut repair." >&2
     echo "Close the browser windows, then run: omarchy-migrate" >&2

--- a/migrations/1787760281.sh
+++ b/migrations/1787760281.sh
@@ -4,6 +4,32 @@ echo "Install the Hermes CLI wrapper for existing installs"
 # is one of them.
 [[ -f $HOME/.local/state/omarchy/preinstalls-removed ]] && exit 0
 
+# Strict mode skips the mise category, but the Hermes installer runs mise
+# (mise where/rm/uninstall/use) and opaque external probes (timeout hermes
+# --version, hermes chat --help). Honoring the category policy beats a silent
+# partial install, so defer when the installer would run without an explicit
+# --mise=run opt-in. The guard sits before either installer invocation so the
+# desktop branch's `|| true` cannot swallow the deferral; the marker stays
+# absent and the queue stops.
+if [[ ${OMARCHY_UPDATE_STRICT:-} == "1" && ${OMARCHY_UPDATE_MISE:-} != "run" ]]; then
+  will_install=0
+  if omarchy-pkg-present hermes-desktop; then
+    will_install=1
+  else
+    strict_hermes_wrapper="$HOME/.local/bin/hermes"
+    if [[ -e $strict_hermes_wrapper || -L $strict_hermes_wrapper ]] && ! omarchy-install-hermes-cli --owns; then
+      will_install=0
+    else
+      will_install=1
+    fi
+  fi
+  if (( will_install )); then
+    echo "Deferring Hermes CLI install in strict mode: installer runs mise, which is skipped." >&2
+    echo "Finish with interactive omarchy-migrate or rerun with --mise=run." >&2
+    exit 1
+  fi
+fi
+
 # Hermes Desktop provides its own Hermes. The installer stands aside for it,
 # removing the mise copy and the Omarchy wrapper an earlier install may have
 # left beside the app. It also reports when the app has not finished setting

--- a/test/shell.d/update-available-test.sh
+++ b/test/shell.d/update-available-test.sh
@@ -9,7 +9,9 @@ trap 'rm -rf "$test_tmp"' EXIT
 
 stub_bin="$test_tmp/bin"
 git_log="$test_tmp/git.log"
+git_env_log="$test_tmp/git.env.log"
 mkdir -p "$stub_bin"
+: >"$git_env_log"
 
 cat >"$stub_bin/checkupdates" <<'SH'
 #!/bin/bash
@@ -63,6 +65,9 @@ shift 2
 
 case "$1" in
   fetch)
+    printf 'GIT_TERMINAL_PROMPT=%s\n' "${GIT_TERMINAL_PROMPT-<unset>}" >>"$TEST_GIT_ENV_LOG"
+    printf 'GIT_ASKPASS=%s\n' "${GIT_ASKPASS-<unset>}" >>"$TEST_GIT_ENV_LOG"
+    printf 'GIT_SSH_COMMAND=%s\n' "${GIT_SSH_COMMAND-<unset>}" >>"$TEST_GIT_ENV_LOG"
     [[ ${TEST_GIT_FETCH:-ok} == "ok" ]]
     ;;
   rev-parse)
@@ -93,6 +98,7 @@ chmod +x "$stub_bin/git"
 run_checker() {
   OMARCHY_PATH="${TEST_OMARCHY_PATH:-/usr/share/omarchy}" \
     TEST_GIT_LOG="$git_log" \
+    TEST_GIT_ENV_LOG="$git_env_log" \
     PATH="$stub_bin:$PATH" \
     "$ROOT/bin/omarchy-update-available"
 }
@@ -211,3 +217,89 @@ grep -Fx 'omarchy-dev-checkout 1 new commit on origin/quattro' "$stdout" >/dev/n
   fail "update checker reports cached dev commits after a fetch failure" "$(cat "$stdout")"
 [[ ! -s $stderr ]] || fail "update checker keeps dev fetch failures quiet" "$(cat "$stderr")"
 pass "update checker uses cached dev state when fetching is unavailable"
+
+: >"$git_log"
+: >"$git_env_log"
+unset OMARCHY_UPDATE_UNATTENDED GIT_TERMINAL_PROMPT GIT_ASKPASS GIT_SSH_COMMAND || true
+if capture_checker "$stdout" "$stderr" \
+  TEST_CHECKUPDATES=none \
+  TEST_INSTALLED_PACKAGE=none \
+  TEST_OMARCHY_PATH="$test_tmp/checkout" \
+  TEST_GIT_BEHIND=0; then
+  status=0
+else
+  status=$?
+fi
+[[ $status -eq 1 ]] || fail "interactive fetch path exits 1 when current" "$status"
+grep -Fx -- "-C $test_tmp/checkout fetch --quiet" "$git_log" >/dev/null ||
+  fail "interactive fetch still runs" "$(cat "$git_log")"
+grep -Fx "GIT_TERMINAL_PROMPT=0" "$git_env_log" >/dev/null ||
+  fail "interactive fetch keeps inline GIT_TERMINAL_PROMPT=0" "$(cat "$git_env_log")"
+grep -Fx "GIT_ASKPASS=<unset>" "$git_env_log" >/dev/null ||
+  fail "interactive fetch exports no new GIT_ASKPASS" "$(cat "$git_env_log")"
+grep -Fx "GIT_SSH_COMMAND=<unset>" "$git_env_log" >/dev/null ||
+  fail "interactive fetch exports no new GIT_SSH_COMMAND" "$(cat "$git_env_log")"
+pass "interactive fetch unchanged"
+
+: >"$git_log"
+: >"$git_env_log"
+unset GIT_TERMINAL_PROMPT GIT_ASKPASS GIT_SSH_COMMAND || true
+if capture_checker "$stdout" "$stderr" \
+  TEST_CHECKUPDATES=none \
+  TEST_INSTALLED_PACKAGE=none \
+  TEST_OMARCHY_PATH="$test_tmp/checkout" \
+  TEST_GIT_BEHIND=2 \
+  OMARCHY_UPDATE_UNATTENDED=1; then
+  status=0
+else
+  status=$?
+fi
+[[ $status -eq 0 ]] || fail "unattended fetch reports dev commits" "$status"
+grep -Fx 'omarchy-dev-checkout 2 new commits on origin/quattro' "$stdout" >/dev/null ||
+  fail "unattended behind-count behavior unchanged" "$(cat "$stdout")"
+grep -Fx "GIT_TERMINAL_PROMPT=0" "$git_env_log" >/dev/null ||
+  fail "unattended fetch disables terminal prompts" "$(cat "$git_env_log")"
+grep -Fx "GIT_ASKPASS=" "$git_env_log" >/dev/null ||
+  fail "unattended fetch clears GIT_ASKPASS to fail closed" "$(cat "$git_env_log")"
+grep -F "GIT_SSH_COMMAND=" "$git_env_log" | grep -F -- "-oBatchMode=yes" >/dev/null ||
+  fail "unattended fetch forces SSH BatchMode" "$(cat "$git_env_log")"
+pass "unattended fetch exports nonprompting git transport env"
+
+: >"$git_log"
+: >"$git_env_log"
+unset GIT_TERMINAL_PROMPT GIT_ASKPASS || true
+if capture_checker "$stdout" "$stderr" \
+  TEST_CHECKUPDATES=none \
+  TEST_INSTALLED_PACKAGE=none \
+  TEST_OMARCHY_PATH="$test_tmp/checkout" \
+  TEST_GIT_BEHIND=2 \
+  OMARCHY_UPDATE_UNATTENDED=1 \
+  GIT_SSH_COMMAND=custom-ssh; then
+  status=0
+else
+  status=$?
+fi
+[[ $status -eq 0 ]] || fail "unattended custom-ssh fetch reports dev commits" "$status"
+grep -Fx "GIT_SSH_COMMAND=custom-ssh" "$git_env_log" >/dev/null ||
+  fail "explicit user GIT_SSH_COMMAND is preserved unattended" "$(cat "$git_env_log")"
+pass "unattended fetch preserves explicit user GIT_SSH_COMMAND"
+
+: >"$git_log"
+: >"$git_env_log"
+unset GIT_TERMINAL_PROMPT GIT_ASKPASS GIT_SSH_COMMAND || true
+if capture_checker "$stdout" "$stderr" \
+  TEST_CHECKUPDATES=none \
+  TEST_INSTALLED_PACKAGE=none \
+  TEST_OMARCHY_PATH="$test_tmp/checkout" \
+  TEST_GIT_BEHIND=1 \
+  TEST_GIT_FETCH=fail \
+  OMARCHY_UPDATE_UNATTENDED=1; then
+  status=0
+else
+  status=$?
+fi
+[[ $status -eq 0 ]] || fail "unattended fetch failure uses cached state" "$status"
+grep -Fx 'omarchy-dev-checkout 1 new commit on origin/quattro' "$stdout" >/dev/null ||
+  fail "unattended fetch failure reports cached dev commits" "$(cat "$stdout")"
+[[ ! -s $stderr ]] || fail "unattended fetch failure stays quiet" "$(cat "$stderr")"
+pass "unattended fetch failure stays quiet with cached state"

--- a/test/shell.d/update-dev-test.sh
+++ b/test/shell.d/update-dev-test.sh
@@ -9,6 +9,7 @@ trap 'rm -rf "$test_tmp"' EXIT
 
 stub_bin="$test_tmp/bin"
 git_log="$test_tmp/git.log"
+git_env_log="$test_tmp/git.env.log"
 checkout="$test_tmp/checkout"
 mkdir -p "$stub_bin" "$checkout"
 
@@ -37,6 +38,13 @@ case "$1" in
     esac
     ;;
   pull)
+    printf 'GIT_TERMINAL_PROMPT=%s\n' "${GIT_TERMINAL_PROMPT-<unset>}" >>"$TEST_GIT_ENV_LOG"
+    printf 'GIT_ASKPASS=%s\n' "${GIT_ASKPASS-<unset>}" >>"$TEST_GIT_ENV_LOG"
+    printf 'GIT_SSH_COMMAND=%s\n' "${GIT_SSH_COMMAND-<unset>}" >>"$TEST_GIT_ENV_LOG"
+    if [[ ${TEST_GIT_PULL:-ok} == "fail" ]]; then
+      echo "fatal: pull failed (stub)" >&2
+      exit 1
+    fi
     [[ $2 == "--ff-only" ]]
     ;;
   *)
@@ -49,6 +57,7 @@ chmod +x "$stub_bin/git"
 run_dev_update() {
   OMARCHY_PATH="$1" \
     TEST_GIT_LOG="$git_log" \
+    TEST_GIT_ENV_LOG="$git_env_log" \
     PATH="$stub_bin:$PATH" \
     "$ROOT/bin/omarchy-update-dev"
 }
@@ -82,3 +91,42 @@ pass "invalid dev checkout fails with a useful error"
 grep -qE '^ *omarchy-update-dev$' "$ROOT/bin/omarchy-update" ||
   fail "top-level update includes the dev checkout step"
 pass "top-level update includes the dev checkout step"
+
+: >"$git_log"
+: >"$git_env_log"
+( unset OMARCHY_UPDATE_UNATTENDED GIT_TERMINAL_PROMPT GIT_ASKPASS GIT_SSH_COMMAND
+  run_dev_update "$checkout" >/dev/null 2>&1 )
+[[ $(cat "$git_env_log") == *"GIT_TERMINAL_PROMPT=<unset>"* ]] ||
+  fail "interactive dev pull does not export GIT_TERMINAL_PROMPT" "$(cat "$git_env_log")"
+[[ $(cat "$git_env_log") == *"GIT_ASKPASS=<unset>"* ]] ||
+  fail "interactive dev pull does not export GIT_ASKPASS" "$(cat "$git_env_log")"
+[[ $(cat "$git_env_log") == *"GIT_SSH_COMMAND=<unset>"* ]] ||
+  fail "interactive dev pull does not export GIT_SSH_COMMAND" "$(cat "$git_env_log")"
+pass "interactive dev pull exports nothing new"
+
+: >"$git_log"
+: >"$git_env_log"
+( unset GIT_TERMINAL_PROMPT GIT_ASKPASS GIT_SSH_COMMAND
+  OMARCHY_UPDATE_UNATTENDED=1 run_dev_update "$checkout" >/dev/null 2>&1 )
+grep -Fx "GIT_TERMINAL_PROMPT=0" "$git_env_log" >/dev/null ||
+  fail "unattended dev pull disables terminal prompts" "$(cat "$git_env_log")"
+grep -Fx "GIT_ASKPASS=" "$git_env_log" >/dev/null ||
+  fail "unattended dev pull clears GIT_ASKPASS to fail closed" "$(cat "$git_env_log")"
+grep -F "GIT_SSH_COMMAND=" "$git_env_log" | grep -F -- "-oBatchMode=yes" >/dev/null ||
+  fail "unattended dev pull forces SSH BatchMode" "$(cat "$git_env_log")"
+pass "unattended dev pull exports nonprompting git transport env"
+
+: >"$git_log"
+: >"$git_env_log"
+( unset GIT_TERMINAL_PROMPT GIT_ASKPASS
+  OMARCHY_UPDATE_UNATTENDED=1 GIT_SSH_COMMAND=custom-ssh run_dev_update "$checkout" >/dev/null 2>&1 )
+grep -Fx "GIT_SSH_COMMAND=custom-ssh" "$git_env_log" >/dev/null ||
+  fail "explicit user GIT_SSH_COMMAND is preserved unattended" "$(cat "$git_env_log")"
+pass "unattended dev pull preserves explicit user GIT_SSH_COMMAND"
+
+: >"$git_log"
+: >"$git_env_log"
+if ( unset OMARCHY_UPDATE_UNATTENDED; TEST_GIT_PULL=fail run_dev_update "$checkout" >"$test_tmp/pull-fail.out" 2>"$test_tmp/pull-fail.err" ); then
+  fail "dev pull failure exits nonzero" "$(cat "$test_tmp/pull-fail.out" "$test_tmp/pull-fail.err")"
+fi
+pass "dev pull failure propagates nonzero"

--- a/test/shell.d/update-disk-space-test.sh
+++ b/test/shell.d/update-disk-space-test.sh
@@ -24,6 +24,7 @@ run_update() {
   XDG_RUNTIME_DIR="$runtime_dir" \
   PATH="$stub_bin:$ROOT/bin:$PATH" \
   LC_ALL=C \
+  OMARCHY_PATH="$ROOT" \
   OMARCHY_UPDATE_LOGGED=1 \
   TEST_AVAILABLE_BYTES=${TEST_AVAILABLE_BYTES:-$((9 * 1024 * 1024 * 1024))} \
   TEST_DF_INVALID=${TEST_DF_INVALID:-0} \
@@ -61,6 +62,18 @@ exit 0'
 write_stub omarchy-snapshot '
 touch "$SNAPSHOT_MARKER"
 exit 0'
+
+write_stub sudo '
+if [[ ${1:-} == "-n" ]]; then
+  shift
+fi
+if [[ ${1:-} == "--" ]]; then
+  shift
+fi
+if (( $# == 0 )); then
+  exit 0
+fi
+exec "$@"'
 
 for command in \
   omarchy-cmd-present \
@@ -116,7 +129,7 @@ pass "interactive update stops before confirmation with low disk space"
 
 rm -f "$snapshot_marker" "$gum_marker"
 output=$(OMARCHY_UPDATE_FORCE=1 run_update -y)
-[[ -z $output ]] || fail "forced update does not emit the free-space warning"
+[[ $output != *"You need at least 10 GiB free"* ]] || fail "forced update does not emit the free-space warning"
 [[ ! -f $gum_marker ]] || fail "forced non-interactive update does not prompt"
 [[ -f $snapshot_marker ]] || fail "forced update continues with low disk space"
 pass "forced update skips the free-space requirement"
@@ -136,6 +149,6 @@ pass "interactive update keeps the normal confirmation prompt when space is suff
 
 rm -f "$snapshot_marker"
 output=$(TEST_DF_INVALID=1 run_update -y)
-[[ -z $output ]] || fail "failed disk-space detection remains silent"
+[[ $output != *"You need at least 10 GiB free"* ]] || fail "failed disk-space detection remains silent"
 [[ -f $snapshot_marker ]] || fail "failed disk-space detection does not block the update"
 pass "failed disk-space detection silently continues"

--- a/test/shell.d/update-environment-test.sh
+++ b/test/shell.d/update-environment-test.sh
@@ -1,0 +1,303 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+test_home="$test_tmp/home"
+mkdir -p "$stub_bin" "$test_home"
+
+adapter_dir="$ROOT/default/omarchy/update-bin"
+run_bin="$ROOT/bin/omarchy-update-run"
+
+[[ -x $run_bin ]] || fail "omarchy-update-run is installed executable"
+pass "omarchy-update-run is installed executable"
+[[ -x $adapter_dir/sudo ]] || fail "sudo adapter is installed executable"
+pass "sudo adapter is installed executable"
+[[ -x $adapter_dir/pkexec ]] || fail "pkexec adapter is installed executable"
+pass "pkexec adapter is installed executable"
+
+fake_log="$test_tmp/fake-sudo.log"
+stub_pkexec_log="$test_tmp/stub-pkexec.log"
+: >"$fake_log"
+: >"$stub_pkexec_log"
+
+cat >"$stub_bin/sudo" <<'STUB'
+#!/bin/bash
+log="${FAKE_SUDO_LOG:-/dev/null}"
+printf '%q ' "$@" >>"$log"
+printf '\n' >>"$log"
+if [[ ${1:-} != "-n" ]]; then
+  echo "fake sudo: missing -n: $*" >&2
+  exit 99
+fi
+shift
+while (( $# > 0 )) && [[ ${1:-} == "-n" ]]; do
+  shift
+done
+if (( $# > 0 )) && [[ ${1:-} == "--" ]]; then
+  shift
+fi
+if (( $# == 1 )) && [[ ${1:-} == "-v" ]]; then
+  exit 0
+fi
+if (( $# >= 3 )) && [[ ${1:-} == "-u" ]]; then
+  shift 2
+fi
+if (( $# == 0 )); then
+  echo "fake sudo: no command" >&2
+  exit 99
+fi
+exec "$@"
+STUB
+chmod +x "$stub_bin/sudo"
+
+cat >"$stub_bin/pkexec" <<STUB
+#!/bin/bash
+printf '%s\n' "\$*" >>"$stub_pkexec_log"
+echo "stub pkexec must not run unattended" >&2
+exit 99
+STUB
+chmod +x "$stub_bin/pkexec"
+
+reset_env() {
+  unset OMARCHY_UPDATE_REAL_SUDO || true
+  unset OMARCHY_UPDATE_ENV_READY || true
+}
+
+# Missing args exits 2.
+reset_env
+set +e
+OMARCHY_PATH="$ROOT" "$run_bin" >"$test_tmp/missing.out" 2>"$test_tmp/missing.err"
+missing_status=$?
+set -e
+(( missing_status == 2 )) || fail "omarchy-update-run with no args exits 2" "got $missing_status"
+pass "omarchy-update-run with no args exits 2"
+
+# Interactive execs argv unchanged with no PATH change.
+reset_env
+interactive_path=$(PATH="$stub_bin:$PATH" OMARCHY_PATH="$ROOT" env -u OMARCHY_UPDATE_UNATTENDED -u OMARCHY_UPDATE_REAL_SUDO -u OMARCHY_UPDATE_ENV_READY "$run_bin" bash -c 'printf "%s" "$PATH"')
+[[ $interactive_path == "$stub_bin:"* ]] || fail "interactive run keeps caller PATH" "$interactive_path"
+[[ $interactive_path != *"$adapter_dir"* ]] || fail "interactive run does not add adapters" "$interactive_path"
+pass "interactive run keeps caller PATH with no adapters"
+
+reset_env
+interactive_ready=$(PATH="$stub_bin:$PATH" OMARCHY_PATH="$ROOT" env -u OMARCHY_UPDATE_UNATTENDED -u OMARCHY_UPDATE_REAL_SUDO -u OMARCHY_UPDATE_ENV_READY "$run_bin" bash -c 'printf "%s" "${OMARCHY_UPDATE_ENV_READY:-unset}"')
+[[ $interactive_ready == "unset" ]] || fail "interactive run does not set ENV_READY" "$interactive_ready"
+pass "interactive run does not set ENV_READY"
+
+# Unattended exact -n argv.
+reset_env
+: >"$fake_log"
+out=$(OMARCHY_UPDATE_UNATTENDED=1 OMARCHY_PATH="$ROOT" PATH="$stub_bin:$PATH" FAKE_SUDO_LOG="$fake_log" "$run_bin" sudo printf '%s' hello)
+[[ $out == "hello" ]] || fail "unattended sudo runs the command" "$out"
+grep -q '^-n printf ' "$fake_log" || fail "unattended sudo injects exactly one -n" "$(cat "$fake_log")"
+pass "unattended sudo injects exactly one -n"
+
+# Stdin pipe preserved through sudo tee.
+reset_env
+: >"$fake_log"
+printf 'hello-stdin\n' | OMARCHY_UPDATE_UNATTENDED=1 OMARCHY_PATH="$ROOT" PATH="$stub_bin:$PATH" FAKE_SUDO_LOG="$fake_log" "$run_bin" sudo tee "$test_tmp/tee-out" >/dev/null
+[[ $(<"$test_tmp/tee-out") == "hello-stdin" ]] || fail "sudo tee preserves stdin" "$(cat "$test_tmp/tee-out" 2>/dev/null)"
+pass "sudo tee preserves stdin"
+
+# Stdout, stderr, and exit 37 propagate.
+reset_env
+set +e
+OMARCHY_UPDATE_UNATTENDED=1 OMARCHY_PATH="$ROOT" PATH="$stub_bin:$PATH" FAKE_SUDO_LOG="$fake_log" "$run_bin" sudo sh -c 'echo out-msg; echo err-msg >&2; exit 37' >"$test_tmp/prop.out" 2>"$test_tmp/prop.err"
+prop_status=$?
+set -e
+(( prop_status == 37 )) || fail "sudo preserves exit 37" "got $prop_status"
+grep -q "out-msg" "$test_tmp/prop.out" || fail "sudo preserves stdout" "$(cat "$test_tmp/prop.out")"
+grep -q "err-msg" "$test_tmp/prop.err" || fail "sudo preserves stderr" "$(cat "$test_tmp/prop.err")"
+pass "sudo preserves stdout stderr and exit 37"
+
+# Nested bash, env, xargs, and mock migration as_root inherit adaptation.
+reset_env
+: >"$fake_log"
+OMARCHY_UPDATE_UNATTENDED=1 OMARCHY_PATH="$ROOT" PATH="$stub_bin:$PATH" FAKE_SUDO_LOG="$fake_log" "$run_bin" bash -c 'sudo printf "%s" nested-ok' >"$test_tmp/nested.out"
+grep -q "nested-ok" "$test_tmp/nested.out" || fail "nested bash sudo runs" "$(cat "$test_tmp/nested.out")"
+grep -q '^-n printf ' "$fake_log" || fail "nested bash sudo uses -n" "$(cat "$fake_log")"
+pass "nested bash sudo inherits adaptation"
+
+reset_env
+: >"$fake_log"
+OMARCHY_UPDATE_UNATTENDED=1 OMARCHY_PATH="$ROOT" PATH="$stub_bin:$PATH" FAKE_SUDO_LOG="$fake_log" "$run_bin" env sudo printf '%s' env-ok >"$test_tmp/env.out"
+grep -q "env-ok" "$test_tmp/env.out" || fail "env sudo runs" "$(cat "$test_tmp/env.out")"
+grep -q '^-n printf ' "$fake_log" || fail "env sudo uses -n" "$(cat "$fake_log")"
+pass "env sudo inherits adaptation"
+
+reset_env
+: >"$fake_log"
+printf 'xargs-ok\n' >"$test_tmp/xargs-in"
+OMARCHY_UPDATE_UNATTENDED=1 OMARCHY_PATH="$ROOT" PATH="$stub_bin:$PATH" FAKE_SUDO_LOG="$fake_log" "$run_bin" xargs -a "$test_tmp/xargs-in" sudo printf '%s' >"$test_tmp/xargs-out"
+grep -q "xargs-ok" "$test_tmp/xargs-out" || fail "xargs sudo runs" "$(cat "$test_tmp/xargs-out")"
+grep -q '^-n printf ' "$fake_log" || fail "xargs sudo uses -n" "$(cat "$fake_log")"
+pass "xargs sudo inherits adaptation"
+
+reset_env
+: >"$fake_log"
+cat >"$test_tmp/mock-migration.sh" <<'MIG'
+#!/bin/bash
+as_root() {
+  sudo "$@"
+}
+as_root printf '%s' migration-ok
+MIG
+chmod +x "$test_tmp/mock-migration.sh"
+OMARCHY_UPDATE_UNATTENDED=1 OMARCHY_PATH="$ROOT" PATH="$stub_bin:$PATH" FAKE_SUDO_LOG="$fake_log" "$run_bin" bash "$test_tmp/mock-migration.sh" >"$test_tmp/mig.out"
+grep -q "migration-ok" "$test_tmp/mig.out" || fail "mock migration as_root runs" "$(cat "$test_tmp/mig.out")"
+grep -q '^-n printf ' "$fake_log" || fail "mock migration as_root uses -n" "$(cat "$fake_log")"
+pass "mock migration as_root inherits adaptation"
+
+# sudo -v and -u value pass without corrupting values.
+reset_env
+: >"$fake_log"
+OMARCHY_UPDATE_UNATTENDED=1 OMARCHY_PATH="$ROOT" PATH="$stub_bin:$PATH" FAKE_SUDO_LOG="$fake_log" "$run_bin" sudo -v
+grep -q '^-n -v' "$fake_log" || fail "sudo -v passes through with -n" "$(cat "$fake_log")"
+pass "sudo -v passes through with -n"
+
+reset_env
+: >"$fake_log"
+OMARCHY_UPDATE_UNATTENDED=1 OMARCHY_PATH="$ROOT" PATH="$stub_bin:$PATH" FAKE_SUDO_LOG="$fake_log" "$run_bin" sudo -u testuser printf '%s' u-ok >"$test_tmp/u.out"
+grep -q "u-ok" "$test_tmp/u.out" || fail "sudo -u runs the command" "$(cat "$test_tmp/u.out")"
+grep -q -- '-u testuser' "$fake_log" || fail "sudo -u value is not corrupted" "$(cat "$fake_log")"
+pass "sudo -u value is not corrupted"
+
+# Reentry twice keeps a single adapter PATH and the original sudo.
+reset_env
+: >"$fake_log"
+reentry_env=$(OMARCHY_UPDATE_UNATTENDED=1 OMARCHY_PATH="$ROOT" PATH="$stub_bin:$PATH" FAKE_SUDO_LOG="$fake_log" "$run_bin" "$run_bin" bash -c 'printf "%s\n%s\n%s\n%s" "$PATH" "$OMARCHY_UPDATE_REAL_SUDO" "${OMARCHY_UPDATE_ENV_READY:-unset}" "$(type -P sudo)"')
+reentry_path=$(printf '%s' "$reentry_env" | sed -n '1p')
+reentry_real=$(printf '%s' "$reentry_env" | sed -n '2p')
+reentry_ready=$(printf '%s' "$reentry_env" | sed -n '3p')
+reentry_which=$(printf '%s' "$reentry_env" | sed -n '4p')
+[[ $reentry_ready == "1" ]] || fail "reentry keeps ENV_READY=1" "$reentry_ready"
+[[ $reentry_real == "$stub_bin/sudo" ]] || fail "reentry preserves original sudo" "$reentry_real"
+[[ $reentry_which == "$adapter_dir/sudo" ]] || fail "reentry resolves sudo to the adapter" "$reentry_which"
+adapter_count=$(printf '%s' "$reentry_path" | grep -F -o "$adapter_dir" | wc -l)
+(( adapter_count == 1 )) || fail "reentry has a single adapter PATH" "$reentry_path"
+[[ $reentry_path == "$adapter_dir:"* ]] || fail "reentry keeps adapters at the front" "$reentry_path"
+pass "reentry twice keeps single adapter PATH and original sudo"
+
+# Recursive and invalid real paths fail safely.
+reset_env
+set +e
+OMARCHY_UPDATE_UNATTENDED=1 OMARCHY_PATH="$ROOT" PATH="$stub_bin:$PATH" OMARCHY_UPDATE_REAL_SUDO="$adapter_dir/sudo" OMARCHY_UPDATE_ENV_READY=1 "$run_bin" bash -c 'echo should-not-run' >"$test_tmp/rec.out" 2>"$test_tmp/rec.err"
+rec_status=$?
+set -e
+(( rec_status != 0 )) || fail "adapter real path is rejected"
+grep -qi "recurs" "$test_tmp/rec.err" || fail "recursive real path reports recursion" "$(cat "$test_tmp/rec.err")"
+pass "adapter real path is rejected"
+
+reset_env
+set +e
+OMARCHY_UPDATE_UNATTENDED=1 OMARCHY_PATH="$ROOT" PATH="$stub_bin:$PATH" OMARCHY_UPDATE_REAL_SUDO="$test_tmp/does-not-exist" OMARCHY_UPDATE_ENV_READY=1 "$run_bin" bash -c 'echo should-not-run' >"$test_tmp/bad.out" 2>"$test_tmp/bad.err"
+bad_status=$?
+set -e
+(( bad_status != 0 )) || fail "invalid real path is rejected"
+pass "invalid real path is rejected"
+
+reset_env
+ln -sf "$adapter_dir/sudo" "$stub_bin/sudo-link"
+set +e
+OMARCHY_UPDATE_UNATTENDED=1 OMARCHY_PATH="$ROOT" PATH="$stub_bin:$PATH" OMARCHY_UPDATE_REAL_SUDO="$stub_bin/sudo-link" OMARCHY_UPDATE_ENV_READY=1 "$run_bin" bash -c 'echo should-not-run' >"$test_tmp/link.out" 2>"$test_tmp/link.err"
+link_status=$?
+set -e
+(( link_status != 0 )) || fail "symlinked adapter real path is rejected"
+pass "symlinked adapter real path is rejected"
+
+reset_env
+set +e
+OMARCHY_UPDATE_UNATTENDED=1 OMARCHY_PATH="$ROOT" PATH="$adapter_dir:$stub_bin:$PATH" env -u OMARCHY_UPDATE_REAL_SUDO -u OMARCHY_UPDATE_ENV_READY "$run_bin" bash -c 'echo should-not-run' >"$test_tmp/cap.out" 2>"$test_tmp/cap.err"
+cap_status=$?
+set -e
+(( cap_status != 0 )) || fail "captured adapter sudo is rejected"
+pass "captured adapter sudo is rejected"
+
+# pkexec never delegates.
+reset_env
+: >"$stub_pkexec_log"
+set +e
+OMARCHY_UPDATE_UNATTENDED=1 OMARCHY_PATH="$ROOT" PATH="$stub_bin:$PATH" STUB_PKEXEC_LOG="$stub_pkexec_log" FAKE_SUDO_LOG="$fake_log" "$run_bin" pkexec true >"$test_tmp/pkexec.out" 2>"$test_tmp/pkexec.err"
+pkexec_status=$?
+set -e
+(( pkexec_status == 1 )) || fail "pkexec adapter exits 1" "got $pkexec_status"
+grep -qi "graphical prompt" "$test_tmp/pkexec.err" || fail "pkexec adapter reports graphical prompt" "$(cat "$test_tmp/pkexec.err")"
+[[ ! -s $stub_pkexec_log ]] || fail "pkexec adapter never delegates" "$(cat "$stub_pkexec_log")"
+pass "pkexec adapter fails closed without delegating"
+
+# Prompt-enabling flags are rejected.
+reset_env
+for flag in "-S" "-A" "--stdin" "--askpass" "--prompt" "-p"; do
+  : >"$fake_log"
+  set +e
+  OMARCHY_UPDATE_UNATTENDED=1 OMARCHY_PATH="$ROOT" PATH="$stub_bin:$PATH" FAKE_SUDO_LOG="$fake_log" "$run_bin" bash -c "sudo $flag printf '%s' hi" >"$test_tmp/rej.out" 2>"$test_tmp/rej.err"
+  rej_status=$?
+  set -e
+  (( rej_status != 0 )) || fail "sudo $flag is rejected" "exit 0"
+  [[ ! -s $fake_log ]] || fail "sudo $flag never reaches real sudo" "$(cat "$fake_log")"
+done
+pass "prompt-enabling sudo flags are rejected"
+
+reset_env
+: >"$fake_log"
+set +e
+OMARCHY_UPDATE_UNATTENDED=1 OMARCHY_PATH="$ROOT" PATH="$stub_bin:$PATH" FAKE_SUDO_LOG="$fake_log" "$run_bin" bash -c 'sudo -Sn printf "%s" hi' >"$test_tmp/rej2.out" 2>"$test_tmp/rej2.err"
+rej2_status=$?
+set -e
+(( rej2_status != 0 )) || fail "combined -Sn is rejected"
+[[ ! -s $fake_log ]] || fail "combined -Sn never reaches real sudo" "$(cat "$fake_log")"
+pass "combined prompt-enabling sudo flags are rejected"
+
+# Target-command arguments that look like prompt flags are not rejected.
+reset_env
+: >"$fake_log"
+OMARCHY_UPDATE_UNATTENDED=1 OMARCHY_PATH="$ROOT" PATH="$stub_bin:$PATH" FAKE_SUDO_LOG="$fake_log" "$run_bin" sudo -- printf '%s' --askpass >"$test_tmp/allow.out" 2>"$test_tmp/allow.err"
+[[ $(<"$test_tmp/allow.out") == "--askpass" ]] || fail "sudo -- passes target args" "$(cat "$test_tmp/allow.out")"
+pass "sudo -- passes target args untouched"
+
+reset_env
+OMARCHY_UPDATE_UNATTENDED=1 OMARCHY_PATH="$ROOT" PATH="$stub_bin:$PATH" FAKE_SUDO_LOG="$fake_log" "$run_bin" sudo printf '%s' --askpass >"$test_tmp/allow2.out" 2>"$test_tmp/allow2.err"
+[[ $(<"$test_tmp/allow2.out") == "--askpass" ]] || fail "command args named like prompt flags pass" "$(cat "$test_tmp/allow2.out")"
+pass "command args named like prompt flags pass"
+
+# Argv with spaces is preserved.
+reset_env
+spaced=$(OMARCHY_UPDATE_UNATTENDED=1 OMARCHY_PATH="$ROOT" PATH="$stub_bin:$PATH" FAKE_SUDO_LOG="$fake_log" "$run_bin" sudo printf '%s|' "a b" "c d")
+[[ $spaced == "a b|c d|" ]] || fail "spaced argv is preserved" "$spaced"
+pass "spaced argv is preserved"
+
+# Manual adapter call without a captured path fails safely.
+reset_env
+set +e
+env -u OMARCHY_UPDATE_REAL_SUDO "$adapter_dir/sudo" printf '%s' hi >"$test_tmp/manual.out" 2>"$test_tmp/manual.err"
+manual_status=$?
+set -e
+(( manual_status != 0 )) || fail "manual sudo adapter call fails safely"
+pass "manual sudo adapter call fails safely"
+
+# Missing adapter installation fails with a useful error.
+reset_env
+set +e
+OMARCHY_UPDATE_UNATTENDED=1 OMARCHY_PATH="$test_tmp/empty" PATH="$stub_bin:$PATH" "$run_bin" bash -c 'echo should-not-run' >"$test_tmp/noinst.out" 2>"$test_tmp/noinst.err"
+noinst_status=$?
+set -e
+(( noinst_status != 0 )) || fail "missing adapter installation fails"
+grep -q "adapter" "$test_tmp/noinst.err" || fail "missing adapter reports installation" "$(cat "$test_tmp/noinst.err")"
+pass "missing adapter installation fails"
+
+# No parent PATH or environment pollution.
+reset_env
+parent_path="$PATH"
+parent_real="${OMARCHY_UPDATE_REAL_SUDO:-unset}"
+parent_ready="${OMARCHY_UPDATE_ENV_READY:-unset}"
+OMARCHY_UPDATE_UNATTENDED=1 OMARCHY_PATH="$ROOT" PATH="$stub_bin:$PATH" FAKE_SUDO_LOG="$fake_log" "$run_bin" bash -c 'true'
+[[ $PATH == "$parent_path" ]] || fail "parent PATH is unchanged"
+[[ ${OMARCHY_UPDATE_REAL_SUDO:-unset} == "$parent_real" ]] || fail "parent REAL_SUDO is unchanged"
+[[ ${OMARCHY_UPDATE_ENV_READY:-unset} == "$parent_ready" ]] || fail "parent ENV_READY is unchanged"
+pass "parent PATH and environment are unchanged"

--- a/test/shell.d/update-keyring-test.sh
+++ b/test/shell.d/update-keyring-test.sh
@@ -1,0 +1,186 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+test_home="$test_tmp/home"
+mkdir -p "$stub_bin" "$test_home"
+
+SUDO_LOG="$test_tmp/sudo.log"
+PACMAN_KEY_LOG="$test_tmp/pacman-key.log"
+PACMAN_LOG="$test_tmp/pacman.log"
+PKG_ADD_LOG="$test_tmp/pkg-add.log"
+: >"$SUDO_LOG"
+: >"$PACMAN_KEY_LOG"
+: >"$PACMAN_LOG"
+: >"$PKG_ADD_LOG"
+
+write_stub() {
+  local name="$1"
+  local body="$2"
+
+  cat >"$stub_bin/$name" <<SH
+#!/bin/bash
+$body
+SH
+  chmod +x "$stub_bin/$name"
+}
+
+reset_logs() {
+  : >"$SUDO_LOG"
+  : >"$PACMAN_KEY_LOG"
+  : >"$PACMAN_LOG"
+  : >"$PKG_ADD_LOG"
+}
+
+write_stub omarchy-pkg-missing 'exit 0'
+write_stub omarchy-pkg-present 'exit 1'
+write_stub omarchy-cmd-missing 'exit 1'
+
+write_stub pacman-key '
+printf "%s\n" "$*" >>"${PACMAN_KEY_LOG:-/dev/null}"
+if [[ $* == *--recv-keys* ]]; then
+  exit "${TEST_RECV_EXIT:-0}"
+fi
+if [[ $* == *--list-keys* ]]; then
+  exit "${TEST_LIST_EXIT:-0}"
+fi
+exit 0'
+
+write_stub pacman '
+printf "%s\n" "$*" >>"${PACMAN_LOG:-/dev/null}"
+if [[ $* == *archlinux-keyring* ]]; then
+  exit "${TEST_ARCH_EXIT:-0}"
+fi
+exit 0'
+
+write_stub omarchy-pkg-add '
+printf "%s\n" "$*" >>"${PKG_ADD_LOG:-/dev/null}"
+exit "${TEST_PKG_ADD_EXIT:-0}"'
+
+write_stub sudo '
+printf "%s\n" "$*" >>"${SUDO_LOG:-/dev/null}"
+if [[ ${1:-} == "-n" && ${2:-} == "true" && $# -eq 2 ]]; then
+  exit "${TEST_SUDO_N_TRUE_EXIT:-0}"
+fi
+exec "$@"'
+
+export SUDO_LOG PACMAN_KEY_LOG PACMAN_LOG PKG_ADD_LOG
+
+run_keyring() {
+  HOME="$test_home" PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-update-keyring"
+}
+
+# Success: unattended with auth, full sequence, Keys correct exactly once.
+reset_logs
+set +e
+export OMARCHY_UPDATE_UNATTENDED="1"
+export TEST_SUDO_N_TRUE_EXIT="0"
+export TEST_RECV_EXIT="0"
+export TEST_LIST_EXIT="0"
+export TEST_ARCH_EXIT="0"
+export TEST_PKG_ADD_EXIT="0"
+HOME="$test_home" PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-update-keyring" >"$test_tmp/success.out" 2>"$test_tmp/success.err"
+success_status=$?
+set -e
+(( success_status == 0 )) || fail "keyring success exits 0" "got $success_status; err=$(cat "$test_tmp/success.err")"
+(( $(grep -c '^Keys are correct$' "$test_tmp/success.out") == 1 )) || fail "keyring success prints Keys are correct exactly once" "$(cat "$test_tmp/success.out")"
+grep -q -- '--recv-keys' "$SUDO_LOG" || fail "keyring success receives keys" "$(cat "$SUDO_LOG")"
+grep -q -- '--lsign-key' "$SUDO_LOG" || fail "keyring success signs keys" "$(cat "$SUDO_LOG")"
+grep -q -- 'archlinux-keyring' "$SUDO_LOG" || fail "keyring success installs archlinux-keyring" "$(cat "$SUDO_LOG")"
+recv_line=$(grep -n -- '--recv-keys' "$SUDO_LOG" | head -n 1 | cut -d: -f1)
+lsign_line=$(grep -n -- '--lsign-key' "$SUDO_LOG" | head -n 1 | cut -d: -f1)
+arch_line=$(grep -n -- 'archlinux-keyring' "$SUDO_LOG" | head -n 1 | cut -d: -f1)
+(( recv_line < lsign_line )) || fail "keyring success receives before signing" "$(cat "$SUDO_LOG")"
+(( lsign_line < arch_line )) || fail "keyring success signs before archlinux-keyring install" "$(cat "$SUDO_LOG")"
+pass "keyring success prints Keys are correct once with sane sequence"
+
+# Unattended no-auth: probe fails, nonzero before any recv attempt.
+reset_logs
+set +e
+export OMARCHY_UPDATE_UNATTENDED="1"
+export TEST_SUDO_N_TRUE_EXIT="1"
+export TEST_RECV_EXIT="0"
+export TEST_LIST_EXIT="0"
+export TEST_ARCH_EXIT="0"
+export TEST_PKG_ADD_EXIT="0"
+HOME="$test_home" PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-update-keyring" >"$test_tmp/noauth.out" 2>"$test_tmp/noauth.err"
+noauth_status=$?
+set -e
+(( noauth_status != 0 )) || fail "unattended no-auth exits nonzero" "got 0"
+grep -q -- '--recv-keys' "$SUDO_LOG" && fail "unattended no-auth never attempts recv-keys" "$(cat "$SUDO_LOG")"
+grep -q 'sudo -n' "$test_tmp/noauth.err" || fail "unattended no-auth reports actionable sudo message" "$(cat "$test_tmp/noauth.err")"
+grep -q '^Keys are correct$' "$test_tmp/noauth.out" && fail "unattended no-auth prints no success" "$(cat "$test_tmp/noauth.out")"
+pass "unattended no-auth fails before recv-keys without false success"
+
+# Unattended with auth but recv failure: nonzero, no Keys-correct.
+reset_logs
+set +e
+export OMARCHY_UPDATE_UNATTENDED="1"
+export TEST_SUDO_N_TRUE_EXIT="0"
+export TEST_RECV_EXIT="1"
+export TEST_LIST_EXIT="0"
+export TEST_ARCH_EXIT="0"
+export TEST_PKG_ADD_EXIT="0"
+HOME="$test_home" PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-update-keyring" >"$test_tmp/recvfail.out" 2>"$test_tmp/recvfail.err"
+recvfail_status=$?
+set -e
+(( recvfail_status != 0 )) || fail "recv failure exits nonzero" "got 0"
+grep -q '^Keys are correct$' "$test_tmp/recvfail.out" && fail "recv failure prints no success" "$(cat "$test_tmp/recvfail.out")"
+pass "recv failure propagates without false success"
+
+# Archlinux-keyring install failure: nonzero, no Keys-correct.
+reset_logs
+set +e
+export OMARCHY_UPDATE_UNATTENDED="1"
+export TEST_SUDO_N_TRUE_EXIT="0"
+export TEST_RECV_EXIT="0"
+export TEST_LIST_EXIT="0"
+export TEST_ARCH_EXIT="1"
+export TEST_PKG_ADD_EXIT="0"
+HOME="$test_home" PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-update-keyring" >"$test_tmp/archfail.out" 2>"$test_tmp/archfail.err"
+archfail_status=$?
+set -e
+(( archfail_status != 0 )) || fail "archlinux-keyring failure exits nonzero" "got 0"
+grep -q '^Keys are correct$' "$test_tmp/archfail.out" && fail "archlinux-keyring failure prints no success" "$(cat "$test_tmp/archfail.out")"
+pass "archlinux-keyring failure propagates without false success"
+
+# omarchy-pkg-add failure: nonzero, no Keys-correct.
+reset_logs
+set +e
+export OMARCHY_UPDATE_UNATTENDED="1"
+export TEST_SUDO_N_TRUE_EXIT="0"
+export TEST_RECV_EXIT="0"
+export TEST_LIST_EXIT="0"
+export TEST_ARCH_EXIT="0"
+export TEST_PKG_ADD_EXIT="1"
+HOME="$test_home" PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-update-keyring" >"$test_tmp/pkgaddfail.out" 2>"$test_tmp/pkgaddfail.err"
+pkgaddfail_status=$?
+set -e
+(( pkgaddfail_status != 0 )) || fail "omarchy-pkg-add failure exits nonzero" "got 0"
+grep -q '^Keys are correct$' "$test_tmp/pkgaddfail.out" && fail "omarchy-pkg-add failure prints no success" "$(cat "$test_tmp/pkgaddfail.out")"
+pass "omarchy-pkg-add failure propagates without false success"
+
+# Interactive (no UNATTENDED): no early -n precheck, success path.
+reset_logs
+set +e
+unset OMARCHY_UPDATE_UNATTENDED
+export TEST_SUDO_N_TRUE_EXIT="1"
+export TEST_RECV_EXIT="0"
+export TEST_LIST_EXIT="0"
+export TEST_ARCH_EXIT="0"
+export TEST_PKG_ADD_EXIT="0"
+HOME="$test_home" PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-update-keyring" >"$test_tmp/interactive.out" 2>"$test_tmp/interactive.err"
+interactive_status=$?
+set -e
+(( interactive_status == 0 )) || fail "interactive keyring exits 0 without precheck" "got $interactive_status; err=$(cat "$test_tmp/interactive.err")"
+(( $(grep -c '^Keys are correct$' "$test_tmp/interactive.out") == 1 )) || fail "interactive keyring prints Keys are correct once" "$(cat "$test_tmp/interactive.out")"
+pass "interactive keyring skips nonprompting precheck"
+
+unset OMARCHY_UPDATE_UNATTENDED
+unset TEST_SUDO_N_TRUE_EXIT TEST_RECV_EXIT TEST_LIST_EXIT TEST_ARCH_EXIT TEST_PKG_ADD_EXIT

--- a/test/shell.d/update-lock-test.sh
+++ b/test/shell.d/update-lock-test.sh
@@ -16,6 +16,7 @@ run_with_lock_env() {
   HOME="$test_home" \
   XDG_RUNTIME_DIR="$runtime_dir" \
   XDG_STATE_HOME="$test_tmp/state" \
+  OMARCHY_PATH="$ROOT" \
   PATH="$stub_bin:$ROOT/bin:$PATH" \
     "$@"
 }
@@ -51,6 +52,24 @@ for command in \
 done
 write_stub omarchy-update-available 'exit 1'
 write_stub pkexec 'exec "$@"'
+write_stub sudo '
+if [[ ${1:-} == "-v" ]]; then
+  exit 0
+fi
+stripped=()
+for a in "$@"; do
+  if [[ $a == "-n" || $a == "--" ]]; then
+    continue
+  fi
+  stripped+=("$a")
+done
+if (( ${#stripped[@]} == 0 )); then
+  exit 0
+fi
+if [[ ${stripped[0]} == "-v" ]]; then
+  exit 0
+fi
+exec "${stripped[@]}"'
 
 # omarchy-update should hold the lock before snapshotting, so a second update
 # cannot even enter its pre-update snapshot.
@@ -151,6 +170,130 @@ SH
   [[ ! -e $pkexec_marker ]] || fail "terminal sleep inhibition does not use pkexec"
   run_with_lock_env "$ROOT/bin/omarchy-update-stay-awake" stop
   pass "terminal updates use sudo instead of Polkit for sleep inhibition"
+fi
+
+if (( EUID != 0 )); then
+  unattended_pty_sudo_log="$test_tmp/unattended-pty-sudo.log"
+  unattended_pty_pkexec_marker="$test_tmp/unattended-pty-pkexec-used"
+  : >"$unattended_pty_sudo_log"
+  rm -f "$unattended_pty_pkexec_marker"
+  write_stub sudo '
+printf "%s\n" "$*" >>"$SUDO_LOG"
+stripped=()
+for a in "$@"; do
+  if [[ $a == "-n" || $a == "--" ]]; then
+    continue
+  fi
+  stripped+=("$a")
+done
+if (( ${#stripped[@]} == 0 )); then
+  exit 0
+fi
+if [[ ${stripped[0]} == "-v" ]]; then
+  exit 0
+fi
+exec "${stripped[@]}"'
+  write_stub pkexec 'touch "$PKEXEC_MARKER"; exec "$@"'
+  write_stub systemd-inhibit 'exec sleep 30'
+
+  unattended_pty_driver="$test_tmp/unattended-pty-stay-awake"
+  cat >"$unattended_pty_driver" <<'SH'
+#!/bin/bash
+omarchy-update-stay-awake start
+for _ in {1..200}; do
+  grep -q -- '-n systemd-inhibit' "$SUDO_LOG" && break
+  sleep 0.05
+done
+SH
+  chmod +x "$unattended_pty_driver"
+
+  OMARCHY_UPDATE_UNATTENDED=1 SUDO_LOG="$unattended_pty_sudo_log" PKEXEC_MARKER="$unattended_pty_pkexec_marker" \
+    run_with_lock_env script -qefc "$unattended_pty_driver" /dev/null >/dev/null
+
+  grep -q -- '-n -v' "$unattended_pty_sudo_log" || fail "unattended PTY sleep inhibition probes sudo nonprompting" "$(cat "$unattended_pty_sudo_log")"
+  grep -q -- '-n systemd-inhibit' "$unattended_pty_sudo_log" || fail "unattended PTY sleep inhibition runs through sudo -n" "$(cat "$unattended_pty_sudo_log")"
+  [[ ! -e $unattended_pty_pkexec_marker ]] || fail "unattended PTY sleep inhibition never uses pkexec"
+  run_with_lock_env "$ROOT/bin/omarchy-update-stay-awake" stop
+  pass "unattended PTY uses sudo -n without pkexec"
+fi
+
+if (( EUID != 0 )); then
+  unattended_headless_sudo_log="$test_tmp/unattended-headless-sudo.log"
+  unattended_headless_pkexec_marker="$test_tmp/unattended-headless-pkexec-used"
+  : >"$unattended_headless_sudo_log"
+  rm -f "$unattended_headless_pkexec_marker"
+  write_stub sudo '
+printf "%s\n" "$*" >>"$SUDO_LOG"
+stripped=()
+for a in "$@"; do
+  if [[ $a == "-n" || $a == "--" ]]; then
+    continue
+  fi
+  stripped+=("$a")
+done
+if (( ${#stripped[@]} == 0 )); then
+  exit 0
+fi
+if [[ ${stripped[0]} == "-v" ]]; then
+  exit 0
+fi
+exec "${stripped[@]}"'
+  write_stub pkexec 'touch "$PKEXEC_MARKER"; exec "$@"'
+  write_stub systemd-inhibit 'exec sleep 30'
+  run_with_lock_env "$ROOT/bin/omarchy-update-stay-awake" stop || true
+
+  set +e
+  OMARCHY_UPDATE_UNATTENDED=1 SUDO_LOG="$unattended_headless_sudo_log" PKEXEC_MARKER="$unattended_headless_pkexec_marker" \
+    run_with_lock_env "$ROOT/bin/omarchy-update-stay-awake" start >"$test_tmp/unattended-headless.out" 2>"$test_tmp/unattended-headless.err"
+  unattended_headless_status=$?
+  set -e
+  (( unattended_headless_status == 0 )) || fail "unattended headless stay-awake exits 0" "got $unattended_headless_status"
+  grep -q -- '-n -v' "$unattended_headless_sudo_log" || fail "unattended headless probes sudo nonprompting" "$(cat "$unattended_headless_sudo_log")"
+  grep -q -- '-n systemd-inhibit' "$unattended_headless_sudo_log" || fail "unattended headless runs through sudo -n" "$(cat "$unattended_headless_sudo_log")"
+  [[ ! -e $unattended_headless_pkexec_marker ]] || fail "unattended headless never uses pkexec"
+  [[ -s $runtime_dir/omarchy-update-stay-awake/inhibit-pid ]] || fail "unattended headless records inhibitor pid"
+  run_with_lock_env "$ROOT/bin/omarchy-update-stay-awake" stop
+  pass "unattended headless uses sudo -n without pkexec"
+fi
+
+if (( EUID != 0 )); then
+  failing_sudo_log="$test_tmp/inhibit-fail-sudo.log"
+  : >"$failing_sudo_log"
+  write_stub systemd-inhibit 'exit 1'
+  write_stub sudo '
+printf "%s\n" "$*" >>"$SUDO_LOG"
+stripped=()
+for a in "$@"; do
+  if [[ $a == "-n" || $a == "--" ]]; then
+    continue
+  fi
+  stripped+=("$a")
+done
+if (( ${#stripped[@]} == 0 )); then
+  exit 0
+fi
+if [[ ${stripped[0]} == "-v" ]]; then
+  exit 0
+fi
+exec "${stripped[@]}"'
+  run_with_lock_env "$ROOT/bin/omarchy-update-stay-awake" stop || true
+  rm -f "$runtime_dir/omarchy-update-stay-awake/inhibit-pid"
+
+  set +e
+  OMARCHY_UPDATE_UNATTENDED=1 SUDO_LOG="$failing_sudo_log" \
+    run_with_lock_env "$ROOT/bin/omarchy-update-stay-awake" start >"$test_tmp/inhibit-fail.out" 2>"$test_tmp/inhibit-fail.err"
+  inhibit_fail_status=$?
+  set -e
+  (( inhibit_fail_status == 0 )) || fail "inhibitor acquisition failure still exits 0" "got $inhibit_fail_status"
+  grep -q 'continuing without sleep inhibition' "$test_tmp/inhibit-fail.err" || fail "inhibitor acquisition failure warns without inhibition" "$(cat "$test_tmp/inhibit-fail.err")"
+  [[ ! -s $runtime_dir/omarchy-update-stay-awake/inhibit-pid ]] || fail "inhibitor acquisition failure leaves no pid file"
+  set +e
+  run_with_lock_env "$ROOT/bin/omarchy-update-stay-awake" stop >"$test_tmp/inhibit-fail-stop.out" 2>"$test_tmp/inhibit-fail-stop.err"
+  inhibit_fail_stop_status=$?
+  set -e
+  (( inhibit_fail_stop_status == 0 )) || fail "stop after acquisition failure exits 0" "got $inhibit_fail_stop_status; $(cat "$test_tmp/inhibit-fail-stop.err")"
+  [[ ! -s $test_tmp/inhibit-fail-stop.err ]] || fail "stop after acquisition failure is quiet" "$(cat "$test_tmp/inhibit-fail-stop.err")"
+  pass "inhibitor acquisition failure warns without false success"
 fi
 
 # Update-owned Stay Awake state must be cleared before the restart helper can

--- a/test/shell.d/update-migration-policy-test.sh
+++ b/test/shell.d/update-migration-policy-test.sh
@@ -1,0 +1,363 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+require_command jq
+require_command python3
+
+copy_migration="$ROOT/migrations/1786643346.sh"
+hermes_migration="$ROOT/migrations/1787760281.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+test_home="$test_tmp/home"
+state_dir="$test_tmp/migration-state"
+mkdir -p "$stub_bin" "$test_home" "$state_dir" "$test_home/.local/bin" "$test_home/.local/state/omarchy"
+
+GUM_LOG="$test_tmp/gum.log"
+PKG_LOG="$test_tmp/pkg.log"
+INSTALLER_LOG="$test_tmp/installer.log"
+MISE_LOG="$test_tmp/mise.log"
+PKG_ADD_LOG="$test_tmp/pkg-add.log"
+: >"$GUM_LOG"
+: >"$PKG_LOG"
+: >"$INSTALLER_LOG"
+: >"$MISE_LOG"
+: >"$PKG_ADD_LOG"
+
+export GUM_LOG PKG_LOG INSTALLER_LOG MISE_LOG PKG_ADD_LOG
+
+unset OMARCHY_UPDATE_UNATTENDED || true
+unset OMARCHY_UPDATE_STRICT || true
+unset OMARCHY_UPDATE_MISE || true
+
+cat >"$stub_bin/gum" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$*" >>"${GUM_LOG:-/dev/null}"
+exit "${OMARCHY_TEST_GUM_EXIT:-99}"
+STUB
+
+cat >"$stub_bin/omarchy-pkg-present" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$*" >>"${PKG_LOG:-/dev/null}"
+if [[ ${1:-} == "hermes-desktop" ]]; then
+  [[ ${OMARCHY_TEST_DESKTOP_INSTALLED:-0} == "1" ]]
+else
+  exit 1
+fi
+STUB
+
+cat >"$stub_bin/omarchy-install-hermes-cli" <<'STUB'
+#!/bin/bash
+printf 'installer:%s\n' "$*" >>"${INSTALLER_LOG:-/dev/null}"
+if [[ ${1:-} == "--owns" ]]; then
+  [[ ${OMARCHY_TEST_WRAPPER_OWNED:-0} == "1" ]]
+else
+  exit "${OMARCHY_TEST_INSTALLER_EXIT:-0}"
+fi
+STUB
+
+cat >"$stub_bin/mise" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$*" >>"${MISE_LOG:-/dev/null}"
+exit 0
+STUB
+
+cat >"$stub_bin/omarchy-pkg-add" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$*" >>"${PKG_ADD_LOG:-/dev/null}"
+exit 0
+STUB
+
+cat >"$stub_bin/omarchy-notification-dismiss" <<'STUB'
+#!/bin/bash
+exit 0
+STUB
+
+chmod +x "$stub_bin"/*
+
+reset_logs() {
+  : >"$GUM_LOG"
+  : >"$PKG_LOG"
+  : >"$INSTALLER_LOG"
+  : >"$MISE_LOG"
+  : >"$PKG_ADD_LOG"
+}
+
+installer_bare_calls() {
+  grep -c '^installer:$' "$INSTALLER_LOG" || true
+}
+
+installer_owns_calls() {
+  grep -c '^installer:--owns$' "$INSTALLER_LOG" || true
+}
+
+# --- Copy URL migration ---
+
+profile_root="$test_home/.config/chromium"
+preferences="$profile_root/Default/Preferences"
+mkdir -p "$(dirname "$preferences")"
+
+ghost_id="ikkebdkaanlebnifjnbeiaklodhbjcci"
+pinned_id="bgpiichlckmfanooecilcjemknkcpngb"
+
+write_stale_preferences() {
+  jq -n --arg ghost "$ghost_id" --arg pinned "$pinned_id" '{extensions: {commands: {"linux:Alt+Shift+L": {command_name: "copy-url", extension: $ghost, global: false}}, settings: {($ghost): {commands: {"copy-url": {suggested_key: "Alt+Shift+L", was_assigned: true}}}, ($pinned): {commands: {"copy-url": {suggested_key: "Alt+Shift+L"}}}}}}' >"$preferences"
+}
+
+open_browser() {
+  mkdir -p "$profile_root"
+  ln -sfn "test-host-1234" "$profile_root/SingletonLock"
+}
+
+close_browser() {
+  rm -f "$profile_root/SingletonLock"
+}
+
+# Unattended + open profile: nonzero, gum never called, actionable stderr.
+write_stale_preferences
+open_browser
+before_hash=$(sha256sum "$preferences" | cut -d' ' -f1)
+reset_logs
+set +e
+OMARCHY_UPDATE_UNATTENDED=1 HOME="$test_home" OMARCHY_MIGRATION_STATE="$state_dir" PATH="$stub_bin:$PATH" \
+  bash -euo pipefail "$copy_migration" >"$test_tmp/copy-unattended.out" 2>"$test_tmp/copy-unattended.err"
+copy_unattended_status=$?
+set -e
+(( copy_unattended_status != 0 )) || fail "copy-url unattended defers with nonzero exit"
+[[ ! -s $GUM_LOG ]] || fail "copy-url unattended never calls gum" "$(cat "$GUM_LOG")"
+grep -q "Close" "$test_tmp/copy-unattended.err" || fail "copy-url unattended stderr is actionable (close browsers)" "$(cat "$test_tmp/copy-unattended.err")"
+grep -q "omarchy-migrate" "$test_tmp/copy-unattended.err" || fail "copy-url unattended stderr names omarchy-migrate" "$(cat "$test_tmp/copy-unattended.err")"
+[[ $(sha256sum "$preferences" | cut -d' ' -f1) == "$before_hash" ]] || fail "copy-url unattended leaves preferences alone"
+[[ ! -f $state_dir/1786643346.sh ]] || fail "copy-url unattended leaves marker absent"
+pass "copy-url unattended defers without prompting"
+
+# Interactive + accept: completes (shape of existing test).
+close_browser
+write_stale_preferences
+open_browser
+cat >"$stub_bin/gum" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$*" >>"${GUM_LOG:-/dev/null}"
+touch "${GUM_CALLED_FILE:?}"
+rm -f "$HOME/.config/chromium/SingletonLock"
+exit 0
+STUB
+chmod +x "$stub_bin/gum"
+reset_logs
+export GUM_CALLED_FILE="$test_tmp/gum-called"
+rm -f "$GUM_CALLED_FILE"
+set +e
+HOME="$test_home" OMARCHY_MIGRATION_STATE="$state_dir" PATH="$stub_bin:$PATH" \
+  env -u OMARCHY_UPDATE_UNATTENDED -u OMARCHY_UPDATE_STRICT \
+  bash -euo pipefail "$copy_migration" >"$test_tmp/copy-interactive.out" 2>"$test_tmp/copy-interactive.err"
+copy_interactive_status=$?
+set -e
+unset GUM_CALLED_FILE
+(( copy_interactive_status == 0 )) || fail "copy-url interactive completes on accept" "$(cat "$test_tmp/copy-interactive.err")"
+[[ -f $test_tmp/gum-called ]] || fail "copy-url interactive asks before repairing"
+jq -e --arg pinned "$pinned_id" '.extensions.commands["linux:Alt+Shift+L"].extension == $pinned' "$preferences" >/dev/null || fail "copy-url interactive repairs after confirm"
+pass "copy-url interactive repairs on confirmation"
+rm -f "$preferences.omarchy-copy-url-repair.bak"
+close_browser
+
+# Restore default gum stub for remaining cases.
+cat >"$stub_bin/gum" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$*" >>"${GUM_LOG:-/dev/null}"
+exit "${OMARCHY_TEST_GUM_EXIT:-99}"
+STUB
+chmod +x "$stub_bin/gum"
+
+# --- Hermes migration ---
+
+hermes_wrapper="$test_home/.local/bin/hermes"
+preinstalls_marker="$test_home/.local/state/omarchy/preinstalls-removed"
+
+reset_hermes_home() {
+  rm -f "$hermes_wrapper" "$preinstalls_marker"
+  rm -f "$state_dir/1787760281.sh"
+}
+
+# strict+skip+plain-install-path: defer, installer not called, marker absent.
+reset_hermes_home
+reset_logs
+set +e
+OMARCHY_UPDATE_STRICT=1 OMARCHY_UPDATE_MISE=skip OMARCHY_TEST_DESKTOP_INSTALLED=0 \
+  HOME="$test_home" OMARCHY_MIGRATION_STATE="$state_dir" PATH="$stub_bin:$ROOT/bin:$PATH" \
+  bash -euo pipefail "$hermes_migration" >"$test_tmp/hermes-defer-plain.out" 2>"$test_tmp/hermes-defer-plain.err"
+hermes_plain_status=$?
+set -e
+(( hermes_plain_status != 0 )) || fail "hermes strict+skip plain defers nonzero"
+[[ ! -s $INSTALLER_LOG ]] || fail "hermes strict+skip plain never calls installer" "$(cat "$INSTALLER_LOG")"
+grep -q "omarchy-migrate" "$test_tmp/hermes-defer-plain.err" || fail "hermes strict+skip plain stderr names omarchy-migrate" "$(cat "$test_tmp/hermes-defer-plain.err")"
+grep -q "mise=run" "$test_tmp/hermes-defer-plain.err" || fail "hermes strict+skip plain stderr names --mise=run" "$(cat "$test_tmp/hermes-defer-plain.err")"
+[[ ! -f $state_dir/1787760281.sh ]] || fail "hermes strict+skip plain leaves marker absent"
+pass "hermes strict+skip defers plain install"
+
+# strict with MISE unset (default skip): also defers.
+reset_hermes_home
+reset_logs
+set +e
+OMARCHY_UPDATE_STRICT=1 OMARCHY_TEST_DESKTOP_INSTALLED=0 \
+  HOME="$test_home" OMARCHY_MIGRATION_STATE="$state_dir" PATH="$stub_bin:$ROOT/bin:$PATH" \
+  env -u OMARCHY_UPDATE_MISE \
+  bash -euo pipefail "$hermes_migration" >"$test_tmp/hermes-defer-unset.out" 2>"$test_tmp/hermes-defer-unset.err"
+hermes_unset_status=$?
+set -e
+(( hermes_unset_status != 0 )) || fail "hermes strict with unset mise defers nonzero"
+[[ ! -s $INSTALLER_LOG ]] || fail "hermes strict with unset mise never calls installer" "$(cat "$INSTALLER_LOG")"
+pass "hermes strict with unset mise defers"
+
+# strict+skip+desktop-present: defer too, not swallowed by || true.
+reset_hermes_home
+reset_logs
+set +e
+OMARCHY_UPDATE_STRICT=1 OMARCHY_UPDATE_MISE=skip OMARCHY_TEST_DESKTOP_INSTALLED=1 \
+  HOME="$test_home" OMARCHY_MIGRATION_STATE="$state_dir" PATH="$stub_bin:$ROOT/bin:$PATH" \
+  bash -euo pipefail "$hermes_migration" >"$test_tmp/hermes-defer-desktop.out" 2>"$test_tmp/hermes-defer-desktop.err"
+hermes_desktop_defer_status=$?
+set -e
+(( hermes_desktop_defer_status != 0 )) || fail "hermes strict+skip desktop defers nonzero"
+[[ ! -s $INSTALLER_LOG ]] || fail "hermes strict+skip desktop never calls installer (not swallowed by || true)" "$(cat "$INSTALLER_LOG")"
+grep -q "omarchy-migrate" "$test_tmp/hermes-defer-desktop.err" || fail "hermes strict+skip desktop stderr names omarchy-migrate"
+[[ ! -f $state_dir/1787760281.sh ]] || fail "hermes strict+skip desktop leaves marker absent"
+pass "hermes strict+skip defers desktop path"
+
+# strict+mise=run bare path: installer called once, completes.
+reset_hermes_home
+reset_logs
+set +e
+OMARCHY_UPDATE_STRICT=1 OMARCHY_UPDATE_MISE=run OMARCHY_TEST_DESKTOP_INSTALLED=0 \
+  HOME="$test_home" OMARCHY_MIGRATION_STATE="$state_dir" PATH="$stub_bin:$ROOT/bin:$PATH" \
+  bash -euo pipefail "$hermes_migration" >"$test_tmp/hermes-strict-run.out" 2>"$test_tmp/hermes-strict-run.err"
+hermes_strict_run_status=$?
+set -e
+(( hermes_strict_run_status == 0 )) || fail "hermes strict+mise=run completes" "$(cat "$test_tmp/hermes-strict-run.err")"
+(( $(installer_bare_calls) == 1 )) || fail "hermes strict+mise=run calls installer once" "$(cat "$INSTALLER_LOG")"
+touch "$state_dir/1787760281.sh"
+[[ -f $state_dir/1787760281.sh ]] || fail "hermes strict+mise=run records marker"
+pass "hermes strict+mise=run installs"
+
+# Full unattended (UNATTENDED=1, no STRICT) with mise=skip: installer called, completes.
+reset_hermes_home
+reset_logs
+set +e
+OMARCHY_UPDATE_UNATTENDED=1 OMARCHY_UPDATE_MISE=skip OMARCHY_TEST_DESKTOP_INSTALLED=0 \
+  HOME="$test_home" OMARCHY_MIGRATION_STATE="$state_dir" PATH="$stub_bin:$ROOT/bin:$PATH" \
+  env -u OMARCHY_UPDATE_STRICT \
+  bash -euo pipefail "$hermes_migration" >"$test_tmp/hermes-full.out" 2>"$test_tmp/hermes-full.err"
+hermes_full_status=$?
+set -e
+(( hermes_full_status == 0 )) || fail "hermes full unattended completes" "$(cat "$test_tmp/hermes-full.err")"
+(( $(installer_bare_calls) == 1 )) || fail "hermes full unattended calls installer" "$(cat "$INSTALLER_LOG")"
+touch "$state_dir/1787760281.sh"
+[[ -f $state_dir/1787760281.sh ]] || fail "hermes full unattended records marker"
+pass "hermes full unattended installs"
+
+# Interactive: completes.
+reset_hermes_home
+reset_logs
+set +e
+OMARCHY_TEST_DESKTOP_INSTALLED=0 \
+  HOME="$test_home" OMARCHY_MIGRATION_STATE="$state_dir" PATH="$stub_bin:$ROOT/bin:$PATH" \
+  env -u OMARCHY_UPDATE_UNATTENDED -u OMARCHY_UPDATE_STRICT -u OMARCHY_UPDATE_MISE \
+  bash -euo pipefail "$hermes_migration" >"$test_tmp/hermes-interactive.out" 2>"$test_tmp/hermes-interactive.err"
+hermes_interactive_status=$?
+set -e
+(( hermes_interactive_status == 0 )) || fail "hermes interactive completes" "$(cat "$test_tmp/hermes-interactive.err")"
+(( $(installer_bare_calls) == 1 )) || fail "hermes interactive calls installer" "$(cat "$INSTALLER_LOG")"
+pass "hermes interactive installs"
+
+# preinstalls-removed strict+skip: exit 0, no installer.
+reset_hermes_home
+mkdir -p "$(dirname "$preinstalls_marker")"
+touch "$preinstalls_marker"
+reset_logs
+set +e
+OMARCHY_UPDATE_STRICT=1 OMARCHY_UPDATE_MISE=skip OMARCHY_TEST_DESKTOP_INSTALLED=0 \
+  HOME="$test_home" OMARCHY_MIGRATION_STATE="$state_dir" PATH="$stub_bin:$ROOT/bin:$PATH" \
+  bash -euo pipefail "$hermes_migration" >"$test_tmp/hermes-preinstalls.out" 2>"$test_tmp/hermes-preinstalls.err"
+hermes_preinstalls_status=$?
+set -e
+(( hermes_preinstalls_status == 0 )) || fail "hermes preinstalls-removed exits 0"
+[[ ! -s $INSTALLER_LOG ]] || fail "hermes preinstalls-removed never calls installer" "$(cat "$INSTALLER_LOG")"
+pass "hermes preinstalls-removed skips"
+rm -f "$preinstalls_marker"
+
+# foreign-wrapper strict+skip: exit 0, no bare install.
+reset_hermes_home
+printf '#!/bin/bash\necho foreign\n' >"$hermes_wrapper"
+chmod +x "$hermes_wrapper"
+before_wrapper=$(cat "$hermes_wrapper")
+reset_logs
+set +e
+OMARCHY_UPDATE_STRICT=1 OMARCHY_UPDATE_MISE=skip OMARCHY_TEST_DESKTOP_INSTALLED=0 OMARCHY_TEST_WRAPPER_OWNED=0 \
+  HOME="$test_home" OMARCHY_MIGRATION_STATE="$state_dir" PATH="$stub_bin:$ROOT/bin:$PATH" \
+  bash -euo pipefail "$hermes_migration" >"$test_tmp/hermes-foreign.out" 2>"$test_tmp/hermes-foreign.err"
+hermes_foreign_status=$?
+set -e
+(( hermes_foreign_status == 0 )) || fail "hermes foreign-wrapper exits 0"
+(( $(installer_bare_calls) == 0 )) || fail "hermes foreign-wrapper never runs installer" "$(cat "$INSTALLER_LOG")"
+[[ $(cat "$hermes_wrapper") == "$before_wrapper" ]] || fail "hermes foreign-wrapper leaves wrapper alone"
+pass "hermes foreign-wrapper skips"
+rm -f "$hermes_wrapper"
+
+# desktop-present+mise=run: installer called, exits 0 (|| true preserved).
+reset_hermes_home
+reset_logs
+set +e
+OMARCHY_UPDATE_STRICT=1 OMARCHY_UPDATE_MISE=run OMARCHY_TEST_DESKTOP_INSTALLED=1 \
+  HOME="$test_home" OMARCHY_MIGRATION_STATE="$state_dir" PATH="$stub_bin:$ROOT/bin:$PATH" \
+  bash -euo pipefail "$hermes_migration" >"$test_tmp/hermes-desktop-run.out" 2>"$test_tmp/hermes-desktop-run.err"
+hermes_desktop_run_status=$?
+set -e
+(( hermes_desktop_run_status == 0 )) || fail "hermes desktop+mise=run exits 0"
+(( $(installer_bare_calls) == 1 )) || fail "hermes desktop+mise=run calls installer" "$(cat "$INSTALLER_LOG")"
+pass "hermes desktop+mise=run stands aside via installer"
+
+# --- Runner: marker + queue stop ---
+
+runner_root="$test_tmp/runner-omarchy"
+runner_home="$test_tmp/runner-home"
+runner_state="$test_tmp/runner-state"
+mkdir -p "$runner_root/migrations" "$runner_home/.local/bin" "$runner_home/.local/state/omarchy" "$runner_state"
+cp "$hermes_migration" "$runner_root/migrations/1787760281.sh"
+cat >"$runner_root/migrations/1787760282.sh" <<SH
+echo second >>"$test_tmp/runner-calls"
+SH
+: >"$test_tmp/runner-calls"
+
+set +e
+OMARCHY_UPDATE_STRICT=1 OMARCHY_UPDATE_MISE=skip OMARCHY_TEST_DESKTOP_INSTALLED=0 \
+  HOME="$runner_home" OMARCHY_PATH="$runner_root" OMARCHY_MIGRATION_STATE="$runner_state" PATH="$stub_bin:$ROOT/bin:$PATH" \
+  "$ROOT/bin/omarchy-migrate" >"$test_tmp/runner-defer.out" 2>"$test_tmp/runner-defer.err"
+runner_defer_status=$?
+set -e
+(( runner_defer_status != 0 )) || fail "runner stops queue on deferral"
+[[ ! -f $runner_state/1787760281.sh ]] || fail "runner leaves deferred marker absent"
+[[ ! -s $test_tmp/runner-calls ]] || fail "runner does not run later migrations after deferral"
+OMARCHY_TEST_DESKTOP_INSTALLED=0 HOME="$runner_home" OMARCHY_PATH="$runner_root" OMARCHY_MIGRATION_STATE="$runner_state" PATH="$stub_bin:$ROOT/bin:$PATH" \
+  "$ROOT/bin/omarchy-migrate" --pending >"$test_tmp/runner-pending.out" 2>/dev/null
+grep -q '^1787760281\.sh$' "$test_tmp/runner-pending.out" || fail "deferred migration stays pending" "$(cat "$test_tmp/runner-pending.out")"
+pass "runner stops queue on deferral and stays pending"
+
+# Runner success records marker.
+runner_root2="$test_tmp/runner2-omarchy"
+runner_home2="$test_tmp/runner2-home"
+runner_state2="$test_tmp/runner2-state"
+mkdir -p "$runner_root2/migrations" "$runner_home2/.local/bin" "$runner_home2/.local/state/omarchy" "$runner_state2"
+cp "$hermes_migration" "$runner_root2/migrations/1787760281.sh"
+set +e
+OMARCHY_UPDATE_STRICT=1 OMARCHY_UPDATE_MISE=run OMARCHY_TEST_DESKTOP_INSTALLED=0 \
+  HOME="$runner_home2" OMARCHY_PATH="$runner_root2" OMARCHY_MIGRATION_STATE="$runner_state2" PATH="$stub_bin:$ROOT/bin:$PATH" \
+  "$ROOT/bin/omarchy-migrate" >"$test_tmp/runner-success.out" 2>"$test_tmp/runner-success.err"
+runner_success_status=$?
+set -e
+(( runner_success_status == 0 )) || fail "runner completes on installer success" "$(cat "$test_tmp/runner-success.err")"
+[[ -f $runner_state2/1787760281.sh ]] || fail "runner records marker on completion"
+pass "runner records marker on completion"

--- a/test/shell.d/update-options-test.sh
+++ b/test/shell.d/update-options-test.sh
@@ -1,0 +1,319 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+mkdir -p "$stub_bin"
+
+steps=(
+  omarchy-update-lock
+  omarchy-update-requires-free-space
+  omarchy-update-confirm
+  omarchy-update-pkg-prune
+  omarchy-snapshot
+  omarchy-update-stay-awake
+  omarchy-update-dev
+  omarchy-update-keyring
+  omarchy-update-system-pkgs
+  omarchy-migrate
+  omarchy-hook
+  omarchy-update-aur-pkgs
+  omarchy-update-mise
+  omarchy-update-orphan-pkgs
+  omarchy-update-analyze-logs
+  omarchy-update-status
+  omarchy-update-restart
+)
+
+for step in "${steps[@]}"; do
+  cat >"$stub_bin/$step" <<'STUB'
+#!/bin/bash
+printf '%s unattended=%s strict=%s hooks=%s aur=%s mise=%s orphans=%s reboot=%s restarts=%s args=%s\n' "${0##*/}" "${OMARCHY_UPDATE_UNATTENDED:-}" "${OMARCHY_UPDATE_STRICT:-}" "${OMARCHY_UPDATE_HOOKS:-}" "${OMARCHY_UPDATE_AUR:-}" "${OMARCHY_UPDATE_MISE:-}" "${OMARCHY_UPDATE_ORPHANS:-}" "${OMARCHY_UPDATE_REBOOT:-}" "${OMARCHY_UPDATE_RESTARTS:-}" "$*" >>"$STEP_LOG"
+exit 0
+STUB
+  chmod +x "$stub_bin/$step"
+done
+
+cat >"$stub_bin/sudo" <<'STUB'
+#!/bin/bash
+printf 'sudo %s\n' "$*" >>"$STEP_LOG"
+args=()
+for a in "$@"; do
+  if [[ $a == "-n" ]]; then
+    continue
+  fi
+  if [[ $a == "--" ]]; then
+    continue
+  fi
+  args+=("$a")
+done
+if (( ${#args[@]} == 0 )); then
+  exit 0
+fi
+exec "${args[@]}"
+STUB
+chmod +x "$stub_bin/sudo"
+
+cat >"$stub_bin/script" <<'STUB'
+#!/bin/bash
+printf 'script %s\n' "$*" >>"$STEP_LOG"
+exit 99
+STUB
+chmod +x "$stub_bin/script"
+
+run_valid() {
+  : >"$test_tmp/steps"
+  : >"$test_tmp/out"
+  : >"$test_tmp/err"
+  STEP_LOG="$test_tmp/steps" \
+    OMARCHY_UPDATE_LOGGED=1 \
+    OMARCHY_PATH="$ROOT" \
+    PATH="$stub_bin:$ROOT/bin:$PATH" \
+    env -u OMARCHY_UPDATE_RUN_REEXEC \
+    bash "$ROOT/bin/omarchy-update" "$@" >"$test_tmp/out" 2>"$test_tmp/err"
+}
+
+run_invalid() {
+  : >"$test_tmp/steps"
+  : >"$test_tmp/out"
+  : >"$test_tmp/err"
+  rm -f /tmp/omarchy-update.log
+  set +e
+  STEP_LOG="$test_tmp/steps" \
+    OMARCHY_PATH="$ROOT" \
+    PATH="$stub_bin:$ROOT/bin:$PATH" \
+    env -u OMARCHY_UPDATE_LOGGED -u OMARCHY_UPDATE_RUN_REEXEC \
+    bash "$ROOT/bin/omarchy-update" "$@" >"$test_tmp/out" 2>"$test_tmp/err"
+  status=$?
+  set -e
+  printf '%s' "$status" >"$test_tmp/status"
+}
+
+expect_invalid() {
+  local desc="$1"
+  shift
+  run_invalid "$@"
+  status=$(<"$test_tmp/status")
+  (( status == 2 )) || fail "$desc exits 2" "got $status out=$(cat "$test_tmp/out") err=$(cat "$test_tmp/err")"
+  [[ ! -s $test_tmp/steps ]] || fail "$desc runs no step/lock/sudo/script mocks" "$(cat "$test_tmp/steps")"
+  [[ ! -e /tmp/omarchy-update.log ]] || fail "$desc creates no transcript" "log exists"
+  pass "$desc"
+}
+
+check_env() {
+  local desc="$1"
+  local expected="$2"
+  grep -q "^omarchy-update-requires-free-space $expected" "$test_tmp/steps" ||
+    fail "$desc forwards env before early steps" "$(cat "$test_tmp/steps")"
+  grep -q "^omarchy-update-system-pkgs $expected" "$test_tmp/steps" ||
+    fail "$desc forwards env to pipeline" "$(cat "$test_tmp/steps")"
+  pass "$desc"
+}
+
+run_valid || fail "interactive defaults succeed"
+check_env "interactive defaults" "unattended= strict= hooks=run aur=run mise=run orphans=ask reboot=ask restarts=run"
+[[ ! -s $test_tmp/out ]] || fail "interactive prints no unattended summary" "$(cat "$test_tmp/out")"
+pass "interactive defaults with no summary"
+
+run_valid -y || fail "-y defaults succeed"
+check_env "-y defaults" "unattended=1 strict= hooks=run aur=run mise=run orphans=keep reboot=never restarts=run"
+grep -q "Unattended update (full)" "$test_tmp/out" || fail "-y prints full summary" "$(cat "$test_tmp/out")"
+pass "-y defaults"
+
+run_valid --yes || fail "--yes defaults succeed"
+check_env "--yes defaults" "unattended=1 strict= hooks=run aur=run mise=run orphans=keep reboot=never restarts=run"
+pass "--yes defaults match -y"
+
+run_valid --non-interactive || fail "strict defaults succeed"
+check_env "strict defaults" "unattended=1 strict=1 hooks=skip aur=skip mise=skip orphans=keep reboot=never restarts=run"
+grep -q "Unattended update (strict)" "$test_tmp/out" || fail "strict prints strict summary" "$(cat "$test_tmp/out")"
+grep -q "Skipping post-update hooks (--hooks=skip)" "$test_tmp/out" || fail "strict reports hook skip" "$(cat "$test_tmp/out")"
+grep -q "Skipping AUR package updates (--aur=skip)" "$test_tmp/out" || fail "strict reports aur skip" "$(cat "$test_tmp/out")"
+grep -q "Skipping mise updates (--mise=skip)" "$test_tmp/out" || fail "strict reports mise skip" "$(cat "$test_tmp/out")"
+[[ $test_tmp/err != *"Warning:"* ]] || fail "strict defaults warn without opt-in" "$(cat "$test_tmp/err")"
+pass "strict defaults skip externals"
+
+for mode in "" "-y" "--non-interactive"; do
+  for val in run skip; do
+    if [[ -z $mode ]]; then
+      label="interactive --hooks=$val"
+    else
+      label="$mode --hooks=$val"
+    fi
+    # shellcheck disable=SC2086
+    run_valid $mode --hooks=$val || fail "$label succeeds"
+    grep -q "hooks=$val " "$test_tmp/steps" || fail "$label forwards hooks" "$(cat "$test_tmp/steps")"
+  done
+  for val in run skip; do
+    # shellcheck disable=SC2086
+    run_valid $mode --aur=$val || fail "$mode --aur=$val succeeds"
+    grep -q "aur=$val " "$test_tmp/steps" || fail "$mode --aur=$val forwards" "$(cat "$test_tmp/steps")"
+  done
+  for val in run skip; do
+    # shellcheck disable=SC2086
+    run_valid $mode --mise=$val || fail "$mode --mise=$val succeeds"
+    grep -q "mise=$val " "$test_tmp/steps" || fail "$mode --mise=$val forwards" "$(cat "$test_tmp/steps")"
+  done
+  for val in run skip; do
+    # shellcheck disable=SC2086
+    run_valid $mode --restarts=$val || fail "$mode --restarts=$val succeeds"
+    grep -q "restarts=$val " "$test_tmp/steps" || fail "$mode --restarts=$val forwards" "$(cat "$test_tmp/steps")"
+  done
+done
+pass "every hooks/aur/mise/restarts value works across modes"
+
+run_valid --orphans=ask || fail "interactive --orphans=ask succeeds"
+grep -q "orphans=ask " "$test_tmp/steps" || fail "interactive ask forwards" "$(cat "$test_tmp/steps")"
+run_valid --orphans=keep || fail "interactive --orphans=keep succeeds"
+run_valid --orphans=remove || fail "interactive --orphans=remove succeeds"
+run_valid -y --orphans=keep || fail "-y --orphans=keep succeeds"
+run_valid -y --orphans=remove || fail "-y --orphans=remove succeeds"
+run_valid --non-interactive --orphans=keep || fail "strict --orphans=keep succeeds"
+run_valid --non-interactive --orphans=remove || fail "strict --orphans=remove succeeds"
+run_valid --reboot=ask || fail "interactive --reboot=ask succeeds"
+run_valid --reboot=never || fail "interactive --reboot=never succeeds"
+run_valid --reboot=if-needed || fail "interactive --reboot=if-needed succeeds"
+run_valid -y --reboot=never || fail "-y --reboot=never succeeds"
+run_valid -y --reboot=if-needed || fail "-y --reboot=if-needed succeeds"
+run_valid --non-interactive --reboot=never || fail "strict --reboot=never succeeds"
+run_valid --non-interactive --reboot=if-needed || fail "strict --reboot=if-needed succeeds"
+pass "every orphans/reboot value works where allowed"
+
+run_valid --non-interactive --aur=run --hooks=skip --mise=skip || fail "order case 1 succeeds"
+env1=$(grep "^omarchy-update-system-pkgs " "$test_tmp/steps")
+run_valid --non-interactive --mise=skip --hooks=skip --aur=run || fail "order case 2 succeeds"
+env2=$(grep "^omarchy-update-system-pkgs " "$test_tmp/steps")
+[[ $env1 == "$env2" ]] || fail "explicit policies are order-independent" "$env1 vs $env2"
+pass "explicit policies are order-independent"
+
+run_valid -y --hooks=run --hooks=run || fail "identical duplicate hooks succeeds"
+run_valid --non-interactive --mise=skip --mise=skip || fail "identical duplicate mise succeeds"
+pass "identical duplicates are allowed"
+
+run_valid -y --yes || fail "-y --yes succeeds"
+grep -q "unattended=1 strict= hooks=run " "$test_tmp/steps" || fail "-y --yes stays full" "$(cat "$test_tmp/steps")"
+run_valid -y --non-interactive || fail "-y + strict succeeds"
+grep -q "unattended=1 strict=1 hooks=skip " "$test_tmp/steps" || fail "-y + strict prefers strict" "$(cat "$test_tmp/steps")"
+run_valid --non-interactive -y || fail "strict + -y order succeeds"
+grep -q "unattended=1 strict=1 hooks=skip " "$test_tmp/steps" || fail "strict wins regardless of order" "$(cat "$test_tmp/steps")"
+run_valid --yes --non-interactive --hooks=run || fail "strict opt-in priority succeeds"
+grep -q "hooks=run " "$test_tmp/steps" || fail "strict opt-in keeps explicit run" "$(cat "$test_tmp/steps")"
+grep -q "Warning: --hooks=run in strict mode" "$test_tmp/err" || fail "strict opt-in warns" "$(cat "$test_tmp/err")"
+pass "strict mode priority with redundant modes"
+
+run_valid -y --orphans=remove --reboot=if-needed || fail "destructive summary succeeds"
+grep -q "Unattended update (full)" "$test_tmp/out" || fail "destructive prints summary" "$(cat "$test_tmp/out")"
+grep -q "Orphan policy: remove" "$test_tmp/out" || fail "destructive reports orphans=remove" "$(cat "$test_tmp/out")"
+grep -q "Reboot policy: if-needed" "$test_tmp/out" || fail "destructive reports reboot=if-needed" "$(cat "$test_tmp/out")"
+pass "unattended summary includes destructive selections"
+
+run_valid --non-interactive --hooks=run || fail "strict hooks opt-in succeeds"
+grep -q "Warning: --hooks=run in strict mode" "$test_tmp/err" || fail "strict hooks warn" "$(cat "$test_tmp/err")"
+[[ $test_tmp/out != *"Skipping post-update hooks"* ]] || fail "strict hooks opt-in must not skip" "$(cat "$test_tmp/out")"
+run_valid --non-interactive --aur=run || fail "strict aur opt-in succeeds"
+grep -q "Warning: --aur=run in strict mode" "$test_tmp/err" || fail "strict aur warn" "$(cat "$test_tmp/err")"
+run_valid --non-interactive --mise=run || fail "strict mise opt-in succeeds"
+grep -q "Warning: --mise=run in strict mode" "$test_tmp/err" || fail "strict mise warn" "$(cat "$test_tmp/err")"
+run_valid -y --hooks=skip || fail "full explicit skip succeeds"
+grep -q "Skipping post-update hooks (--hooks=skip)" "$test_tmp/out" || fail "full skip reports" "$(cat "$test_tmp/out")"
+[[ $test_tmp/err != *"Warning:"* ]] || fail "full skip must not warn" "$(cat "$test_tmp/err")"
+pass "external skip and warn reports"
+
+set +e
+STEP_LOG="$test_tmp/steps" OMARCHY_UPDATE_LOGGED=1 OMARCHY_PATH="$ROOT" PATH="$stub_bin:$ROOT/bin:$PATH" \
+  env OMARCHY_UPDATE_UNATTENDED=1 OMARCHY_UPDATE_STRICT=1 OMARCHY_UPDATE_HOOKS=skip OMARCHY_UPDATE_AUR=skip OMARCHY_UPDATE_MISE=skip OMARCHY_UPDATE_ORPHANS=remove OMARCHY_UPDATE_REBOOT=if-needed OMARCHY_UPDATE_RESTARTS=skip \
+  bash "$ROOT/bin/omarchy-update" >"$test_tmp/out" 2>"$test_tmp/err"
+set -e
+grep -q "^omarchy-update-requires-free-space unattended= strict= hooks=run aur=run mise=run orphans=ask reboot=ask restarts=run " "$test_tmp/steps" ||
+  fail "stale inherited policy does not leak into interactive" "$(cat "$test_tmp/steps")"
+pass "stale inherited values are ignored for interactive"
+
+set +e
+STEP_LOG="$test_tmp/steps" OMARCHY_UPDATE_LOGGED=1 OMARCHY_PATH="$ROOT" PATH="$stub_bin:$ROOT/bin:$PATH" \
+  env OMARCHY_UPDATE_HOOKS=skip OMARCHY_UPDATE_AUR=skip OMARCHY_UPDATE_ORPHANS=ask \
+  bash "$ROOT/bin/omarchy-update" -y >"$test_tmp/out" 2>"$test_tmp/err"
+set -e
+grep -q "^omarchy-update-system-pkgs unattended=1 strict= hooks=run aur=run mise=run orphans=keep reboot=never restarts=run " "$test_tmp/steps" ||
+  fail "public args are authoritative over stale env" "$(cat "$test_tmp/steps")"
+pass "public args are authoritative not inherited policy env"
+
+set +e
+STEP_LOG="$test_tmp/steps" OMARCHY_UPDATE_LOGGED=1 OMARCHY_PATH="$ROOT" PATH="$stub_bin:$ROOT/bin:$PATH" \
+  env OMARCHY_UPDATE_UNATTENDED=1 OMARCHY_UPDATE_ENV_READY=1 OMARCHY_UPDATE_REAL_SUDO=/nonexistent \
+  bash "$ROOT/bin/omarchy-update" >"$test_tmp/out" 2>"$test_tmp/err"
+status=$?
+set -e
+grep -q "^omarchy-update-requires-free-space unattended= strict= " "$test_tmp/steps" ||
+  fail "interactive is not turned unattended by inherited env" "$(cat "$test_tmp/steps") err=$(cat "$test_tmp/err") status=$status"
+pass "interactive must not be turned unattended by inherited policy env"
+
+expect_invalid "contradictory duplicate hooks" --hooks=run --hooks=skip
+expect_invalid "contradictory duplicate orphans" -y --orphans=keep --orphans=remove
+expect_invalid "unknown flag" --frobnicate
+expect_invalid "unknown hooks spelling" --hook=run
+expect_invalid "missing hooks value" --hooks
+expect_invalid "empty hooks value" --hooks=
+expect_invalid "invalid hooks value" --hooks=maybe
+expect_invalid "invalid hooks case" --hooks=Run
+expect_invalid "missing aur value" --aur=
+expect_invalid "invalid orphans value" --orphans=never
+expect_invalid "invalid reboot value" --reboot=run
+expect_invalid "invalid restarts value" --restarts=ask
+expect_invalid "space-separated policy" --hooks run
+expect_invalid "positional arg" foo
+expect_invalid "positional after -y" -y foo
+expect_invalid "single-dash unknown" -n
+expect_invalid "combined -yy" -yy
+expect_invalid "mode with value" --yes=true
+expect_invalid "strict with value" --non-interactive=true
+expect_invalid "ask orphans with -y" -y --orphans=ask
+expect_invalid "ask orphans before -y" --orphans=ask -y
+expect_invalid "ask reboot with -y" -y --reboot=ask
+expect_invalid "ask reboot with strict" --non-interactive --reboot=ask
+expect_invalid "ask reboot before strict" --reboot=ask --non-interactive
+expect_invalid "ask orphans with strict" --non-interactive --orphans=ask
+
+: >"$test_tmp/steps"
+rm -f /tmp/omarchy-update.log
+set +e
+STEP_LOG="$test_tmp/steps" OMARCHY_PATH="$ROOT" PATH="$stub_bin:$ROOT/bin:$PATH" \
+  env -u OMARCHY_UPDATE_LOGGED bash "$ROOT/bin/omarchy-update" -h >"$test_tmp/out" 2>"$test_tmp/err"
+h_status=$?
+set -e
+(( h_status == 0 )) || fail "-h exits 0" "got $h_status"
+grep -q "^Usage: omarchy update" "$test_tmp/out" || fail "-h prints usage" "$(cat "$test_tmp/out")"
+[[ ! -s $test_tmp/steps ]] || fail "-h runs no mocks" "$(cat "$test_tmp/steps")"
+[[ ! -e /tmp/omarchy-update.log ]] || fail "-h creates no transcript"
+pass "-h prints usage with no actions"
+
+: >"$test_tmp/steps"
+rm -f /tmp/omarchy-update.log
+set +e
+STEP_LOG="$test_tmp/steps" OMARCHY_PATH="$ROOT" PATH="$stub_bin:$ROOT/bin:$PATH" \
+  env -u OMARCHY_UPDATE_LOGGED bash "$ROOT/bin/omarchy-update" --help >"$test_tmp/out" 2>"$test_tmp/err"
+help_status=$?
+set -e
+(( help_status == 0 )) || fail "--help exits 0" "got $help_status"
+grep -q "^Usage: omarchy update" "$test_tmp/out" || fail "--help prints usage" "$(cat "$test_tmp/out")"
+grep -q "orphans=ask" "$test_tmp/out" || fail "--help is detailed" "$(cat "$test_tmp/out")"
+[[ ! -s $test_tmp/steps ]] || fail "--help runs no mocks" "$(cat "$test_tmp/steps")"
+[[ ! -e /tmp/omarchy-update.log ]] || fail "--help creates no transcript"
+pass "--help prints detailed usage with no actions"
+
+: >"$test_tmp/steps"
+rm -f /tmp/omarchy-update.log
+set +e
+STEP_LOG="$test_tmp/steps" OMARCHY_PATH="$ROOT" PATH="$stub_bin:$ROOT/bin:$PATH" \
+  env -u OMARCHY_UPDATE_LOGGED bash "$ROOT/bin/omarchy-update" --bogus --help >"$test_tmp/out" 2>"$test_tmp/err"
+mixed_status=$?
+set -e
+(( mixed_status == 0 )) || fail "help wins over invalid flags exits 0" "got $mixed_status"
+grep -q "^Usage: omarchy update" "$test_tmp/out" || fail "help wins prints usage" "$(cat "$test_tmp/out")"
+[[ ! -s $test_tmp/steps ]] || fail "help wins runs no mocks" "$(cat "$test_tmp/steps")"
+[[ ! -e /tmp/omarchy-update.log ]] || fail "help wins creates no transcript"
+pass "help takes precedence over invalid flags deterministically"

--- a/test/shell.d/update-orphan-test.sh
+++ b/test/shell.d/update-orphan-test.sh
@@ -4,12 +4,19 @@ set -euo pipefail
 
 source "$(dirname "$0")/base-test.sh"
 
+require_command script
+
 test_tmp=$(mktemp -d)
 trap 'rm -rf "$test_tmp"' EXIT
 
 stub_bin="$test_tmp/bin"
 test_home="$test_tmp/home"
 mkdir -p "$stub_bin" "$test_home"
+
+GUM_LOG="$test_tmp/gum.log"
+SUDO_LOG="$test_tmp/sudo.log"
+: >"$GUM_LOG"
+: >"$SUDO_LOG"
 
 write_stub() {
   local name="$1"
@@ -23,19 +30,244 @@ SH
 }
 
 run_orphan_checker() {
-  HOME="$test_home" PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-update-orphan-pkgs"
+  HOME="$test_home" PATH="$stub_bin:$PATH" GUM_LOG="$GUM_LOG" SUDO_LOG="$SUDO_LOG" env -u OMARCHY_UPDATE_ORPHANS -u OMARCHY_UPDATE_UNATTENDED "$ROOT/bin/omarchy-update-orphan-pkgs"
 }
 
-write_stub pacman 'if [[ $1 == "-Qtdq" ]]; then printf "old-lib\nunused-tool\n"; exit 0; fi; exit 1'
-write_stub sudo 'echo "sudo should not be called" >&2; exit 99'
-write_stub gum 'echo "gum should not be called" >&2; exit 99'
+run_orphan_headless() {
+  HOME="$test_home" PATH="$stub_bin:$PATH" GUM_LOG="$GUM_LOG" SUDO_LOG="$SUDO_LOG" "$ROOT/bin/omarchy-update-orphan-pkgs"
+}
 
+run_orphan_pty() {
+  # Inherits exported env (including OMARCHY_UPDATE_*); child gets a real PTY
+  # for stdin/stdout/stderr via script(1) so [[ -t 0 && -t 1 ]] is true.
+  HOME="$test_home" PATH="$stub_bin:$PATH" GUM_LOG="$GUM_LOG" SUDO_LOG="$SUDO_LOG" \
+    script -qec "$ROOT/bin/omarchy-update-orphan-pkgs" /dev/null
+}
+
+reset_logs() {
+  : >"$GUM_LOG"
+  : >"$SUDO_LOG"
+}
+
+clean_pty_out() {
+  tr -d '\r' <"$1"
+}
+
+# Default stubs: two orphans, gum/sudo must not run unless a case allows them.
+write_stub pacman 'if [[ $1 == "-Qtdq" ]]; then printf "old-lib\nunused-tool\n"; exit 0; fi; exit 1'
+write_stub sudo 'printf "%s\n" "$*" >>"${SUDO_LOG:-/dev/null}"; echo "sudo should not be called" >&2; exit 99'
+write_stub gum 'printf "%s\n" "$*" >>"${GUM_LOG:-/dev/null}"; echo "gum should not be called" >&2; exit 99'
+
+reset_logs
 run_orphan_checker >"$test_tmp/noninteractive.out" 2>"$test_tmp/noninteractive.err"
 grep -q '^  old-lib$' "$test_tmp/noninteractive.out" || fail "orphan checker lists orphan packages"
 grep -q 'Re-run omarchy-update-orphan-pkgs in a terminal' "$test_tmp/noninteractive.out" || fail "orphan checker does not remove packages non-interactively"
+[[ ! -s $GUM_LOG ]] || fail "orphan checker does not call gum non-interactively"
+[[ ! -s $SUDO_LOG ]] || fail "orphan checker does not call sudo non-interactively"
 pass "orphan checker only reports orphans non-interactively"
 
 write_stub pacman 'if [[ $1 == "-Qtdq" ]]; then exit 0; fi; exit 1'
+reset_logs
 run_orphan_checker >"$test_tmp/none.out" 2>"$test_tmp/none.err"
 [[ ! -s $test_tmp/none.out ]] || fail "orphan checker stays quiet when no orphans exist"
+[[ ! -s $GUM_LOG ]] || fail "orphan checker does not call gum without orphans"
+[[ ! -s $SUDO_LOG ]] || fail "orphan checker does not call sudo without orphans"
 pass "orphan checker stays quiet without orphans"
+
+# Restore orphan list for the remaining cases.
+write_stub pacman 'if [[ $1 == "-Qtdq" ]]; then printf "old-lib\nunused-tool\n"; exit 0; fi; exit 1'
+
+# ask PTY + decline: gum called once, orphans retained, exit 0.
+write_stub gum 'printf "%s\n" "$*" >>"${GUM_LOG:-/dev/null}"; exit 1'
+write_stub sudo 'printf "%s\n" "$*" >>"${SUDO_LOG:-/dev/null}"; echo "sudo should not be called" >&2; exit 99'
+reset_logs
+set +e
+unset OMARCHY_UPDATE_ORPHANS
+unset OMARCHY_UPDATE_UNATTENDED
+export GUM_LOG SUDO_LOG
+HOME="$test_home" PATH="$stub_bin:$PATH" script -qec "$ROOT/bin/omarchy-update-orphan-pkgs" /dev/null >"$test_tmp/ask-decline.out" 2>"$test_tmp/ask-decline.err"
+ask_decline_status=$?
+set -e
+(( ask_decline_status == 0 )) || fail "ask PTY decline exits 0" "got $ask_decline_status"
+(( $(wc -l <"$GUM_LOG") == 1 )) || fail "ask PTY decline calls gum once" "$(cat "$GUM_LOG")"
+grep -q 'confirm --default=false' "$GUM_LOG" || fail "ask PTY decline confirms with default=false" "$(cat "$GUM_LOG")"
+[[ ! -s $SUDO_LOG ]] || fail "ask PTY decline does not call sudo" "$(cat "$SUDO_LOG")"
+clean_pty_out "$test_tmp/ask-decline.out" | grep -q 'Keeping orphaned packages' || fail "ask PTY decline keeps orphans" "$(clean_pty_out "$test_tmp/ask-decline.out")"
+pass "ask PTY decline keeps orphans without sudo"
+
+# ask PTY + accept: sudo without --noconfirm, interactive behavior preserved.
+write_stub gum 'printf "%s\n" "$*" >>"${GUM_LOG:-/dev/null}"; exit 0'
+write_stub sudo 'printf "%s\n" "$*" >>"${SUDO_LOG:-/dev/null}"; exit 0'
+reset_logs
+set +e
+unset OMARCHY_UPDATE_ORPHANS
+unset OMARCHY_UPDATE_UNATTENDED
+HOME="$test_home" PATH="$stub_bin:$PATH" script -qec "$ROOT/bin/omarchy-update-orphan-pkgs" /dev/null >"$test_tmp/ask-accept.out" 2>"$test_tmp/ask-accept.err"
+ask_accept_status=$?
+set -e
+(( ask_accept_status == 0 )) || fail "ask PTY accept exits 0" "got $ask_accept_status"
+(( $(wc -l <"$GUM_LOG") == 1 )) || fail "ask PTY accept calls gum once" "$(cat "$GUM_LOG")"
+grep -q 'pacman' "$SUDO_LOG" || fail "ask PTY accept calls sudo pacman" "$(cat "$SUDO_LOG")"
+grep -q -- '--noconfirm' "$SUDO_LOG" && fail "ask PTY accept does not use --noconfirm" "$(cat "$SUDO_LOG")"
+grep -q 'old-lib' "$SUDO_LOG" || fail "ask PTY accept passes orphan list to sudo" "$(cat "$SUDO_LOG")"
+pass "ask PTY accept removes without --noconfirm"
+
+# keep headless: no gum/no sudo, Keeping report, exit 0.
+write_stub gum 'printf "%s\n" "$*" >>"${GUM_LOG:-/dev/null}"; echo "gum should not be called" >&2; exit 99'
+write_stub sudo 'printf "%s\n" "$*" >>"${SUDO_LOG:-/dev/null}"; echo "sudo should not be called" >&2; exit 99'
+reset_logs
+set +e
+export OMARCHY_UPDATE_ORPHANS="keep"
+unset OMARCHY_UPDATE_UNATTENDED
+run_orphan_headless >"$test_tmp/keep-headless.out" 2>"$test_tmp/keep-headless.err"
+keep_headless_status=$?
+set -e
+(( keep_headless_status == 0 )) || fail "keep headless exits 0" "got $keep_headless_status"
+grep -q 'Keeping orphaned packages' "$test_tmp/keep-headless.out" || fail "keep headless reports Keeping" "$(cat "$test_tmp/keep-headless.out")"
+grep -q 'Re-run omarchy-update-orphan-pkgs in a terminal' "$test_tmp/keep-headless.out" || fail "keep headless reuses headless wording" "$(cat "$test_tmp/keep-headless.out")"
+[[ ! -s $GUM_LOG ]] || fail "keep headless does not call gum" "$(cat "$GUM_LOG")"
+[[ ! -s $SUDO_LOG ]] || fail "keep headless does not call sudo" "$(cat "$SUDO_LOG")"
+pass "keep headless lists and keeps without gum or sudo"
+
+# keep PTY: still no gum (mutation-proof: old helper would call gum here).
+reset_logs
+set +e
+export OMARCHY_UPDATE_ORPHANS="keep"
+unset OMARCHY_UPDATE_UNATTENDED
+HOME="$test_home" PATH="$stub_bin:$PATH" script -qec "$ROOT/bin/omarchy-update-orphan-pkgs" /dev/null >"$test_tmp/keep-pty.out" 2>"$test_tmp/keep-pty.err"
+keep_pty_status=$?
+set -e
+(( keep_pty_status == 0 )) || fail "keep PTY exits 0" "got $keep_pty_status"
+[[ ! -s $GUM_LOG ]] || fail "keep PTY does not call gum" "$(cat "$GUM_LOG")"
+[[ ! -s $SUDO_LOG ]] || fail "keep PTY does not call sudo" "$(cat "$SUDO_LOG")"
+clean_pty_out "$test_tmp/keep-pty.out" | grep -q 'Keeping orphaned packages' || fail "keep PTY reports Keeping" "$(clean_pty_out "$test_tmp/keep-pty.out")"
+pass "keep PTY lists and keeps without gum or sudo"
+
+# remove via scoped adapter: -n plus --noconfirm and package list in order.
+write_stub gum 'printf "%s\n" "$*" >>"${GUM_LOG:-/dev/null}"; echo "gum should not be called" >&2; exit 99'
+cat >"$stub_bin/sudo" <<'STUB'
+#!/bin/bash
+printf '%q ' "$@" >>"${SUDO_LOG:-/dev/null}"
+printf '\n' >>"${SUDO_LOG:-/dev/null}"
+exit 0
+STUB
+chmod +x "$stub_bin/sudo"
+reset_logs
+set +e
+export OMARCHY_UPDATE_ORPHANS="remove"
+export OMARCHY_UPDATE_UNATTENDED=1
+export OMARCHY_PATH="$ROOT"
+HOME="$test_home" PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-update-run" "$ROOT/bin/omarchy-update-orphan-pkgs" >"$test_tmp/remove-adapter.out" 2>"$test_tmp/remove-adapter.err"
+remove_status=$?
+set -e
+(( remove_status == 0 )) || fail "remove via adapter exits 0" "got $remove_status; out=$(cat "$test_tmp/remove-adapter.out"); err=$(cat "$test_tmp/remove-adapter.err")"
+[[ ! -s $GUM_LOG ]] || fail "remove does not call gum" "$(cat "$GUM_LOG")"
+grep -q -- '-n' "$SUDO_LOG" || fail "remove via adapter uses sudo -n" "$(cat "$SUDO_LOG")"
+grep -q -- '--noconfirm' "$SUDO_LOG" || fail "remove uses --noconfirm" "$(cat "$SUDO_LOG")"
+grep -q 'old-lib.*unused-tool' "$SUDO_LOG" || fail "remove passes packages in order" "$(cat "$SUDO_LOG")"
+grep -q 'Removing orphan system packages' "$test_tmp/remove-adapter.out" || fail "remove prints removing message" "$(cat "$test_tmp/remove-adapter.out")"
+unset OMARCHY_PATH
+pass "remove via adapter uses sudo -n --noconfirm with package list"
+
+# remove failure propagates nonzero with no success message after failure.
+write_stub gum 'printf "%s\n" "$*" >>"${GUM_LOG:-/dev/null}"; echo "gum should not be called" >&2; exit 99'
+write_stub sudo 'printf "%s\n" "$*" >>"${SUDO_LOG:-/dev/null}"; exit 7'
+reset_logs
+set +e
+export OMARCHY_UPDATE_ORPHANS="remove"
+unset OMARCHY_UPDATE_UNATTENDED
+unset OMARCHY_PATH
+run_orphan_headless >"$test_tmp/remove-fail.out" 2>"$test_tmp/remove-fail.err"
+remove_fail_status=$?
+set -e
+(( remove_fail_status != 0 )) || fail "remove failure exits nonzero" "got 0"
+(( remove_fail_status == 7 )) || fail "remove failure propagates exit 7" "got $remove_fail_status"
+grep -q 'pacman' "$SUDO_LOG" || fail "remove failure still calls sudo" "$(cat "$SUDO_LOG")"
+[[ ! -s $GUM_LOG ]] || fail "remove failure does not call gum" "$(cat "$GUM_LOG")"
+pass "remove failure propagates nonzero without masking"
+
+# empty orphans: all policies exit 0 with no gum/sudo calls.
+write_stub pacman 'if [[ $1 == "-Qtdq" ]]; then exit 0; fi; exit 1'
+write_stub gum 'printf "%s\n" "$*" >>"${GUM_LOG:-/dev/null}"; echo "gum should not be called" >&2; exit 99'
+write_stub sudo 'printf "%s\n" "$*" >>"${SUDO_LOG:-/dev/null}"; echo "sudo should not be called" >&2; exit 99'
+for policy in ask keep remove; do
+  reset_logs
+  set +e
+  export OMARCHY_UPDATE_ORPHANS="$policy"
+  unset OMARCHY_UPDATE_UNATTENDED
+  run_orphan_headless >"$test_tmp/empty-$policy.out" 2>"$test_tmp/empty-$policy.err"
+  empty_status=$?
+  set -e
+  (( empty_status == 0 )) || fail "empty orphans with $policy exits 0" "got $empty_status"
+  [[ ! -s $test_tmp/empty-$policy.out ]] || fail "empty orphans with $policy stays quiet" "$(cat "$test_tmp/empty-$policy.out")"
+  [[ ! -s $GUM_LOG ]] || fail "empty orphans with $policy does not call gum" "$(cat "$GUM_LOG")"
+  [[ ! -s $SUDO_LOG ]] || fail "empty orphans with $policy does not call sudo" "$(cat "$SUDO_LOG")"
+done
+pass "empty orphans exit 0 quietly for all policies"
+
+# Restore orphan list.
+write_stub pacman 'if [[ $1 == "-Qtdq" ]]; then printf "old-lib\nunused-tool\n"; exit 0; fi; exit 1'
+
+# unattended without policy defaults to keep (no gum).
+write_stub gum 'printf "%s\n" "$*" >>"${GUM_LOG:-/dev/null}"; echo "gum should not be called" >&2; exit 99'
+write_stub sudo 'printf "%s\n" "$*" >>"${SUDO_LOG:-/dev/null}"; echo "sudo should not be called" >&2; exit 99'
+reset_logs
+set +e
+unset OMARCHY_UPDATE_ORPHANS
+export OMARCHY_UPDATE_UNATTENDED=1
+run_orphan_headless >"$test_tmp/unattended-default.out" 2>"$test_tmp/unattended-default.err"
+unattended_default_status=$?
+set -e
+(( unattended_default_status == 0 )) || fail "unattended default exits 0" "got $unattended_default_status"
+grep -q 'Keeping orphaned packages' "$test_tmp/unattended-default.out" || fail "unattended default keeps orphans" "$(cat "$test_tmp/unattended-default.out")"
+[[ ! -s $GUM_LOG ]] || fail "unattended default does not call gum" "$(cat "$GUM_LOG")"
+[[ ! -s $SUDO_LOG ]] || fail "unattended default does not call sudo" "$(cat "$SUDO_LOG")"
+pass "unattended without policy defaults to keep"
+
+# unattended + ask under PTY must not reach gum.
+reset_logs
+set +e
+export OMARCHY_UPDATE_ORPHANS="ask"
+export OMARCHY_UPDATE_UNATTENDED=1
+HOME="$test_home" PATH="$stub_bin:$PATH" script -qec "$ROOT/bin/omarchy-update-orphan-pkgs" /dev/null >"$test_tmp/unattended-ask-pty.out" 2>"$test_tmp/unattended-ask-pty.err"
+unattended_ask_status=$?
+set -e
+(( unattended_ask_status == 0 )) || fail "unattended ask PTY exits 0" "got $unattended_ask_status"
+[[ ! -s $GUM_LOG ]] || fail "unattended ask PTY does not call gum" "$(cat "$GUM_LOG")"
+[[ ! -s $SUDO_LOG ]] || fail "unattended ask PTY does not call sudo" "$(cat "$SUDO_LOG")"
+clean_pty_out "$test_tmp/unattended-ask-pty.out" | grep -q 'Re-run omarchy-update-orphan-pkgs in a terminal' || fail "unattended ask PTY reports instead of prompting" "$(clean_pty_out "$test_tmp/unattended-ask-pty.out")"
+pass "unattended ask never reaches gum even under PTY"
+
+# invalid policy exits 2.
+reset_logs
+set +e
+export OMARCHY_UPDATE_ORPHANS="bogus"
+unset OMARCHY_UPDATE_UNATTENDED
+run_orphan_headless >"$test_tmp/invalid.out" 2>"$test_tmp/invalid.err"
+invalid_status=$?
+set -e
+(( invalid_status == 2 )) || fail "invalid policy exits 2" "got $invalid_status"
+[[ ! -s $GUM_LOG ]] || fail "invalid policy does not call gum" "$(cat "$GUM_LOG")"
+[[ ! -s $SUDO_LOG ]] || fail "invalid policy does not call sudo" "$(cat "$SUDO_LOG")"
+pass "invalid policy exits 2"
+
+# explicit remove with interactive env still removes nonconfirm without gum.
+write_stub gum 'printf "%s\n" "$*" >>"${GUM_LOG:-/dev/null}"; echo "gum should not be called" >&2; exit 99'
+write_stub sudo 'printf "%s\n" "$*" >>"${SUDO_LOG:-/dev/null}"; exit 0'
+reset_logs
+set +e
+export OMARCHY_UPDATE_ORPHANS="remove"
+unset OMARCHY_UPDATE_UNATTENDED
+unset OMARCHY_PATH
+run_orphan_headless >"$test_tmp/remove-interactive.out" 2>"$test_tmp/remove-interactive.err"
+remove_interactive_status=$?
+set -e
+(( remove_interactive_status == 0 )) || fail "explicit remove interactive exits 0" "got $remove_interactive_status"
+[[ ! -s $GUM_LOG ]] || fail "explicit remove interactive does not call gum" "$(cat "$GUM_LOG")"
+grep -q -- '--noconfirm' "$SUDO_LOG" || fail "explicit remove interactive uses --noconfirm" "$(cat "$SUDO_LOG")"
+grep -q 'old-lib.*unused-tool' "$SUDO_LOG" || fail "explicit remove interactive passes packages in order" "$(cat "$SUDO_LOG")"
+pass "explicit remove runs nonconfirm without gum when interactive"
+
+unset OMARCHY_UPDATE_ORPHANS
+unset OMARCHY_UPDATE_UNATTENDED
+unset OMARCHY_PATH

--- a/test/shell.d/update-restart-test.sh
+++ b/test/shell.d/update-restart-test.sh
@@ -1,0 +1,489 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+require_command script
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+test_home="$test_tmp/home"
+mkdir -p "$stub_bin" "$test_home/.local/state/omarchy"
+
+GUM_LOG="$test_tmp/gum.log"
+SUDO_LOG="$test_tmp/sudo.log"
+REBOOT_LOG="$test_tmp/reboot.log"
+STATE_LOG="$test_tmp/state.log"
+RESTART_LOG="$test_tmp/restart.log"
+SYSTEMCTL_LOG="$test_tmp/systemctl.log"
+SHELL_LOG="$test_tmp/shell.log"
+: >"$GUM_LOG"
+: >"$SUDO_LOG"
+: >"$REBOOT_LOG"
+: >"$STATE_LOG"
+: >"$RESTART_LOG"
+: >"$SYSTEMCTL_LOG"
+: >"$SHELL_LOG"
+
+write_stub() {
+  local name="$1"
+  local body="$2"
+
+  cat >"$stub_bin/$name" <<SH
+#!/bin/bash
+$body
+SH
+  chmod +x "$stub_bin/$name"
+}
+
+reset_logs() {
+  : >"$GUM_LOG"
+  : >"$SUDO_LOG"
+  : >"$REBOOT_LOG"
+  : >"$STATE_LOG"
+  : >"$RESTART_LOG"
+  : >"$SYSTEMCTL_LOG"
+  : >"$SHELL_LOG"
+}
+
+clean_pty_out() {
+  tr -d '\r' <"$1"
+}
+
+clear_reboot_markers() {
+  rm -f "$test_home/.local/state/omarchy/reboot-required"
+}
+
+clear_restart_markers() {
+  rm -f "$test_home"/.local/state/omarchy/restart-*-required
+}
+
+existing_kernel="$(basename "$(dirname "$(ls /usr/lib/modules/*/vmlinuz 2>/dev/null | head -n 1)")")"
+[[ -n $existing_kernel ]] || existing_kernel="$(uname -r)"
+
+write_stub uname 'if [[ ${1:-} == "-r" ]]; then printf "%s\\n" "${TEST_RUNNING_KERNEL:-fake}"; exit 0; fi
+exec /usr/bin/uname "$@"'
+
+write_stub pacman 'if [[ ${1:-} == "-Qo" ]]; then exit 0; fi
+echo "unexpected pacman $*" >&2
+exit 1'
+
+write_stub pgrep 'if [[ ${1:-} == "-x" && ${2:-} == "Hyprland" ]]; then
+  if [[ ${TEST_PGREP_MODE:-none} == "present" ]]; then printf "1234\\n"; exit 0; else exit 1; fi
+fi
+echo "unexpected pgrep $*" >&2
+exit 1'
+
+write_stub readlink 'if [[ ${1:-} == "-f" ]]; then exec /usr/bin/readlink "$@"; fi
+if [[ ${1:-} == /proc/*/exe ]]; then
+  if [[ ${TEST_HYPRLAND_DELETED:-0} == "1" ]]; then printf "/usr/bin/Hyprland (deleted)\\n"; exit 0; else exit 1; fi
+fi
+exec /usr/bin/readlink "$@"'
+
+write_stub gum 'printf "%s\\n" "$*" >>"${GUM_LOG:-/dev/null}"
+exit "${TEST_GUM_EXIT:-99}"'
+
+write_stub omarchy-system-reboot 'printf "reboot\\n%s\\n" "$*" >>"${REBOOT_LOG:-/dev/null}"
+exit 0'
+
+write_stub omarchy-state 'printf "%s\\n" "$*" >>"${STATE_LOG:-/dev/null}"
+if [[ ${1:-} == "clear" ]]; then rm -f "$HOME/.local/state/omarchy/${2:-}"; exit 0; fi
+exit 0'
+
+write_stub omarchy-restart-audio 'printf "audio %s\\n" "$*" >>"${RESTART_LOG:-/dev/null}"
+exit "${TEST_RESTART_AUDIO_EXIT:-0}"'
+
+write_stub omarchy-restart-trackpad 'printf "trackpad %s\\n" "$*" >>"${RESTART_LOG:-/dev/null}"
+exit "${TEST_RESTART_TRACKPAD_EXIT:-0}"'
+
+write_stub omarchy-restart-shell 'printf "shell %s\\n" "$*" >>"${SHELL_LOG:-/dev/null}"
+exit 0'
+
+write_stub sudo 'printf "%q " "$@" >>"${SUDO_LOG:-/dev/null}"
+printf "\\n" >>"${SUDO_LOG:-/dev/null}"
+args=()
+for a in "$@"; do
+  if [[ $a == "-n" ]]; then continue; fi
+  if [[ $a == "--" ]]; then continue; fi
+  args+=("$a")
+done
+if (( ${#args[@]} == 0 )); then exit 0; fi
+exec "${args[@]}"'
+
+write_stub systemctl 'printf "%q " "$@" >>"${SYSTEMCTL_LOG:-/dev/null}"
+printf "\\n" >>"${SYSTEMCTL_LOG:-/dev/null}"
+exit "${TEST_SYSTEMCTL_EXIT:-0}"'
+
+export GUM_LOG SUDO_LOG REBOOT_LOG STATE_LOG RESTART_LOG SYSTEMCTL_LOG SHELL_LOG
+
+# Interactive ask PTY decline: default policy (unset) with unset UNATTENDED is
+# ask; gum decline continues without reboot.
+reset_logs
+clear_reboot_markers
+clear_restart_markers
+set +e
+unset OMARCHY_UPDATE_REBOOT
+unset OMARCHY_UPDATE_UNATTENDED
+export OMARCHY_UPDATE_RESTARTS="run"
+export TEST_RUNNING_KERNEL="0.0.0-fake-no-match"
+export TEST_PGREP_MODE="none"
+export TEST_HYPRLAND_DELETED="0"
+export TEST_GUM_EXIT="1"
+export TEST_SYSTEMCTL_EXIT="0"
+export TEST_RESTART_AUDIO_EXIT="0"
+export TEST_RESTART_TRACKPAD_EXIT="0"
+HOME="$test_home" PATH="$stub_bin:$PATH" script -qec "$ROOT/bin/omarchy-update-restart" /dev/null >"$test_tmp/ask-decline.out" 2>"$test_tmp/ask-decline.err"
+ask_decline_status=$?
+set -e
+(( ask_decline_status == 0 )) || fail "ask PTY decline exits 0" "got $ask_decline_status"
+(( $(wc -l <"$GUM_LOG") == 1 )) || fail "ask PTY decline calls gum once" "$(cat "$GUM_LOG")"
+grep -q 'confirm' "$GUM_LOG" || fail "ask PTY decline uses gum confirm" "$(cat "$GUM_LOG")"
+grep -q 'Linux kernel has been updated. Reboot?' "$GUM_LOG" || fail "ask PTY decline preserves kernel message" "$(cat "$GUM_LOG")"
+[[ ! -s $REBOOT_LOG ]] || fail "ask PTY decline does not reboot" "$(cat "$REBOOT_LOG")"
+[[ ! -s $SUDO_LOG ]] || fail "ask PTY decline does not call sudo" "$(cat "$SUDO_LOG")"
+pass "ask PTY decline preserves interactive prompt without reboot"
+
+# Interactive ask PTY accept: explicit ask calls omarchy-system-reboot once and
+# exits before shell restart.
+reset_logs
+clear_reboot_markers
+clear_restart_markers
+set +e
+export OMARCHY_UPDATE_REBOOT="ask"
+unset OMARCHY_UPDATE_UNATTENDED
+export OMARCHY_UPDATE_RESTARTS="run"
+export TEST_RUNNING_KERNEL="0.0.0-fake-no-match"
+export TEST_PGREP_MODE="none"
+export TEST_HYPRLAND_DELETED="0"
+export TEST_GUM_EXIT="0"
+HOME="$test_home" PATH="$stub_bin:$PATH" script -qec "$ROOT/bin/omarchy-update-restart" /dev/null >"$test_tmp/ask-accept.out" 2>"$test_tmp/ask-accept.err"
+ask_accept_status=$?
+set -e
+(( ask_accept_status == 0 )) || fail "ask PTY accept exits 0" "got $ask_accept_status"
+(( $(wc -l <"$GUM_LOG") == 1 )) || fail "ask PTY accept calls gum once" "$(cat "$GUM_LOG")"
+(( $(grep -c '^reboot$' "$REBOOT_LOG") == 1 )) || fail "ask PTY accept calls omarchy-system-reboot once" "$(cat "$REBOOT_LOG")"
+[[ ! -s $SUDO_LOG ]] || fail "ask PTY accept does not call sudo directly" "$(cat "$SUDO_LOG")"
+[[ ! -s $SYSTEMCTL_LOG ]] || fail "ask PTY accept does not call systemctl" "$(cat "$SYSTEMCTL_LOG")"
+[[ ! -s $SHELL_LOG ]] || fail "ask PTY accept exits before shell restart" "$(cat "$SHELL_LOG")"
+pass "ask PTY accept calls omarchy-system-reboot once"
+
+# Unattended ask under PTY must never reach gum (leak regression).
+reset_logs
+clear_reboot_markers
+clear_restart_markers
+set +e
+export OMARCHY_UPDATE_REBOOT="ask"
+export OMARCHY_UPDATE_UNATTENDED="1"
+export OMARCHY_UPDATE_RESTARTS="run"
+export TEST_RUNNING_KERNEL="0.0.0-fake-no-match"
+export TEST_PGREP_MODE="none"
+export TEST_HYPRLAND_DELETED="0"
+export TEST_GUM_EXIT="0"
+HOME="$test_home" PATH="$stub_bin:$PATH" script -qec "$ROOT/bin/omarchy-update-restart" /dev/null >"$test_tmp/unattended-ask-pty.out" 2>"$test_tmp/unattended-ask-pty.err"
+unattended_ask_status=$?
+set -e
+(( unattended_ask_status == 0 )) || fail "unattended ask PTY exits 0" "got $unattended_ask_status"
+[[ ! -s $GUM_LOG ]] || fail "unattended ask PTY does not call gum" "$(cat "$GUM_LOG")"
+[[ ! -s $REBOOT_LOG ]] || fail "unattended ask PTY does not reboot" "$(cat "$REBOOT_LOG")"
+[[ ! -s $SUDO_LOG ]] || fail "unattended ask PTY does not call sudo" "$(cat "$SUDO_LOG")"
+clean_pty_out "$test_tmp/unattended-ask-pty.out" | grep -q 'Reboot required:' || fail "unattended ask PTY reports need" "$(clean_pty_out "$test_tmp/unattended-ask-pty.out")"
+pass "unattended ask never reaches gum even under PTY"
+
+# never under PTY + unattended: report, no gum, no reboot, markers kept.
+reset_logs
+clear_restart_markers
+mkdir -p "$test_home/.local/state/omarchy"
+touch "$test_home/.local/state/omarchy/reboot-required"
+set +e
+export OMARCHY_UPDATE_REBOOT="never"
+export OMARCHY_UPDATE_UNATTENDED="1"
+export OMARCHY_UPDATE_RESTARTS="run"
+export TEST_RUNNING_KERNEL="$existing_kernel"
+export TEST_PGREP_MODE="none"
+export TEST_HYPRLAND_DELETED="0"
+export TEST_GUM_EXIT="99"
+HOME="$test_home" PATH="$stub_bin:$PATH" script -qec "$ROOT/bin/omarchy-update-restart" /dev/null >"$test_tmp/never-pty.out" 2>"$test_tmp/never-pty.err"
+never_pty_status=$?
+set -e
+(( never_pty_status == 0 )) || fail "never PTY exits 0" "got $never_pty_status"
+[[ ! -s $GUM_LOG ]] || fail "never PTY does not call gum" "$(cat "$GUM_LOG")"
+[[ ! -s $REBOOT_LOG ]] || fail "never PTY does not reboot" "$(cat "$REBOOT_LOG")"
+[[ ! -s $SUDO_LOG ]] || fail "never PTY does not call sudo" "$(cat "$SUDO_LOG")"
+clean_pty_out "$test_tmp/never-pty.out" | grep -q 'Reboot required:' || fail "never PTY reports need" "$(clean_pty_out "$test_tmp/never-pty.out")"
+[[ -f $test_home/.local/state/omarchy/reboot-required ]] || fail "never PTY keeps reboot marker"
+pass "never reports without reboot under PTY"
+
+# if-needed unattended PTY via scoped adapter: single sudo reboot, no double.
+reset_logs
+clear_restart_markers
+mkdir -p "$test_home/.local/state/omarchy"
+touch "$test_home/.local/state/omarchy/reboot-required"
+set +e
+export OMARCHY_UPDATE_REBOOT="if-needed"
+export OMARCHY_UPDATE_UNATTENDED="1"
+export OMARCHY_UPDATE_RESTARTS="run"
+export OMARCHY_PATH="$ROOT"
+export TEST_RUNNING_KERNEL="0.0.0-fake-no-match"
+export TEST_PGREP_MODE="present"
+export TEST_HYPRLAND_DELETED="1"
+export TEST_GUM_EXIT="99"
+export TEST_SYSTEMCTL_EXIT="0"
+HOME="$test_home" PATH="$stub_bin:$PATH" script -qec "$ROOT/bin/omarchy-update-run $ROOT/bin/omarchy-update-restart" /dev/null >"$test_tmp/ifneeded-pty.out" 2>"$test_tmp/ifneeded-pty.err"
+ifneeded_status=$?
+set -e
+(( ifneeded_status == 0 )) || fail "if-needed PTY exits 0" "got $ifneeded_status; out=$(clean_pty_out "$test_tmp/ifneeded-pty.out"); err=$(cat "$test_tmp/ifneeded-pty.err")"
+[[ ! -s $GUM_LOG ]] || fail "if-needed PTY does not call gum" "$(cat "$GUM_LOG")"
+[[ ! -s $REBOOT_LOG ]] || fail "if-needed does not call omarchy-system-reboot" "$(cat "$REBOOT_LOG")"
+grep -q -- '-n' "$SUDO_LOG" || fail "if-needed via adapter uses sudo -n" "$(cat "$SUDO_LOG")"
+grep -q 'systemctl' "$SUDO_LOG" || fail "if-needed calls systemctl via sudo" "$(cat "$SUDO_LOG")"
+grep -q -- '--no-ask-password' "$SUDO_LOG" || fail "if-needed uses --no-ask-password" "$(cat "$SUDO_LOG")"
+grep -q -- 'reboot' "$SUDO_LOG" || fail "if-needed reboots via sudo" "$(cat "$SUDO_LOG")"
+grep -q -- '--no-wall' "$SUDO_LOG" || fail "if-needed uses --no-wall" "$(cat "$SUDO_LOG")"
+(( $(wc -l <"$SUDO_LOG") == 1 )) || fail "if-needed requests reboot exactly once" "$(cat "$SUDO_LOG")"
+(( $(wc -l <"$SYSTEMCTL_LOG") == 1 )) || fail "if-needed calls systemctl exactly once" "$(cat "$SYSTEMCTL_LOG")"
+clean_pty_out "$test_tmp/ifneeded-pty.out" | grep -q 'Reboot requested\.' || fail "if-needed prints success message" "$(clean_pty_out "$test_tmp/ifneeded-pty.out")"
+unset OMARCHY_PATH
+pass "if-needed reboots once via sudo -n without double request"
+
+# if-needed failure: systemctl exit 5 -> nonzero, no success message.
+reset_logs
+clear_reboot_markers
+clear_restart_markers
+set +e
+export OMARCHY_UPDATE_REBOOT="if-needed"
+export OMARCHY_UPDATE_UNATTENDED="1"
+export OMARCHY_PATH="$ROOT"
+export OMARCHY_UPDATE_RESTARTS="run"
+export TEST_RUNNING_KERNEL="0.0.0-fake-no-match"
+export TEST_PGREP_MODE="none"
+export TEST_HYPRLAND_DELETED="0"
+export TEST_GUM_EXIT="99"
+export TEST_SYSTEMCTL_EXIT="5"
+HOME="$test_home" PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-update-run" "$ROOT/bin/omarchy-update-restart" >"$test_tmp/ifneeded-fail.out" 2>"$test_tmp/ifneeded-fail.err"
+ifneeded_fail_status=$?
+set -e
+(( ifneeded_fail_status != 0 )) || fail "if-needed failure exits nonzero" "got 0"
+grep -q 'Reboot requested\.' "$test_tmp/ifneeded-fail.out" && fail "if-needed failure prints no success message" "$(cat "$test_tmp/ifneeded-fail.out")"
+grep -q 'automatic reboot failed' "$test_tmp/ifneeded-fail.err" || fail "if-needed failure reports on stderr" "$(cat "$test_tmp/ifneeded-fail.err")"
+[[ ! -s $GUM_LOG ]] || fail "if-needed failure does not call gum" "$(cat "$GUM_LOG")"
+[[ ! -s $REBOOT_LOG ]] || fail "if-needed failure does not call omarchy-system-reboot" "$(cat "$REBOOT_LOG")"
+unset OMARCHY_PATH
+pass "if-needed failure exits nonzero without success message"
+
+# never with all 3 triggers: one report line per need, no reboot, markers kept.
+reset_logs
+clear_restart_markers
+mkdir -p "$test_home/.local/state/omarchy"
+touch "$test_home/.local/state/omarchy/reboot-required"
+set +e
+export OMARCHY_UPDATE_REBOOT="never"
+export OMARCHY_UPDATE_UNATTENDED="1"
+export OMARCHY_UPDATE_RESTARTS="run"
+unset OMARCHY_PATH
+export TEST_RUNNING_KERNEL="0.0.0-fake-no-match"
+export TEST_PGREP_MODE="present"
+export TEST_HYPRLAND_DELETED="1"
+export TEST_GUM_EXIT="99"
+export TEST_SYSTEMCTL_EXIT="0"
+HOME="$test_home" PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-update-restart" >"$test_tmp/never-all.out" 2>"$test_tmp/never-all.err"
+never_all_status=$?
+set -e
+(( never_all_status == 0 )) || fail "never all triggers exits 0" "got $never_all_status"
+[[ ! -s $GUM_LOG ]] || fail "never all triggers does not call gum" "$(cat "$GUM_LOG")"
+[[ ! -s $REBOOT_LOG ]] || fail "never all triggers does not reboot" "$(cat "$REBOOT_LOG")"
+[[ ! -s $SUDO_LOG ]] || fail "never all triggers does not call sudo" "$(cat "$SUDO_LOG")"
+[[ ! -s $SYSTEMCTL_LOG ]] || fail "never all triggers does not call systemctl" "$(cat "$SYSTEMCTL_LOG")"
+(( $(grep -c 'Reboot required:' "$test_tmp/never-all.out") == 3 )) || fail "never all triggers reports each need once" "$(cat "$test_tmp/never-all.out")"
+grep -q 'Linux kernel has been updated. Reboot?' "$test_tmp/never-all.out" || fail "never all triggers reports kernel" "$(cat "$test_tmp/never-all.out")"
+grep -q 'Updates require reboot. Ready?' "$test_tmp/never-all.out" || fail "never all triggers reports marker" "$(cat "$test_tmp/never-all.out")"
+grep -q 'Hyprland has been updated. Reboot?' "$test_tmp/never-all.out" || fail "never all triggers reports hyprland" "$(cat "$test_tmp/never-all.out")"
+[[ -f $test_home/.local/state/omarchy/reboot-required ]] || fail "never all triggers keeps reboot marker"
+pass "never with all triggers reports each need once without reboot"
+
+# No triggers: no reboot output, quiet.
+reset_logs
+clear_reboot_markers
+clear_restart_markers
+set +e
+export OMARCHY_UPDATE_REBOOT="never"
+unset OMARCHY_UPDATE_UNATTENDED
+export OMARCHY_UPDATE_RESTARTS="run"
+export TEST_RUNNING_KERNEL="$existing_kernel"
+export TEST_PGREP_MODE="none"
+export TEST_HYPRLAND_DELETED="0"
+export TEST_GUM_EXIT="99"
+HOME="$test_home" PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-update-restart" >"$test_tmp/no-trigger.out" 2>"$test_tmp/no-trigger.err"
+no_trigger_status=$?
+set -e
+(( no_trigger_status == 0 )) || fail "no triggers exits 0" "got $no_trigger_status"
+grep -q 'Reboot required:' "$test_tmp/no-trigger.out" && fail "no triggers prints no reboot output" "$(cat "$test_tmp/no-trigger.out")"
+[[ ! -s $GUM_LOG ]] || fail "no triggers does not call gum" "$(cat "$GUM_LOG")"
+[[ ! -s $REBOOT_LOG ]] || fail "no triggers does not reboot" "$(cat "$REBOOT_LOG")"
+[[ ! -s $SUDO_LOG ]] || fail "no triggers does not call sudo" "$(cat "$SUDO_LOG")"
+pass "no triggers stays quiet without reboot output"
+
+# restarts=skip with markers present: intact, no restart calls, exit 0.
+reset_logs
+clear_reboot_markers
+mkdir -p "$test_home/.local/state/omarchy"
+touch "$test_home/.local/state/omarchy/restart-audio-required"
+touch "$test_home/.local/state/omarchy/restart-trackpad-required"
+set +e
+export OMARCHY_UPDATE_REBOOT="never"
+unset OMARCHY_UPDATE_UNATTENDED
+export OMARCHY_UPDATE_RESTARTS="skip"
+export TEST_RUNNING_KERNEL="$existing_kernel"
+export TEST_PGREP_MODE="none"
+export TEST_HYPRLAND_DELETED="0"
+export TEST_GUM_EXIT="99"
+HOME="$test_home" PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-update-restart" >"$test_tmp/skip.out" 2>"$test_tmp/skip.err"
+skip_status=$?
+set -e
+(( skip_status == 0 )) || fail "restarts skip exits 0" "got $skip_status"
+[[ -f $test_home/.local/state/omarchy/restart-audio-required ]] || fail "restarts skip keeps audio marker"
+[[ -f $test_home/.local/state/omarchy/restart-trackpad-required ]] || fail "restarts skip keeps trackpad marker"
+[[ ! -s $RESTART_LOG ]] || fail "restarts skip makes no service calls" "$(cat "$RESTART_LOG")"
+[[ ! -s $SHELL_LOG ]] || fail "restarts skip makes no shell call" "$(cat "$SHELL_LOG")"
+[[ ! -s $STATE_LOG ]] || fail "restarts skip clears no marker" "$(cat "$STATE_LOG")"
+grep -q 'Skipping service restarts (--restarts=skip)' "$test_tmp/skip.out" || fail "restarts skip reports summary" "$(cat "$test_tmp/skip.out")"
+grep -q 'Shell restart deferred' "$test_tmp/skip.out" || fail "restarts skip defers shell" "$(cat "$test_tmp/skip.out")"
+pass "restarts skip retains markers without restart calls"
+
+# restarts=run: failing service keeps marker, later services attempted, nonzero.
+reset_logs
+clear_reboot_markers
+mkdir -p "$test_home/.local/state/omarchy"
+touch "$test_home/.local/state/omarchy/restart-audio-required"
+touch "$test_home/.local/state/omarchy/restart-trackpad-required"
+set +e
+export OMARCHY_UPDATE_REBOOT="never"
+unset OMARCHY_UPDATE_UNATTENDED
+export OMARCHY_UPDATE_RESTARTS="run"
+export TEST_RUNNING_KERNEL="$existing_kernel"
+export TEST_PGREP_MODE="none"
+export TEST_HYPRLAND_DELETED="0"
+export TEST_GUM_EXIT="99"
+export TEST_RESTART_AUDIO_EXIT="3"
+export TEST_RESTART_TRACKPAD_EXIT="0"
+HOME="$test_home" PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-update-restart" >"$test_tmp/run-fail.out" 2>"$test_tmp/run-fail.err"
+run_fail_status=$?
+set -e
+(( run_fail_status != 0 )) || fail "restarts run failure exits nonzero" "got 0"
+grep -q 'audio' "$RESTART_LOG" || fail "restarts run attempts failing service" "$(cat "$RESTART_LOG")"
+grep -q 'trackpad' "$RESTART_LOG" || fail "restarts run continues to later service" "$(cat "$RESTART_LOG")"
+[[ -f $test_home/.local/state/omarchy/restart-audio-required ]] || fail "restarts run keeps failing marker"
+[[ ! -f $test_home/.local/state/omarchy/restart-trackpad-required ]] || fail "restarts run clears succeeding marker"
+grep -q 'clear.*restart-trackpad-required' "$STATE_LOG" || fail "restarts run clears only after success" "$(cat "$STATE_LOG")"
+grep -q 'clear.*restart-audio-required' "$STATE_LOG" && fail "restarts run does not clear failing marker" "$(cat "$STATE_LOG")"
+grep -q 'failed to restart audio' "$test_tmp/run-fail.err" || fail "restarts run reports failure" "$(cat "$test_tmp/run-fail.err")"
+(( $(grep -c '^shell' "$SHELL_LOG") == 1 )) || fail "restarts run still restarts shell after failure" "$(cat "$SHELL_LOG")"
+pass "restarts run clears only after success and fails nonzero"
+
+# Shell restart still runs when restarts=run even with no markers.
+reset_logs
+clear_reboot_markers
+clear_restart_markers
+set +e
+export OMARCHY_UPDATE_REBOOT="never"
+unset OMARCHY_UPDATE_UNATTENDED
+export OMARCHY_UPDATE_RESTARTS="run"
+export TEST_RUNNING_KERNEL="$existing_kernel"
+export TEST_PGREP_MODE="none"
+export TEST_HYPRLAND_DELETED="0"
+export TEST_GUM_EXIT="99"
+export TEST_RESTART_AUDIO_EXIT="0"
+export TEST_RESTART_TRACKPAD_EXIT="0"
+HOME="$test_home" PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-update-restart" >"$test_tmp/shell.out" 2>"$test_tmp/shell.err"
+shell_status=$?
+set -e
+(( shell_status == 0 )) || fail "shell restart with no markers exits 0" "got $shell_status"
+(( $(grep -c '^shell' "$SHELL_LOG") == 1 )) || fail "shell restart runs with no markers" "$(cat "$SHELL_LOG")"
+grep -q 'Restarting shell' "$test_tmp/shell.out" || fail "shell restart prints message" "$(cat "$test_tmp/shell.out")"
+pass "shell restart still runs with no markers"
+
+# Invalid reboot policy exits 2 with no side effects.
+reset_logs
+mkdir -p "$test_home/.local/state/omarchy"
+touch "$test_home/.local/state/omarchy/reboot-required"
+touch "$test_home/.local/state/omarchy/restart-audio-required"
+set +e
+export OMARCHY_UPDATE_REBOOT="bogus"
+unset OMARCHY_UPDATE_UNATTENDED
+export OMARCHY_UPDATE_RESTARTS="run"
+export TEST_RUNNING_KERNEL="0.0.0-fake-no-match"
+export TEST_PGREP_MODE="present"
+export TEST_HYPRLAND_DELETED="1"
+export TEST_GUM_EXIT="0"
+HOME="$test_home" PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-update-restart" >"$test_tmp/invalid-reboot.out" 2>"$test_tmp/invalid-reboot.err"
+invalid_reboot_status=$?
+set -e
+(( invalid_reboot_status == 2 )) || fail "invalid reboot exits 2" "got $invalid_reboot_status"
+[[ ! -s $GUM_LOG ]] || fail "invalid reboot does not call gum" "$(cat "$GUM_LOG")"
+[[ ! -s $SUDO_LOG ]] || fail "invalid reboot does not call sudo" "$(cat "$SUDO_LOG")"
+[[ ! -s $REBOOT_LOG ]] || fail "invalid reboot does not reboot" "$(cat "$REBOOT_LOG")"
+[[ ! -s $RESTART_LOG ]] || fail "invalid reboot makes no restart calls" "$(cat "$RESTART_LOG")"
+[[ -f $test_home/.local/state/omarchy/reboot-required ]] || fail "invalid reboot keeps markers"
+[[ -f $test_home/.local/state/omarchy/restart-audio-required ]] || fail "invalid reboot keeps restart markers"
+pass "invalid reboot exits 2 without side effects"
+
+# Invalid restarts policy exits 2 with no side effects.
+reset_logs
+clear_reboot_markers
+rm -f "$test_home/.local/state/omarchy/restart-audio-required"
+touch "$test_home/.local/state/omarchy/restart-trackpad-required"
+set +e
+export OMARCHY_UPDATE_REBOOT="never"
+unset OMARCHY_UPDATE_UNATTENDED
+export OMARCHY_UPDATE_RESTARTS="bogus"
+export TEST_RUNNING_KERNEL="$existing_kernel"
+export TEST_PGREP_MODE="none"
+export TEST_HYPRLAND_DELETED="0"
+HOME="$test_home" PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-update-restart" >"$test_tmp/invalid-restarts.out" 2>"$test_tmp/invalid-restarts.err"
+invalid_restarts_status=$?
+set -e
+(( invalid_restarts_status == 2 )) || fail "invalid restarts exits 2" "got $invalid_restarts_status"
+[[ ! -s $GUM_LOG ]] || fail "invalid restarts does not call gum" "$(cat "$GUM_LOG")"
+[[ ! -s $RESTART_LOG ]] || fail "invalid restarts makes no restart calls" "$(cat "$RESTART_LOG")"
+[[ ! -s $SHELL_LOG ]] || fail "invalid restarts makes no shell call" "$(cat "$SHELL_LOG")"
+[[ -f $test_home/.local/state/omarchy/restart-trackpad-required ]] || fail "invalid restarts keeps markers"
+pass "invalid restarts exits 2 without side effects"
+
+# Stale env documents value-only behavior: UNATTENDED=1 reports, unset prompts.
+reset_logs
+clear_reboot_markers
+clear_restart_markers
+set +e
+export OMARCHY_UPDATE_REBOOT="ask"
+export OMARCHY_UPDATE_UNATTENDED="1"
+export OMARCHY_UPDATE_RESTARTS="run"
+export TEST_RUNNING_KERNEL="0.0.0-fake-no-match"
+export TEST_PGREP_MODE="none"
+export TEST_HYPRLAND_DELETED="0"
+export TEST_GUM_EXIT="99"
+HOME="$test_home" PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-update-restart" >"$test_tmp/stale-set.out" 2>"$test_tmp/stale-set.err"
+stale_set_status=$?
+set -e
+(( stale_set_status == 0 )) || fail "stale UNATTENDED=1 exits 0" "got $stale_set_status"
+[[ ! -s $GUM_LOG ]] || fail "stale UNATTENDED=1 does not call gum" "$(cat "$GUM_LOG")"
+grep -q 'Reboot required:' "$test_tmp/stale-set.out" || fail "stale UNATTENDED=1 reports need" "$(cat "$test_tmp/stale-set.out")"
+reset_logs
+set +e
+export OMARCHY_UPDATE_REBOOT="ask"
+unset OMARCHY_UPDATE_UNATTENDED
+export TEST_GUM_EXIT="1"
+HOME="$test_home" PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-update-restart" </dev/null >"$test_tmp/stale-unset.out" 2>"$test_tmp/stale-unset.err"
+stale_unset_status=$?
+set -e
+# Headless without TTY reports even when unset; interactive PTY covered above.
+(( stale_unset_status == 0 )) || fail "unset UNATTENDED headless exits 0" "got $stale_unset_status"
+[[ ! -s $GUM_LOG ]] || fail "unset UNATTENDED headless does not call gum without TTY" "$(cat "$GUM_LOG")"
+grep -q 'Reboot required:' "$test_tmp/stale-unset.out" || fail "unset UNATTENDED headless reports without TTY" "$(cat "$test_tmp/stale-unset.out")"
+pass "stale UNATTENDED keys on value only without speculative reject"
+
+unset OMARCHY_UPDATE_REBOOT
+unset OMARCHY_UPDATE_RESTARTS
+unset OMARCHY_UPDATE_UNATTENDED
+unset OMARCHY_PATH

--- a/test/shell.d/update-sequence-test.sh
+++ b/test/shell.d/update-sequence-test.sh
@@ -10,8 +10,6 @@ trap 'rm -rf "$test_tmp"' EXIT
 stub_bin="$test_tmp/bin"
 mkdir -p "$stub_bin"
 
-# Every step omarchy-update runs, recorded in order with the unattended flag it
-# was handed. One of them can be told to fail.
 steps=(
   omarchy-update-lock
   omarchy-update-requires-free-space
@@ -35,20 +33,48 @@ steps=(
 for step in "${steps[@]}"; do
   cat >"$stub_bin/$step" <<'STUB'
 #!/bin/bash
-printf '%s unattended=%s\n' "${0##*/}" "${OMARCHY_UPDATE_UNATTENDED:-}" >>"$STEP_LOG"
+printf '%s unattended=%s strict=%s hooks=%s aur=%s mise=%s orphans=%s reboot=%s restarts=%s args=%s\n' "${0##*/}" "${OMARCHY_UPDATE_UNATTENDED:-}" "${OMARCHY_UPDATE_STRICT:-}" "${OMARCHY_UPDATE_HOOKS:-}" "${OMARCHY_UPDATE_AUR:-}" "${OMARCHY_UPDATE_MISE:-}" "${OMARCHY_UPDATE_ORPHANS:-}" "${OMARCHY_UPDATE_REBOOT:-}" "${OMARCHY_UPDATE_RESTARTS:-}" "$*" >>"$STEP_LOG"
 [[ ${FAILING_STEP:-} != "${0##*/}" ]] || exit 1
 STUB
   chmod +x "$stub_bin/$step"
 done
 
-# OMARCHY_UPDATE_LOGGED stands in for the script(1) wrapper the update re-execs
-# itself under; the stubbed lock reports itself already held.
+cat >"$stub_bin/sudo" <<'STUB'
+#!/bin/bash
+printf 'sudo %s\n' "$*" >>"$STEP_LOG"
+args=()
+for a in "$@"; do
+  if [[ $a == "-n" ]]; then
+    continue
+  fi
+  if [[ $a == "--" ]]; then
+    continue
+  fi
+  args+=("$a")
+done
+if (( ${#args[@]} == 0 )); then
+  exit 0
+fi
+exec "${args[@]}"
+STUB
+chmod +x "$stub_bin/sudo"
+
+cat >"$stub_bin/script" <<'STUB'
+#!/bin/bash
+echo "script should not run when LOGGED=1" >>"$STEP_LOG"
+exit 99
+STUB
+chmod +x "$stub_bin/script"
+
 run_update() {
   : >"$test_tmp/steps"
+  : >"$test_tmp/out"
+  : >"$test_tmp/err"
   STEP_LOG="$test_tmp/steps" \
     FAILING_STEP="${FAILING_STEP:-}" \
     OMARCHY_UPDATE_LOGGED=1 \
-    PATH="$stub_bin:$PATH" \
+    OMARCHY_PATH="$ROOT" \
+    PATH="$stub_bin:$ROOT/bin:$PATH" \
     bash "$ROOT/bin/omarchy-update" "$@" >"$test_tmp/out" 2>"$test_tmp/err"
 }
 
@@ -56,13 +82,10 @@ steps_run() {
   cut -d' ' -f1 "$test_tmp/steps"
 }
 
-# Every step of a whole update, in order. $1 asks for the one a person confirms.
-# Stay Awake bookends the work, so it is here twice.
-expected_steps() {
+expected_full() {
   printf '%s\n' \
     omarchy-update-lock \
     omarchy-update-requires-free-space \
-    ${1:+omarchy-update-confirm} \
     omarchy-update-pkg-prune \
     omarchy-snapshot \
     omarchy-update-stay-awake \
@@ -80,23 +103,97 @@ expected_steps() {
     omarchy-update-restart
 }
 
+expected_interactive() {
+  printf '%s\n' \
+    omarchy-update-lock \
+    omarchy-update-requires-free-space \
+    omarchy-update-confirm \
+    omarchy-update-pkg-prune \
+    omarchy-snapshot \
+    omarchy-update-stay-awake \
+    omarchy-update-dev \
+    omarchy-update-keyring \
+    omarchy-update-system-pkgs \
+    omarchy-migrate \
+    omarchy-hook \
+    omarchy-update-aur-pkgs \
+    omarchy-update-mise \
+    omarchy-update-orphan-pkgs \
+    omarchy-update-analyze-logs \
+    omarchy-update-status \
+    omarchy-update-stay-awake \
+    omarchy-update-restart
+}
+
+expected_strict() {
+  printf '%s\n' \
+    omarchy-update-lock \
+    omarchy-update-requires-free-space \
+    omarchy-update-pkg-prune \
+    omarchy-snapshot \
+    omarchy-update-stay-awake \
+    omarchy-update-dev \
+    omarchy-update-keyring \
+    omarchy-update-system-pkgs \
+    omarchy-migrate \
+    omarchy-update-orphan-pkgs \
+    omarchy-update-analyze-logs \
+    omarchy-update-status \
+    omarchy-update-stay-awake \
+    omarchy-update-restart
+}
+
 run_update -y || fail "an update where everything works reports a failure"
-diff <(expected_steps) <(steps_run) >"$test_tmp/order" ||
+diff <(expected_full) <(steps_run) >"$test_tmp/order" ||
   fail "an update where everything works does not run every step in order" "$(cat "$test_tmp/order")"
 pass "an update where every step works runs all of them, in order"
 
-grep -q '^omarchy-update-system-pkgs unattended=1$' "$test_tmp/steps" ||
-  fail "-y does not mark the update unattended"
+grep -q '^omarchy-update-system-pkgs unattended=1 strict= hooks=run aur=run mise=run orphans=keep reboot=never restarts=run ' "$test_tmp/steps" ||
+  fail "-y normalizes to full unattended env" "$(cat "$test_tmp/steps")"
+grep -q "Unattended update (full)" "$test_tmp/out" ||
+  fail "-y prints full unattended summary" "$(cat "$test_tmp/out")"
+pass "-y normalizes full pipeline env with summary"
+
+run_update --yes || fail "--yes reports failure"
+diff <(expected_full) <(steps_run) >"$test_tmp/order" ||
+  fail "--yes runs different steps than -y" "$(cat "$test_tmp/order")"
+grep -q '^omarchy-update-system-pkgs unattended=1 strict= hooks=run ' "$test_tmp/steps" ||
+  fail "--yes does not match -y env" "$(cat "$test_tmp/steps")"
+pass "-y alias matches --yes"
+
 run_update </dev/null || fail "a confirmed update reports a failure"
-diff <(expected_steps confirmed) <(steps_run) >"$test_tmp/order" ||
+diff <(expected_interactive) <(steps_run) >"$test_tmp/order" ||
   fail "a confirmed update runs a different set of steps" "$(cat "$test_tmp/order")"
-grep -q '^omarchy-update-system-pkgs unattended=$' "$test_tmp/steps" ||
-  fail "an update a person confirmed is treated as unattended"
+grep -q '^omarchy-update-system-pkgs unattended= strict= hooks=run aur=run mise=run orphans=ask reboot=ask restarts=run ' "$test_tmp/steps" ||
+  fail "an update a person confirmed is treated as unattended" "$(cat "$test_tmp/steps")"
 pass "-y is what marks an update unattended, not the update itself"
 
-# Migrations ship with the packages the upgrade installs and are written against
-# them. Running them against what is still on disk is the failure this ordering
-# exists to prevent, so the update stops where the packages did.
+run_update --non-interactive || fail "strict update reports failure"
+diff <(expected_strict) <(steps_run) >"$test_tmp/order" ||
+  fail "strict update does not skip hook/aur/mise in order" "$(cat "$test_tmp/order")"
+grep -q '^omarchy-update-system-pkgs unattended=1 strict=1 hooks=skip aur=skip mise=skip orphans=keep reboot=never restarts=run ' "$test_tmp/steps" ||
+  fail "strict does not normalize to skip env" "$(cat "$test_tmp/steps")"
+grep -q "Unattended update (strict)" "$test_tmp/out" ||
+  fail "strict prints strict summary" "$(cat "$test_tmp/out")"
+grep -q "Skipping post-update hooks (--hooks=skip)" "$test_tmp/out" ||
+  fail "strict reports hook skip" "$(cat "$test_tmp/out")"
+grep -q "Skipping AUR package updates (--aur=skip)" "$test_tmp/out" ||
+  fail "strict reports aur skip" "$(cat "$test_tmp/out")"
+grep -q "Skipping mise updates (--mise=skip)" "$test_tmp/out" ||
+  fail "strict reports mise skip" "$(cat "$test_tmp/out")"
+pass "strict defaults skip external steps with reports"
+
+run_update --non-interactive --hooks=run --aur=run --mise=run || fail "strict opt-in reports failure"
+diff <(expected_full) <(steps_run) >"$test_tmp/order" ||
+  fail "strict opt-in does not run external steps" "$(cat "$test_tmp/order")"
+grep -q "Warning: --hooks=run in strict mode" "$test_tmp/err" ||
+  fail "strict hooks opt-in does not warn" "$(cat "$test_tmp/err")"
+grep -q "Warning: --aur=run in strict mode" "$test_tmp/err" ||
+  fail "strict aur opt-in does not warn" "$(cat "$test_tmp/err")"
+grep -q "Warning: --mise=run in strict mode" "$test_tmp/err" ||
+  fail "strict mise opt-in does not warn" "$(cat "$test_tmp/err")"
+pass "strict opt-in runs externals with warnings"
+
 if FAILING_STEP=omarchy-update-system-pkgs run_update -y; then
   fail "an update whose packages did not upgrade passes for a whole one"
 fi
@@ -105,4 +202,6 @@ for step in omarchy-migrate omarchy-hook omarchy-update-aur-pkgs omarchy-update-
     fail "a blocked package upgrade still runs $step"
   fi
 done
+grep -q "^omarchy-update-stay-awake .*args=stop" "$test_tmp/steps" ||
+  fail "a blocked package upgrade does not release the inhibitor" "$(cat "$test_tmp/steps")"
 pass "a blocked package upgrade stops the update before it migrates"

--- a/test/shell.d/update-unattended-test.sh
+++ b/test/shell.d/update-unattended-test.sh
@@ -1,0 +1,653 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+require_command script
+require_command timeout
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+test_home="$test_tmp/home"
+runtime_dir="$test_tmp/runtime"
+state_dir="$test_tmp/state"
+migration_state="$test_tmp/migration-state"
+mkdir -p "$stub_bin" "$test_home/.local/state/omarchy" "$test_home/.config/omarchy/hooks/post-update.d" "$test_home/.local/bin" "$runtime_dir" "$state_dir" "$migration_state"
+
+STEP_LOG="$test_tmp/steps.log"
+GUM_LOG="$test_tmp/gum.log"
+SUDO_LOG="$test_tmp/sudo.log"
+PACMAN_LOG="$test_tmp/pacman.log"
+PACMAN_KEY_LOG="$test_tmp/pacman-key.log"
+SNAPPER_LOG="$test_tmp/snapper.log"
+PACCACHE_LOG="$test_tmp/paccache.log"
+YAY_LOG="$test_tmp/yay.log"
+MISE_LOG="$test_tmp/mise.log"
+GIT_LOG="$test_tmp/git.log"
+GIT_ENV_LOG="$test_tmp/git-env.log"
+SYSTEMCTL_LOG="$test_tmp/systemctl.log"
+INHIBIT_LOG="$test_tmp/inhibit.log"
+REBOOT_LOG="$test_tmp/reboot.log"
+SHELL_LOG="$test_tmp/shell.log"
+RESTART_LOG="$test_tmp/restart.log"
+SHELL_RESTART_LOG="$test_tmp/shell-restart.log"
+STATE_LOG="$test_tmp/state.log"
+CHECKUPDATES_LOG="$test_tmp/checkupdates.log"
+AUR_ACCESS_LOG="$test_tmp/aur-access.log"
+HOOK_LOG="$test_tmp/hook.log"
+
+export STEP_LOG GUM_LOG SUDO_LOG PACMAN_LOG PACMAN_KEY_LOG SNAPPER_LOG PACCACHE_LOG YAY_LOG MISE_LOG GIT_LOG GIT_ENV_LOG SYSTEMCTL_LOG INHIBIT_LOG REBOOT_LOG SHELL_LOG RESTART_LOG SHELL_RESTART_LOG STATE_LOG CHECKUPDATES_LOG AUR_ACCESS_LOG HOOK_LOG
+export SHELL=/bin/bash
+
+: >"$STEP_LOG"; : >"$GUM_LOG"; : >"$SUDO_LOG"; : >"$PACMAN_LOG"; : >"$PACMAN_KEY_LOG"
+: >"$SNAPPER_LOG"; : >"$PACCACHE_LOG"; : >"$YAY_LOG"; : >"$MISE_LOG"; : >"$GIT_LOG"
+: >"$GIT_ENV_LOG"; : >"$SYSTEMCTL_LOG"; : >"$INHIBIT_LOG"; : >"$REBOOT_LOG"; : >"$SHELL_LOG"
+: >"$RESTART_LOG"; : >"$SHELL_RESTART_LOG"; : >"$STATE_LOG"; : >"$CHECKUPDATES_LOG"
+: >"$AUR_ACCESS_LOG"; : >"$HOOK_LOG"
+
+write_stub() {
+  local name="$1"
+  local body="$2"
+  cat >"$stub_bin/$name" <<SH
+#!/bin/bash
+$body
+SH
+  chmod +x "$stub_bin/$name"
+}
+
+write_wrapper() {
+  local name="$1"
+  cat >"$stub_bin/$name" <<SH
+#!/bin/bash
+printf '%s %s\n' "$name" "\$*" >>"\$STEP_LOG"
+exec "\$OMARCHY_PATH/bin/$name" "\$@"
+SH
+  chmod +x "$stub_bin/$name"
+}
+
+for step in omarchy-update-requires-free-space omarchy-update-confirm omarchy-update-pkg-prune omarchy-snapshot omarchy-update-stay-awake omarchy-update-dev omarchy-update-keyring omarchy-update-system-pkgs omarchy-migrate omarchy-hook omarchy-update-aur-pkgs omarchy-update-mise omarchy-update-orphan-pkgs omarchy-update-analyze-logs omarchy-update-status omarchy-update-restart; do
+  write_wrapper "$step"
+done
+
+cat >"$stub_bin/omarchy-state" <<'SH'
+#!/bin/bash
+printf '%s %s\n' "omarchy-state" "$*" >>"$STATE_LOG"
+exec "$OMARCHY_PATH/bin/omarchy-state" "$@"
+SH
+chmod +x "$stub_bin/omarchy-state"
+
+cat >"$stub_bin/omarchy-toggle-idle" <<'SH'
+#!/bin/bash
+printf '%s %s\n' "omarchy-toggle-idle" "$*" >>"$STATE_LOG"
+exec "$OMARCHY_PATH/bin/omarchy-toggle-idle" "$@"
+SH
+chmod +x "$stub_bin/omarchy-toggle-idle"
+
+write_stub sudo '
+printf "%q " "$@" >>"${SUDO_LOG:-/dev/null}"
+printf "\n" >>"${SUDO_LOG:-/dev/null}"
+stripped=()
+for a in "$@"; do
+  if [[ $a == "-n" || $a == "--" ]]; then continue; fi
+  stripped+=("$a")
+done
+if (( ${#stripped[@]} == 1 )) && [[ ${stripped[0]} == "true" ]]; then
+  exit "${TEST_SUDO_N_TRUE_EXIT:-0}"
+fi
+if (( ${#stripped[@]} == 0 )); then exit 0; fi
+if [[ ${stripped[0]} == "-v" ]]; then exit 0; fi
+exec "${stripped[@]}"'
+
+write_stub pacman '
+printf "%q " "$@" >>"${PACMAN_LOG:-/dev/null}"
+printf "\n" >>"${PACMAN_LOG:-/dev/null}"
+if [[ ${1:-} == "-Qtdq" ]]; then
+  if [[ ${TEST_ORPHANS_EMPTY:-0} == "1" ]]; then exit 0; fi
+  printf "old-lib\nunused-tool\n"
+  exit 0
+fi
+if [[ ${1:-} == "-Qo" ]]; then
+  exit "${TEST_PACMAN_QO_EXIT:-0}"
+fi
+if [[ ${1:-} == "-Qq" ]]; then
+  exit 1
+fi
+if [[ ${1:-} == "-Qem" ]]; then
+  exit "${TEST_PACMAN_QEM_EXIT:-0}"
+fi
+if [[ ${1:-} == "-Q" ]]; then
+  exit 0
+fi
+if [[ $* == *"-Syu"* ]]; then
+  if [[ ${TEST_SYSTEM_PKGS_FAIL:-0} == "1" ]]; then
+    echo "error: unresolvable package conflicts detected" >&2
+    exit 1
+  fi
+  exit 0
+fi
+if [[ ${1:-} == "-Sy" ]]; then
+  exit 0
+fi
+if [[ ${1:-} == "-S" ]]; then
+  exit 0
+fi
+if [[ $* == *"-Rns"* ]]; then
+  exit "${TEST_ORPHAN_REMOVE_EXIT:-0}"
+fi
+exit 0'
+
+write_stub pacman-key '
+printf "%s\n" "$*" >>"${PACMAN_KEY_LOG:-/dev/null}"
+exit 0'
+
+write_stub pkexec '
+printf "%s\n" "$*" >>"${SUDO_LOG:-/dev/null}"
+echo "pkexec should not be called unattended" >&2
+exit 1'
+
+write_stub gum '
+printf "%q " "$@" >>"${GUM_LOG:-/dev/null}"
+printf "\n" >>"${GUM_LOG:-/dev/null}"
+if [[ ${1:-} == "style" ]]; then exit 0; fi
+if [[ ${1:-} == "confirm" ]]; then
+  shift
+  if [[ $* == *"Continue with update?"* ]]; then exit "${TEST_UPDATE_CONFIRM_EXIT:-0}"; fi
+  if [[ $* == *"orphan"* ]]; then exit "${TEST_ORPHAN_CONFIRM_EXIT:-1}"; fi
+  if [[ $* == *"Reboot"* || $* == *"reboot"* ]]; then exit "${TEST_REBOOT_CONFIRM_EXIT:-1}"; fi
+  exit 1
+fi
+exit 99'
+
+write_stub snapper '
+printf "%q " "$@" >>"${SNAPPER_LOG:-/dev/null}"
+printf "\n" >>"${SNAPPER_LOG:-/dev/null}"
+if [[ ${TEST_SNAP_SLEEP:-0} == "1" ]]; then sleep 2; fi
+if [[ $* == *"list-configs"* ]]; then
+  printf "config,subvolume\n"
+  exit 0
+fi
+exit 0'
+
+write_stub paccache '
+printf "%q " "$@" >>"${PACCACHE_LOG:-/dev/null}"
+printf "\n" >>"${PACCACHE_LOG:-/dev/null}"
+exit 0'
+
+write_stub yay '
+printf "%q " "$@" >>"${YAY_LOG:-/dev/null}"
+printf "\n" >>"${YAY_LOG:-/dev/null}"
+exit 0'
+
+write_stub mise '
+printf "%q " "$@" >>"${MISE_LOG:-/dev/null}"
+printf "\n" >>"${MISE_LOG:-/dev/null}"
+exit 0'
+
+write_stub git '
+printf "env:TERMINAL_PROMPT=%s ASKPASS=%s SSH=%s args:%s\n" "${GIT_TERMINAL_PROMPT-<unset>}" "${GIT_ASKPASS-<unset>}" "${GIT_SSH_COMMAND-<unset>}" "$*" >>"${GIT_LOG:-/dev/null}"
+printf "TERMINAL_PROMPT=%s\n" "${GIT_TERMINAL_PROMPT-<unset>}" >>"${GIT_ENV_LOG:-/dev/null}"
+if [[ $* == *"rev-parse --is-inside-work-tree"* ]]; then exit 0; fi
+if [[ $* == *"rev-parse --abbrev-ref"* ]]; then printf "origin/quattro\n"; exit 0; fi
+if [[ $* == *"pull --ff-only"* ]]; then exit "${TEST_GIT_PULL_EXIT:-0}"; fi
+if [[ $* == *"fetch --quiet"* ]]; then exit 0; fi
+if [[ $* == *"rev-list --count"* ]]; then printf "0\n"; exit 0; fi
+if [[ $* == *"rev-parse --short HEAD"* ]]; then printf "abc123\n"; exit 0; fi
+exit 0'
+
+write_stub systemctl '
+printf "%q " "$@" >>"${SYSTEMCTL_LOG:-/dev/null}"
+printf "\n" >>"${SYSTEMCTL_LOG:-/dev/null}"
+exit "${TEST_SYSTEMCTL_EXIT:-0}"'
+
+write_stub systemd-inhibit '
+printf "%q " "$@" >>"${INHIBIT_LOG:-/dev/null}"
+printf "\n" >>"${INHIBIT_LOG:-/dev/null}"
+exec sleep 30'
+
+write_stub omarchy-system-reboot '
+printf "reboot %s\n" "$*" >>"${REBOOT_LOG:-/dev/null}"
+exit 0'
+
+write_stub omarchy-shell '
+printf "%q " "$@" >>"${SHELL_LOG:-/dev/null}"
+printf "\n" >>"${SHELL_LOG:-/dev/null}"
+exit 0'
+
+write_stub omarchy-restart-audio '
+printf "audio %s\n" "$*" >>"${RESTART_LOG:-/dev/null}"
+exit 0'
+
+write_stub omarchy-restart-trackpad '
+printf "trackpad %s\n" "$*" >>"${RESTART_LOG:-/dev/null}"
+exit 0'
+
+write_stub omarchy-restart-shell '
+printf "shell %s\n" "$*" >>"${SHELL_RESTART_LOG:-/dev/null}"
+exit 0'
+
+write_stub checkupdates '
+printf "%s\n" "$*" >>"${CHECKUPDATES_LOG:-/dev/null}"
+exit 0'
+
+write_stub omarchy-pkg-aur-accessible '
+printf "probe\n" >>"${AUR_ACCESS_LOG:-/dev/null}"
+exit "${TEST_AUR_ACCESSIBLE:-0}"'
+
+write_stub uname '
+if [[ ${1:-} == "-r" ]]; then
+  if [[ -n ${TEST_RUNNING_KERNEL:-} ]]; then printf "%s\n" "$TEST_RUNNING_KERNEL"; else exec /usr/bin/uname -r; fi
+  exit 0
+fi
+exec /usr/bin/uname "$@"'
+
+write_stub pgrep '
+if [[ ${1:-} == "-x" && ${2:-} == "Hyprland" ]]; then
+  if [[ ${TEST_PGREP_MODE:-none} == "present" ]]; then printf "1234\n"; exit 0; else exit 1; fi
+fi
+exit 1'
+
+write_stub readlink '
+if [[ ${1:-} == /proc/*/exe ]]; then
+  if [[ ${TEST_HYPRLAND_DELETED:-0} == "1" ]]; then printf "/usr/bin/Hyprland (deleted)\n"; exit 0; else exit 1; fi
+fi
+exec /usr/bin/readlink "$@"'
+
+cat >"$test_home/.config/omarchy/hooks/post-update.d/test-hook" <<'SH'
+#!/bin/bash
+printf 'hook-ran\n' >>"$HOOK_LOG"
+exit 0
+SH
+chmod +x "$test_home/.config/omarchy/hooks/post-update.d/test-hook"
+
+premark_migrations() {
+  local tree="$1"
+  local statedir="$2"
+  mkdir -p "$statedir"
+  local f
+  for f in "$tree"/migrations/*.sh; do
+    [[ -f $f ]] || continue
+    touch "$statedir/$(basename "$f")"
+  done
+}
+premark_migrations "$ROOT" "$migration_state"
+
+reset_logs() {
+  : >"$STEP_LOG"; : >"$GUM_LOG"; : >"$SUDO_LOG"; : >"$PACMAN_LOG"; : >"$PACMAN_KEY_LOG"
+  : >"$SNAPPER_LOG"; : >"$PACCACHE_LOG"; : >"$YAY_LOG"; : >"$MISE_LOG"; : >"$GIT_LOG"
+  : >"$GIT_ENV_LOG"; : >"$SYSTEMCTL_LOG"; : >"$INHIBIT_LOG"; : >"$REBOOT_LOG"; : >"$SHELL_LOG"
+  : >"$RESTART_LOG"; : >"$SHELL_RESTART_LOG"; : >"$STATE_LOG"; : >"$CHECKUPDATES_LOG"
+  : >"$AUR_ACCESS_LOG"; : >"$HOOK_LOG"
+}
+
+reset_state() {
+  rm -f "$test_home/.local/state/omarchy/reboot-required"
+  rm -f "$test_home"/.local/state/omarchy/restart-*-required
+  rm -rf "$runtime_dir/omarchy-update-stay-awake"
+  rm -f "$runtime_dir/omarchy-update.lock"
+  rm -f /tmp/omarchy-update.log
+  reset_logs
+}
+
+clean_out() {
+  tr -d '\r' <"$1"
+}
+
+base_env() {
+  env HOME="$test_home" \
+    XDG_RUNTIME_DIR="$runtime_dir" \
+    XDG_STATE_HOME="$state_dir" \
+    XDG_CACHE_HOME="$test_home/.cache" \
+    XDG_CONFIG_HOME="$test_home/.config" \
+    XDG_DATA_HOME="$test_home/.local/share" \
+    OMARCHY_PATH="$ROOT" \
+    OMARCHY_MIGRATION_STATE="$migration_state" \
+    STEP_LOG="$STEP_LOG" GUM_LOG="$GUM_LOG" SUDO_LOG="$SUDO_LOG" PACMAN_LOG="$PACMAN_LOG" \
+    PACMAN_KEY_LOG="$PACMAN_KEY_LOG" SNAPPER_LOG="$SNAPPER_LOG" PACCACHE_LOG="$PACCACHE_LOG" \
+    YAY_LOG="$YAY_LOG" MISE_LOG="$MISE_LOG" GIT_LOG="$GIT_LOG" GIT_ENV_LOG="$GIT_ENV_LOG" \
+    SYSTEMCTL_LOG="$SYSTEMCTL_LOG" INHIBIT_LOG="$INHIBIT_LOG" REBOOT_LOG="$REBOOT_LOG" \
+    SHELL_LOG="$SHELL_LOG" RESTART_LOG="$RESTART_LOG" SHELL_RESTART_LOG="$SHELL_RESTART_LOG" \
+    STATE_LOG="$STATE_LOG" CHECKUPDATES_LOG="$CHECKUPDATES_LOG" AUR_ACCESS_LOG="$AUR_ACCESS_LOG" \
+    HOOK_LOG="$HOOK_LOG" SHELL=/bin/bash \
+    PATH="$stub_bin:$ROOT/bin:/usr/local/sbin:/usr/local/bin:/usr/bin" \
+    "$@"
+}
+
+run_pty() {
+  local out="$1"
+  local err="$2"
+  shift 2
+  local cmd_str
+  cmd_str=$(printf '%q ' "$@")
+  base_env timeout 90 script -qefc "$cmd_str" /dev/null >"$out" 2>"$err"
+}
+
+run_headless() {
+  local out="$1"
+  local err="$2"
+  shift 2
+  base_env "$@" </dev/null >"$out" 2>"$err"
+}
+
+check_transcript() {
+  local desc="$1"
+  [[ -f /tmp/omarchy-update.log ]] || fail "$desc transcript exists" "missing /tmp/omarchy-update.log"
+  [[ -s /tmp/omarchy-update.log ]] || fail "$desc transcript non-empty" "empty log"
+  pass "$desc transcript exists non-empty"
+}
+
+check_unattended_summary() {
+  local desc="$1"
+  local kind="$2"
+  clean_out /tmp/omarchy-update.log | grep -q "Unattended update ($kind)" ||
+    fail "$desc transcript has unattended $kind summary" "$(clean_out /tmp/omarchy-update.log | head -n 30)"
+  pass "$desc transcript has unattended $kind summary"
+}
+
+steps_names() {
+  cut -d' ' -f1 "$STEP_LOG"
+}
+
+# --- 1. interactive TTY accept: confirm accept, orphan decline, reboot decline ---
+reset_state
+export TEST_UPDATE_CONFIRM_EXIT=0 TEST_ORPHAN_CONFIRM_EXIT=1 TEST_REBOOT_CONFIRM_EXIT=1
+export TEST_RUNNING_KERNEL="" TEST_PGREP_MODE="none" TEST_HYPRLAND_DELETED="0"
+export TEST_SUDO_N_TRUE_EXIT=0 TEST_SYSTEM_PKGS_FAIL=0 TEST_SYSTEMCTL_EXIT=0 TEST_ORPHANS_EMPTY=0
+touch "$test_home/.local/state/omarchy/reboot-required"
+set +e
+run_pty "$test_tmp/i-acc.out" "$test_tmp/i-acc.err" omarchy-update
+i_acc_status=$?
+set -e
+(( i_acc_status == 0 )) || fail "interactive accept exits 0" "got $i_acc_status out=$(clean_out "$test_tmp/i-acc.out") err=$(cat "$test_tmp/i-acc.err") steps=$(cat "$STEP_LOG")"
+grep -q '^omarchy-update-confirm ' "$STEP_LOG" || fail "interactive accept runs confirm" "$(cat "$STEP_LOG")"
+grep -q '^omarchy-update-pkg-prune ' "$STEP_LOG" || fail "interactive accept runs prune" "$(cat "$STEP_LOG")"
+grep -q '^omarchy-update-system-pkgs ' "$STEP_LOG" || fail "interactive accept runs system-pkgs" "$(cat "$STEP_LOG")"
+grep -q '^omarchy-migrate ' "$STEP_LOG" || fail "interactive accept runs migrate" "$(cat "$STEP_LOG")"
+grep -q '^omarchy-update-orphan-pkgs ' "$STEP_LOG" || fail "interactive accept runs orphan" "$(cat "$STEP_LOG")"
+grep -q '^omarchy-update-restart ' "$STEP_LOG" || fail "interactive accept runs restart" "$(cat "$STEP_LOG")"
+(( $(grep -c '^confirm' "$GUM_LOG") == 3 )) || fail "interactive accept calls gum 3 times (confirm+orphan+reboot)" "$(cat "$GUM_LOG")"
+[[ ! -s $REBOOT_LOG ]] || fail "interactive decline reboot does not reboot" "$(cat "$REBOOT_LOG")"
+check_transcript "interactive accept"
+pass "interactive TTY accept runs full pipeline with orphan+reboot prompts"
+
+# --- 2. interactive TTY decline confirm ---
+reset_state
+export TEST_UPDATE_CONFIRM_EXIT=1
+set +e
+run_pty "$test_tmp/i-dec.out" "$test_tmp/i-dec.err" omarchy-update
+i_dec_status=$?
+set -e
+(( i_dec_status == 0 )) || fail "interactive decline exits 0" "got $i_dec_status"
+grep -q '^omarchy-update-confirm ' "$STEP_LOG" || fail "interactive decline runs confirm" "$(cat "$STEP_LOG")"
+grep -q '^omarchy-update-pkg-prune ' "$STEP_LOG" && fail "interactive decline runs no prune" "$(cat "$STEP_LOG")"
+grep -q '^omarchy-snapshot ' "$STEP_LOG" && fail "interactive decline runs no snapshot" "$(cat "$STEP_LOG")"
+grep -q '^omarchy-update-system-pkgs ' "$STEP_LOG" && fail "interactive decline runs no system-pkgs" "$(cat "$STEP_LOG")"
+check_transcript "interactive decline"
+pass "interactive decline exits 0 before prune/snapshot/system-pkgs"
+
+# --- 3. -y PTY full ---
+reset_state
+unset TEST_UPDATE_CONFIRM_EXIT TEST_ORPHAN_CONFIRM_EXIT TEST_REBOOT_CONFIRM_EXIT
+export TEST_RUNNING_KERNEL="" TEST_PGREP_MODE="none" TEST_HYPRLAND_DELETED="0"
+export TEST_SUDO_N_TRUE_EXIT=0 TEST_SYSTEM_PKGS_FAIL=0 TEST_SYSTEMCTL_EXIT=0 TEST_ORPHANS_EMPTY=0
+set +e
+run_pty "$test_tmp/y.out" "$test_tmp/y.err" omarchy-update -y
+y_status=$?
+set -e
+(( y_status == 0 )) || fail "-y PTY exits 0" "got $y_status out=$(clean_out "$test_tmp/y.out" | tail -n 20) err=$(cat "$test_tmp/y.err") steps=$(cat "$STEP_LOG")"
+[[ ! -s $GUM_LOG ]] || fail "-y PTY calls no gum" "$(cat "$GUM_LOG")"
+for s in omarchy-update-requires-free-space omarchy-update-pkg-prune omarchy-snapshot omarchy-update-dev omarchy-update-keyring omarchy-update-system-pkgs omarchy-migrate omarchy-hook omarchy-update-aur-pkgs omarchy-update-mise omarchy-update-orphan-pkgs omarchy-update-analyze-logs omarchy-update-status omarchy-update-restart; do
+  grep -q "^$s " "$STEP_LOG" || fail "-y PTY runs $s" "$(cat "$STEP_LOG")"
+done
+grep -q '^omarchy-update-confirm ' "$STEP_LOG" && fail "-y PTY skips confirm" "$(cat "$STEP_LOG")"
+clean_out "$test_tmp/y.out" | grep -q 'Keeping orphaned packages' || fail "-y PTY reports orphans kept" "$(clean_out "$test_tmp/y.out")"
+clean_out "$test_tmp/y.out" | grep -q 'Reboot required:' && fail "-y PTY reports no reboot without triggers" "$(clean_out "$test_tmp/y.out")"
+[[ -s $YAY_LOG ]] || fail "-y PTY runs aur (yay called)" "yay empty steps=$(cat "$STEP_LOG")"
+[[ -s $MISE_LOG ]] || fail "-y PTY runs mise" "$(cat "$STEP_LOG")"
+[[ -s $HOOK_LOG ]] || fail "-y PTY runs hooks" "$(cat "$STEP_LOG")"
+grep -q -- '-n -v' "$SUDO_LOG" || fail "-y PTY stay-awake probes sudo -n" "$(cat "$SUDO_LOG")"
+grep -q -- '-n systemd-inhibit' "$SUDO_LOG" || fail "-y PTY stay-awake runs sudo -n inhibit" "$(cat "$SUDO_LOG")"
+[[ ! -s $REBOOT_LOG ]] || fail "-y PTY never reboots" "$(cat "$REBOOT_LOG")"
+(( $(grep -c '^shell' "$SHELL_RESTART_LOG") == 1 )) || fail "-y PTY restarts shell" "$(cat "$SHELL_RESTART_LOG")"
+check_transcript "-y PTY"
+check_unattended_summary "-y PTY" "full"
+pass "-y PTY full pipeline unattended no-gum with transcript"
+
+# --- 4. --yes alias identical ---
+reset_state
+set +e
+run_pty "$test_tmp/yes.out" "$test_tmp/yes.err" omarchy-update --yes
+yes_status=$?
+set -e
+(( yes_status == 0 )) || fail "--yes PTY exits 0" "got $yes_status"
+[[ ! -s $GUM_LOG ]] || fail "--yes PTY calls no gum" "$(cat "$GUM_LOG")"
+for s in omarchy-migrate omarchy-hook omarchy-update-aur-pkgs omarchy-update-mise omarchy-update-orphan-pkgs omarchy-update-restart; do
+  grep -q "^$s " "$STEP_LOG" || fail "--yes PTY runs $s" "$(cat "$STEP_LOG")"
+done
+clean_out "$test_tmp/yes.out" | grep -q 'Keeping orphaned packages' || fail "--yes reports orphans kept" "$(clean_out "$test_tmp/yes.out")"
+check_transcript "--yes PTY"
+check_unattended_summary "--yes PTY" "full"
+pass "--yes alias identical to -y"
+
+# --- 5. --non-interactive PTY strict skip ---
+reset_state
+set +e
+run_pty "$test_tmp/strict.out" "$test_tmp/strict.err" omarchy-update --non-interactive
+strict_status=$?
+set -e
+(( strict_status == 0 )) || fail "strict PTY exits 0" "got $strict_status err=$(cat "$test_tmp/strict.err")"
+[[ ! -s $GUM_LOG ]] || fail "strict PTY calls no gum" "$(cat "$GUM_LOG")"
+grep -q '^omarchy-migrate ' "$STEP_LOG" || fail "strict still runs migrations" "$(cat "$STEP_LOG")"
+grep -q '^omarchy-hook ' "$STEP_LOG" && fail "strict skips hooks" "$(cat "$STEP_LOG")"
+grep -q '^omarchy-update-aur-pkgs ' "$STEP_LOG" && fail "strict skips aur" "$(cat "$STEP_LOG")"
+grep -q '^omarchy-update-mise ' "$STEP_LOG" && fail "strict skips mise" "$(cat "$STEP_LOG")"
+clean_out "$test_tmp/strict.out" | grep -q 'Skipping post-update hooks (--hooks=skip)' || fail "strict reports hook skip" "$(clean_out "$test_tmp/strict.out")"
+clean_out "$test_tmp/strict.out" | grep -q 'Skipping AUR package updates (--aur=skip)' || fail "strict reports aur skip" "$(clean_out "$test_tmp/strict.out")"
+clean_out "$test_tmp/strict.out" | grep -q 'Skipping mise updates (--mise=skip)' || fail "strict reports mise skip" "$(clean_out "$test_tmp/strict.out")"
+[[ ! -s $YAY_LOG ]] || fail "strict does not call yay" "$(cat "$YAY_LOG")"
+[[ ! -s $MISE_LOG ]] || fail "strict does not call mise" "$(cat "$MISE_LOG")"
+[[ ! -s $HOOK_LOG ]] || fail "strict does not run hooks" "$(cat "$HOOK_LOG")"
+clean_out "$test_tmp/strict.out" | grep -q 'Keeping orphaned packages' || fail "strict reports orphans kept" "$(clean_out "$test_tmp/strict.out")"
+check_transcript "strict PTY"
+check_unattended_summary "strict PTY" "strict"
+pass "--non-interactive skips hooks/aur/mise with messages, migrations run"
+
+# --- 6. strict opt-in warnings ---
+reset_state
+set +e
+run_pty "$test_tmp/optin.out" "$test_tmp/optin.err" omarchy-update --non-interactive --hooks=run --aur=run --mise=run
+optin_status=$?
+set -e
+(( optin_status == 0 )) || fail "strict opt-in exits 0" "got $optin_status"
+grep -q '^omarchy-hook ' "$STEP_LOG" || fail "strict opt-in runs hooks" "$(cat "$STEP_LOG")"
+grep -q '^omarchy-update-aur-pkgs ' "$STEP_LOG" || fail "strict opt-in runs aur" "$(cat "$STEP_LOG")"
+grep -q '^omarchy-update-mise ' "$STEP_LOG" || fail "strict opt-in runs mise" "$(cat "$STEP_LOG")"
+clean_out "$test_tmp/optin.out" | grep -q 'Warning: --hooks=run in strict mode' || fail "strict hooks opt-in warns" "$(clean_out "$test_tmp/optin.out")"
+clean_out "$test_tmp/optin.out" | grep -q 'Warning: --aur=run in strict mode' || fail "strict aur opt-in warns" "$(clean_out "$test_tmp/optin.out")"
+clean_out "$test_tmp/optin.out" | grep -q 'Warning: --mise=run in strict mode' || fail "strict mise opt-in warns" "$(clean_out "$test_tmp/optin.out")"
+check_transcript "strict opt-in"
+pass "strict opt-in runs externals with warnings"
+
+# --- 7. --orphans=remove PTY ---
+reset_state
+set +e
+run_pty "$test_tmp/orm.out" "$test_tmp/orm.err" omarchy-update -y --orphans=remove
+orm_status=$?
+set -e
+(( orm_status == 0 )) || fail "orphans=remove exits 0" "got $orm_status"
+[[ ! -s $GUM_LOG ]] || fail "orphans=remove calls no gum" "$(cat "$GUM_LOG")"
+grep -q -- '-n' "$SUDO_LOG" || fail "orphans=remove uses sudo -n" "$(cat "$SUDO_LOG")"
+grep -q -- '--noconfirm' "$PACMAN_LOG" || fail "orphans=remove uses --noconfirm" "$(cat "$PACMAN_LOG")"
+grep -q 'old-lib.*unused-tool' "$PACMAN_LOG" || fail "orphans=remove passes package list" "$(cat "$PACMAN_LOG")"
+clean_out "$test_tmp/orm.out" | grep -q 'Removing orphan system packages' || fail "orphans=remove reports removing" "$(clean_out "$test_tmp/orm.out")"
+check_transcript "orphans=remove"
+pass "--orphans=remove uses sudo -n pacman -Rns --noconfirm with list, no gum"
+
+# --- 8. --orphans=keep PTY ---
+reset_state
+set +e
+run_pty "$test_tmp/keep.out" "$test_tmp/keep.err" omarchy-update -y --orphans=keep
+keep_status=$?
+set -e
+(( keep_status == 0 )) || fail "orphans=keep exits 0" "got $keep_status"
+[[ ! -s $GUM_LOG ]] || fail "orphans=keep calls no gum" "$(cat "$GUM_LOG")"
+grep -q -- '-Rns' "$PACMAN_LOG" && fail "orphans=keep runs no removal" "$(cat "$PACMAN_LOG")"
+clean_out "$test_tmp/keep.out" | grep -q 'Keeping orphaned packages' || fail "orphans=keep reports keeping" "$(clean_out "$test_tmp/keep.out")"
+check_transcript "orphans=keep"
+pass "--orphans=keep reports only, no removal"
+
+# --- 9. --reboot=if-needed success with kernel mismatch ---
+reset_state
+export TEST_RUNNING_KERNEL="0.0.0-fake-no-match" TEST_PGREP_MODE="none" TEST_HYPRLAND_DELETED="0" TEST_SYSTEMCTL_EXIT=0
+set +e
+run_pty "$test_tmp/rb.out" "$test_tmp/rb.err" omarchy-update -y --reboot=if-needed
+rb_status=$?
+set -e
+(( rb_status == 0 )) || fail "reboot if-needed exits 0" "got $rb_status out=$(clean_out "$test_tmp/rb.out") err=$(cat "$test_tmp/rb.err")"
+[[ ! -s $GUM_LOG ]] || fail "reboot if-needed calls no gum" "$(cat "$GUM_LOG")"
+grep -q -- '--no-ask-password' "$SUDO_LOG" || fail "reboot uses --no-ask-password" "$(cat "$SUDO_LOG")"
+grep -q -- 'reboot' "$SUDO_LOG" || fail "reboot calls reboot" "$(cat "$SUDO_LOG")"
+grep -q -- '--no-wall' "$SUDO_LOG" || fail "reboot uses --no-wall" "$(cat "$SUDO_LOG")"
+(( $(grep -c -- 'systemctl.*reboot' "$SUDO_LOG") == 1 )) || fail "reboot requested exactly once" "$(cat "$SUDO_LOG")"
+(( $(wc -l <"$SYSTEMCTL_LOG") == 1 )) || fail "systemctl called exactly once" "$(cat "$SYSTEMCTL_LOG")"
+clean_out "$test_tmp/rb.out" | grep -q 'Reboot requested\.' || fail "reboot prints success" "$(clean_out "$test_tmp/rb.out")"
+check_transcript "reboot if-needed"
+export TEST_RUNNING_KERNEL=""
+pass "--reboot=if-needed single sudo systemctl reboot, exit 0"
+
+# --- 10. --reboot=if-needed systemctl failure ---
+reset_state
+export TEST_RUNNING_KERNEL="0.0.0-fake-no-match" TEST_SYSTEMCTL_EXIT=5
+touch "$test_home/.local/state/omarchy/reboot-required"
+set +e
+run_pty "$test_tmp/rbf.out" "$test_tmp/rbf.err" omarchy-update -y --reboot=if-needed
+rbf_status=$?
+set -e
+(( rbf_status != 0 )) || fail "reboot failure exits nonzero" "got 0"
+clean_out "$test_tmp/rbf.out" | grep -q 'Reboot requested\.' && fail "reboot failure prints no success" "$(clean_out "$test_tmp/rbf.out")"
+[[ -f $test_home/.local/state/omarchy/reboot-required ]] || fail "reboot failure preserves marker" "marker gone"
+check_transcript "reboot failure"
+export TEST_RUNNING_KERNEL="" TEST_SYSTEMCTL_EXIT=0
+pass "--reboot=if-needed failure exits nonzero, marker preserved"
+
+# --- 11. --restarts=skip PTY ---
+reset_state
+mkdir -p "$test_home/.local/state/omarchy"
+touch "$test_home/.local/state/omarchy/restart-audio-required"
+touch "$test_home/.local/state/omarchy/restart-trackpad-required"
+set +e
+run_pty "$test_tmp/rskip.out" "$test_tmp/rskip.err" omarchy-update -y --restarts=skip
+rskip_status=$?
+set -e
+(( rskip_status == 0 )) || fail "restarts=skip exits 0" "got $rskip_status"
+[[ -f $test_home/.local/state/omarchy/restart-audio-required ]] || fail "restarts=skip keeps audio marker" "gone"
+[[ -f $test_home/.local/state/omarchy/restart-trackpad-required ]] || fail "restarts=skip keeps trackpad marker" "gone"
+[[ ! -s $RESTART_LOG ]] || fail "restarts=skip makes no service calls" "$(cat "$RESTART_LOG")"
+[[ ! -s $SHELL_RESTART_LOG ]] || fail "restarts=skip makes no shell restart" "$(cat "$SHELL_RESTART_LOG")"
+clean_out "$test_tmp/rskip.out" | grep -q 'Skipping service restarts' || fail "restarts=skip reports summary" "$(clean_out "$test_tmp/rskip.out")"
+check_transcript "restarts=skip"
+pass "--restarts=skip preserves markers, no restart calls"
+
+# --- 12. headless -y ---
+reset_state
+export TEST_RUNNING_KERNEL="" TEST_PGREP_MODE="none" TEST_HYPRLAND_DELETED="0" TEST_SYSTEMCTL_EXIT=0
+set +e
+run_headless "$test_tmp/head.out" "$test_tmp/head.err" omarchy-update -y
+head_status=$?
+set -e
+(( head_status == 0 )) || fail "headless -y exits 0" "got $head_status out=$(cat "$test_tmp/head.out") err=$(cat "$test_tmp/head.err") steps=$(cat "$STEP_LOG")"
+[[ ! -s $GUM_LOG ]] || fail "headless -y calls no gum" "$(cat "$GUM_LOG")"
+grep -q '^omarchy-migrate ' "$STEP_LOG" || fail "headless runs migrate" "$(cat "$STEP_LOG")"
+grep -q '^omarchy-update-orphan-pkgs ' "$STEP_LOG" || fail "headless runs orphan" "$(cat "$STEP_LOG")"
+check_transcript "headless -y"
+check_unattended_summary "headless -y" "full"
+pass "headless -y same as PTY minus TTY, transcript written"
+
+# --- 13. conflicting packages stop before migrate ---
+reset_state
+export TEST_SYSTEM_PKGS_FAIL=1
+set +e
+run_pty "$test_tmp/conf.out" "$test_tmp/conf.err" omarchy-update -y
+conf_status=$?
+set -e
+(( conf_status != 0 )) || fail "conflicting packages exit nonzero" "got 0"
+grep -q '^omarchy-update-system-pkgs ' "$STEP_LOG" || fail "conflict runs system-pkgs" "$(cat "$STEP_LOG")"
+grep -q '^omarchy-migrate ' "$STEP_LOG" && fail "conflict stops before migrate" "$(cat "$STEP_LOG")"
+clean_out "$test_tmp/conf.out" | grep -q 'Something went wrong' || clean_out "$test_tmp/conf.err" | grep -q 'Something went wrong' || fail "conflict prints ERR trap message" "out=$(clean_out "$test_tmp/conf.out") err=$(clean_out "$test_tmp/conf.err")"
+check_transcript "conflicting packages"
+export TEST_SYSTEM_PKGS_FAIL=0
+pass "conflicting packages stop before migrate with ERR message"
+
+# --- 14. keyring no-auth fails before system-pkgs ---
+reset_state
+export TEST_SUDO_N_TRUE_EXIT=1
+set +e
+run_pty "$test_tmp/noauth.out" "$test_tmp/noauth.err" omarchy-update -y
+noauth_status=$?
+set -e
+(( noauth_status != 0 )) || fail "keyring no-auth exits nonzero" "got 0"
+grep -q '^omarchy-update-keyring ' "$STEP_LOG" || fail "no-auth runs keyring" "$(cat "$STEP_LOG")"
+grep -q '^omarchy-update-system-pkgs ' "$STEP_LOG" && fail "no-auth stops before system-pkgs" "$(cat "$STEP_LOG")"
+clean_out "$test_tmp/noauth.out" | grep -q 'sudo -n' || clean_out "$test_tmp/noauth.err" | grep -q 'sudo -n' || fail "no-auth actionable stderr" "out=$(clean_out "$test_tmp/noauth.out") err=$(clean_out "$test_tmp/noauth.err")"
+check_transcript "keyring no-auth"
+export TEST_SUDO_N_TRUE_EXIT=0
+pass "keyring no-auth exits nonzero before system-pkgs with actionable stderr"
+
+# --- 15. real lock second instance through transcript path ---
+reset_state
+export TEST_SNAP_SLEEP=1 TEST_SUDO_N_TRUE_EXIT=0 TEST_SYSTEM_PKGS_FAIL=0
+rm -f "$test_tmp/first-started" "$test_tmp/second.out"
+base_env omarchy-update -y </dev/null >"$test_tmp/first.out" 2>"$test_tmp/first.err" &
+first_pid=$!
+for _ in $(seq 1 100); do
+  grep -q 'list-configs' "$SNAPPER_LOG" 2>/dev/null && break
+  sleep 0.05
+done
+grep -q 'list-configs' "$SNAPPER_LOG" || fail "first update reached snapshot under lock" "$(cat "$SNAPPER_LOG")"
+set +e
+base_env omarchy-update -y </dev/null >"$test_tmp/second.out" 2>"$test_tmp/second.err"
+second_status=$?
+set -e
+wait "$first_pid"
+first_status=$?
+export TEST_SNAP_SLEEP=0
+(( second_status != 0 )) || fail "second update exits nonzero while lock held" "got 0"
+grep -q 'already running' "$test_tmp/second.out" || grep -q 'already running' "$test_tmp/second.err" || clean_out /tmp/omarchy-update.log | grep -q 'already running' || fail "second update reports held lock" "out=$(cat "$test_tmp/second.out") err=$(cat "$test_tmp/second.err")"
+(( first_status == 0 )) || fail "first update succeeds after lock released" "got $first_status"
+pass "real lock second instance exits nonzero already running"
+
+# --- 16. mutation proof: orphan + reboot guards catch regressions in disposable copies ---
+reset_state
+mut_orphan="$test_tmp/mut-orphan"
+rm -rf "$mut_orphan"
+cp -a "$ROOT" "$mut_orphan"
+chmod -R u+w "$mut_orphan"
+sed -i 's/if \[\[ ${OMARCHY_UPDATE_UNATTENDED:-} == "1" \]\]; then/if false; then/' "$mut_orphan/bin/omarchy-update-orphan-pkgs"
+grep -q 'if false; then' "$mut_orphan/bin/omarchy-update-orphan-pkgs" || fail "orphan mutation applied" "sed missed"
+: >"$GUM_LOG"
+set +e
+HOME="$test_home" PATH="$stub_bin:$mut_orphan/bin:/usr/local/sbin:/usr/local/bin:/usr/bin" OMARCHY_PATH="$mut_orphan" OMARCHY_UPDATE_ORPHANS="ask" OMARCHY_UPDATE_UNATTENDED="1" GUM_LOG="$GUM_LOG" SUDO_LOG="$SUDO_LOG" script -qec "$mut_orphan/bin/omarchy-update-orphan-pkgs" /dev/null >"$test_tmp/mut-orphan.out" 2>"$test_tmp/mut-orphan.err"
+mut_orphan_status=$?
+set -e
+[[ -s $GUM_LOG ]] || fail "orphan guard mutation calls gum (test catches regression)" "gum empty, status=$mut_orphan_status"
+pass "mutation proof orphan unattended no-gum fails on reverted guard"
+
+: >"$GUM_LOG"
+mut_reboot="$test_tmp/mut-reboot"
+rm -rf "$mut_reboot"
+cp -a "$ROOT" "$mut_reboot"
+chmod -R u+w "$mut_reboot"
+sed -i 's/if \[\[ ${OMARCHY_UPDATE_UNATTENDED:-} != "1" && -t 0 && -t 1 \]\]; then/if [[ -t 0 \&\& -t 1 ]]; then/' "$mut_reboot/bin/omarchy-update-restart"
+grep -q 'if \[\[ -t 0 && -t 1 \]\]; then' "$mut_reboot/bin/omarchy-update-restart" || fail "reboot mutation applied" "sed missed"
+: >"$GUM_LOG"
+: >"$SUDO_LOG"
+set +e
+HOME="$test_home" PATH="$stub_bin:$mut_reboot/bin:/usr/local/sbin:/usr/local/bin:/usr/bin" OMARCHY_PATH="$mut_reboot" OMARCHY_UPDATE_REBOOT="ask" OMARCHY_UPDATE_UNATTENDED="1" OMARCHY_UPDATE_RESTARTS="run" TEST_RUNNING_KERNEL="0.0.0-fake-no-match" TEST_PGREP_MODE="none" TEST_HYPRLAND_DELETED="0" TEST_GUM_EXIT="0" GUM_LOG="$GUM_LOG" SUDO_LOG="$SUDO_LOG" REBOOT_LOG="$REBOOT_LOG" STATE_LOG="$STATE_LOG" RESTART_LOG="$RESTART_LOG" SYSTEMCTL_LOG="$SYSTEMCTL_LOG" SHELL_LOG="$SHELL_LOG" script -qec "$mut_reboot/bin/omarchy-update-restart" /dev/null >"$test_tmp/mut-reboot.out" 2>"$test_tmp/mut-reboot.err"
+mut_reboot_status=$?
+set -e
+[[ -s $GUM_LOG ]] || fail "reboot guard mutation calls gum (test catches regression)" "gum empty status=$mut_reboot_status"
+pass "mutation proof reboot unattended no-gum fails on reverted guard"
+
+unset TEST_RUNNING_KERNEL TEST_PGREP_MODE TEST_HYPRLAND_DELETED TEST_SUDO_N_TRUE_EXIT TEST_SYSTEM_PKGS_FAIL TEST_SYSTEMCTL_EXIT TEST_ORPHANS_EMPTY TEST_SNAP_SLEEP TEST_UPDATE_CONFIRM_EXIT TEST_ORPHAN_CONFIRM_EXIT TEST_REBOOT_CONFIRM_EXIT


### PR DESCRIPTION
## Summary

Scripted `omarchy update` currently has no supported contract: `--yes` is absent, and `-y` leaks prompts under a transcript PTY (orphan `gum confirm`, reboot `gum confirm` reachable with a terminal attached), which the prior audit reproduced. This change adds explicit unattended modes plus per-area policy flags with deterministic parsing, a subprocess-scoped nonprompting privilege environment covering the whole descendant tree (including migrations), policy gating for hooks/AUR/mise/orphans/reboot/restarts, failure-closed keyring/inhibitor/git/conflict/migration-deferral semantics, and user plus internal docs. Interactive no-argument behavior is unchanged. This belongs to the #9501 family (scripted-update support).

## Flag contract

`omarchy update [--yes|-y|--non-interactive] [--hooks=run|skip] [--aur=run|skip] [--mise=run|skip] [--orphans=ask|keep|remove] [--reboot=ask|never|if-needed] [--restarts=run|skip]`

| Flag | Values | Notes |
| --- | --- | --- |
| `-y`, `--yes` | (mode) | Identical unattended first-party full pipeline. |
| `--non-interactive` | (mode) | Unattended strict mode; hooks/aur/mise default `skip`. |
| `--hooks` | `run\|skip` | Overrides mode default order-independently. |
| `--aur` | `run\|skip` | Overrides mode default order-independently. |
| `--mise` | `run\|skip` | Overrides mode default order-independently. |
| `--orphans` | `ask\|keep\|remove` | `remove` authorizes removal without confirmation. |
| `--reboot` | `ask\|never\|if-needed` | `if-needed` authorizes automatic reboot on success path only. |
| `--restarts` | `run\|skip` | `skip` defers service/shell restarts, keeps markers. |

Parsing rules: exact `--name=value` only; repeating the same policy with the same value is allowed; contradictory repeats fail exit 2; `-y`/`--yes` and `--non-interactive` may combine with strict winning regardless of order; `ask` with either unattended mode fails exit 2 regardless of order; unknown args, missing/invalid values, and positional args fail exit 2 before transcript creation, lock acquisition, or side effects; `-h`/`--help` anywhere prints usage with exit 0 without validating other args or running steps.

## Behavior defaults per mode

| Mode | hooks | aur | mise | orphans | reboot | restarts |
| --- | --- | --- | --- | --- | --- | --- |
| No flags (interactive) | `run` | `run` | `run` | `ask` | `ask` | `run` |
| `-y` / `--yes` (full) | `run` | `run` | `run` | `keep` | `never` | `run` |
| `--non-interactive` (strict) | `skip` | `skip` | `skip` | `keep` | `never` | `run` |

Unattended runs print `Unattended update (full): ...` (or the `(strict)` form) with normalized policies, plus `Orphan policy: remove -- orphaned packages will be removed without confirmation` for `--orphans=remove` and `Reboot policy: if-needed -- system will reboot automatically when required (may close unsaved applications)` for `--reboot=if-needed`. Skipped hooks/AUR/mise print `Skipping post-update hooks (--hooks=skip)` / `Skipping AUR package updates (--aur=skip)` / `Skipping mise updates (--mise=skip)`; strict opt-in (`--hooks=run`, `--aur=run`, `--mise=run`) runs but first warns on stderr that the non-interactive guarantee is relaxed for that component. Normalized exports: `OMARCHY_UPDATE_UNATTENDED=1` (either unattended mode, unset interactive), `OMARCHY_UPDATE_STRICT=1` (strict only, unset otherwise), `OMARCHY_UPDATE_HOOKS`/`OMARCHY_UPDATE_AUR`/`OMARCHY_UPDATE_MISE` (`run|skip`), `OMARCHY_UPDATE_ORPHANS` (`ask|keep|remove`), `OMARCHY_UPDATE_REBOOT` (`ask|never|if-needed`), `OMARCHY_UPDATE_RESTARTS` (`run|skip`).

## Guarantees and explicit boundaries

Guaranteed: deterministic parsing/validation before mutation; subprocess-scoped `sudo -n` adaptation inherited by plain-`sudo` descendants (nested bash, xargs/env, migration helpers) with stdin/stdout/stderr and exit-status preservation; `pkexec` fails closed with no graphical dialog; keyring/inhibitor/reboot/restart/migration/conflict/git failure semantics below; required-migration ordering with deferral staying pending. Explicitly not guaranteed: the adapter directory is subprocess `PATH` prepend only, not a security boundary and not installed as system `sudo`; absolute-path sudo, cleared-`PATH` callers, and custom programs bypass it. User hooks, AUR PKGBUILDs, mise backends, package ALPM hooks, and git credential helpers / custom `core.sshCommand` programs are cooperative external execution outside the guarantee (strict `run` opt-in warns per flag). Sudo credential precondition: unattended runs need a cached ticket or NOPASSWD; otherwise `sudo -n` fails promptly with no password/GUI dialog (keyring precheck exits 1 with `omarchy-update-keyring: unattended update cannot authenticate with sudo (sudo -n failed); run interactively or refresh sudo credentials before retrying`).

## Destructive-policy warnings

`--orphans=remove` removes the currently detected orphan packages without confirmation (`sudo pacman -Rns --noconfirm`, existing recursive semantics); it is not authorization to resolve arbitrary package conflicts. `--reboot=if-needed` reboots automatically via `sudo systemctl --no-ask-password reboot --no-wall` only after all required work succeeds and update-owned inhibitors are released; it never reboots midway or after failure, keeps the reboot marker when the reboot request fails, and can close unsaved applications.

## What changed (file by file)

- `bin/omarchy-update`: CLI parse/validate/normalize/export, unattended runner re-exec before transcript/lock/space checks, transcript (`script(1)` → `/tmp/omarchy-update.log`) and lock order preserved, hooks/AUR/mise gating with skip/warning/summary lines, destructive-policy summaries, preserved order and failure propagation.
- `bin/omarchy-update-run` (new): hidden runner installing the scoped privilege environment (`OMARCHY_UPDATE_REAL_SUDO` capture, `update-bin` prepend, `OMARCHY_UPDATE_ENV_READY=1`, `OMARCHY_UPDATE_RUN_REEXEC=1` re-entry guard).
- `default/omarchy/update-bin/sudo` (new): unattended adapter execing captured real sudo with `-n`, rejecting `-S`/`--stdin`, `-A`/`--askpass`, `-p`/`--prompt`.
- `default/omarchy/update-bin/pkexec` (new): unattended fail-closed adapter, exit 1, no dialog.
- `bin/omarchy-update-orphan-pkgs`: `OMARCHY_UPDATE_ORPHANS` policy (`ask` interactive gum flow preserved byte-for-byte; `keep` lists/retains; `remove` nonconfirm removal with error propagation; unattended/headless ask reports without gum; invalid exits 2).
- `bin/omarchy-update-restart`: `OMARCHY_UPDATE_REBOOT`/`OMARCHY_UPDATE_RESTARTS` policies, single automatic reboot on final success path only, `Reboot required: ...` reporting, `Skipping service restarts ...` / `Shell restart deferred` for `skip`, marker retention on failures, no gum unattended even with PTY.
- `bin/omarchy-update-stay-awake`: unattended `sudo -n` runner selection (never `pkexec`), observed acquisition with `Warning: sleep inhibitor failed to start; continuing without sleep inhibition.` warn-and-continue, PID/lock-FD/cleanup semantics preserved.
- `bin/omarchy-update-keyring`: `set -euo pipefail` plus unattended `sudo -n true` precheck described above; `Keys are correct` only on success.
- `bin/omarchy-update-dev`, `bin/omarchy-update-available`: unattended `GIT_TERMINAL_PROMPT=0`, empty `GIT_ASKPASS=`, `GIT_SSH_COMMAND="${GIT_SSH_COMMAND:-ssh -oBatchMode=yes}"` (explicit env preserved, custom sshCommand never executed, no new-host-key autoaccept); dev pull failure propagates nonzero, available fetch failure keeps quiet cached-state fallback.
- `migrations/1786643346.sh`: unattended browser-open deferral with actionable stderr and exit 1, marker absent, interactive unchanged.
- `migrations/1787760281.sh`: strict-plus-`OMARCHY_UPDATE_MISE!=run` explicit deferral before either installer branch (never swallowed by `|| true`), true no-ops preserved.
- Docs: `docs/update-process.md` (full flag/mode/env/runner/adapter/keyring/inhibitor/git/exit-code contract, interactive unchanged), `manual/30-updates.md` (new user-facing Non-interactive updates section with defaults table, examples, prerequisites, warnings, boundaries, restarts/reboot/migration/conflict notes), `agents/skills/migrations.md` (new Unattended updates authoring subsection citing both migration patterns).
- Tests: new `test/shell.d/update-environment-test.sh`, `test/shell.d/update-options-test.sh`, `test/shell.d/update-restart-test.sh`, `test/shell.d/update-keyring-test.sh`, `test/shell.d/update-migration-policy-test.sh`, `test/shell.d/update-unattended-test.sh` (35-check mocked PTY/headless end-to-end); rewritten `test/shell.d/update-sequence-test.sh`; extended `test/shell.d/update-orphan-test.sh`, `test/shell.d/update-lock-test.sh`, `test/shell.d/update-dev-test.sh`, `test/shell.d/update-available-test.sh`; focused `test/shell.d/update-disk-space-test.sh` fixture/assertion updates.

## Test plan

Focused suites via the sandbox runner (`python3 <run-dir>/sandbox.py -- ...`): `update-options-test.sh`, `update-sequence-test.sh`, `update-orphan-test.sh`, `update-restart-test.sh`, `update-lock-test.sh`, `update-keyring-test.sh`, `update-migration-policy-test.sh`, `update-dev-test.sh`, `update-available-test.sh`, `update-disk-space-test.sh`, `update-environment-test.sh`, plus `bash -n` on touched bash and `git diff --check`. Integration: `update-unattended-test.sh` passes 35 checks (interactive accept/decline, `-y`/`--yes`/strict defaults and overrides, PTY plus headless, orphan remove/keep, reboot if-needed success/failure/single-request, restarts skip, conflict stop, keyring no-auth stop, concurrent lock, transcript/summary presence). `./test/cli` passes. `./test/all` shows only the 4 pre-existing environment failures from baseline (3 from the missing omarchy-pkgs checkout plus the isolated-network QR sandbox artifact). PTY mutation proofs: disposable-copy removal of the orphan unattended guard and the restart unattended no-gum condition makes the matching PTY tests call gum, confirming the tests catch regressions. No live package operations, reboots, removals, or desktop use in tests.

## Relation to existing PRs

Related: #9511 (open), #8894, #8992, #9875, #6830. Overlap is expected around scripted-update modes and prompt suppression. What this draft adds beyond that overlap: the full explicit flag contract with per-mode defaults and order-independent parsing/validation rules; a privilege adapter scoped to updater descendants that also covers migrations and transitive first-party sudo callers; keyring unattended precheck and inhibitor acquisition failure semantics; reboot/restarts policies with single-request automatic reboot; git unattended env for dev/available with custom-helper boundaries; migration deferral patterns for unattended and strict-mise cases; plus user and internal docs. Happy to rebase onto whichever related branch lands first and to coordinate rather than duplicate: please point out the preferred base and I will reshape this accordingly.

## Limitations

Packaging rule verified for `default/**` copy into `/usr/share/omarchy/default/` (covers the new adapters and preserves executability) from the omarchy-pkgs PKGBUILD, but a full package build was not run and the omarchy-pkgs repo was not checked out here. No live update was executed; end-to-end means the full orchestrator flow with real transcript/lock/helpers and mocked package/system boundaries, not a live upgrade. No timeout is imposed on real package transactions. Upstream package hooks and third-party prompts remain outside the guarantee as documented.

## Compliance notes

Docs follow repo `AGENTS.md` markdown style (full lines, two-space indent). Suggested atomic commits, one per area: CLI/runner/adapters plus environment tests; orphan policy plus tests; restart/reboot policy plus tests; stay-awake/keyring plus tests; migrations plus policy tests; git/dev/available plus tests; unattended integration test; docs (update-process, manual, migrations skill). No commits made here; branch `feat/update-automation-policies` holds unstaged implementation plus docs for review.
