### PR TITLE
Skip tray grab until the SNI menu has children

### DIFF
--- a/shell/plugins/bar/widgets/Tray.qml
+++ b/shell/plugins/bar/widgets/Tray.qml
@@ -115,11 +115,10 @@ BarWidget {
   }
 
   function openTrayMenu(item, anchorItem, mouse) {
-    if (!item || !item.menu) {
-      var point = anchorItem.QsWindow.contentItem.mapFromItem(anchorItem, mouse.x, mouse.y)
-      item.display(anchorItem.QsWindow.window, point.x, point.y)
-      return
-    }
+    // Unready SNI (Menu/IconName Get still failing) has no menu handle.
+    // Platform display() is a documented no-op without UseQApplication, and
+    // setting trayMenuOpen anyway takes HyprlandFocusGrab on an empty popup.
+    if (!item || !item.menu) return
 
     // Reset before switching items: trayMenuOpener.menu binds to
     // activeTrayItem.menu, so assigning a new item invalidates the old root's
@@ -128,7 +127,7 @@ BarWidget {
     resetTrayMenu()
     activeTrayItem = item
     activeTrayAnchor = anchorItem
-    trayMenuOpen = true
+    trayMenuOpen = trayMenuOpener.children.length > 0
   }
 
   function trayIconSource(icon) {
@@ -516,6 +515,12 @@ BarWidget {
   QsMenuOpener {
     id: trayMenuOpener
     menu: root.activeTrayItem ? root.activeTrayItem.menu : null
+    onChildrenChanged: {
+      if (root.activeTrayItem && children.length > 0 && !root.trayMenuOpen)
+        root.trayMenuOpen = true
+      else if (root.trayMenuOpen && children.length === 0)
+        root.close()
+    }
   }
 
   PopupCard {

--- a/test/shell.d/tray-unready-sni-test.sh
+++ b/test/shell.d/tray-unready-sni-test.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tray="$ROOT/shell/plugins/bar/widgets/Tray.qml"
+
+open_tray_menu=$(sed -n '/^  function openTrayMenu(/,/^  function trayIconSource(/p' "$tray")
+normalized=$(tr '\n\r\t' '   ' <<<"$open_tray_menu")
+
+echo "$normalized" | grep -Eq 'item\.display\(' &&
+  fail "openTrayMenu still calls item.display when the SNI has no menu"
+
+echo "$normalized" | grep -Eq 'if *\( *!item *\|\| *!item\.menu *\) *return' ||
+  fail "openTrayMenu does not no-op when the SNI has no menu"
+
+echo "$normalized" | grep -Eq 'trayMenuOpen *= *trayMenuOpener\.children\.length *> *0' ||
+  fail "openTrayMenu still sets trayMenuOpen without opener children"
+
+opener=$(sed -n '/^  QsMenuOpener {/,/^  PopupCard {/p' "$tray")
+opener_n=$(tr '\n\r\t' '   ' <<<"$opener")
+
+echo "$opener_n" | grep -Eq 'onChildrenChanged' ||
+  fail "trayMenuOpener does not watch children for a late-ready SNI menu"
+
+echo "$opener_n" | grep -Eq 'children\.length *=== *0' ||
+  fail "trayMenuOpener does not close the grab when opener children drop to 0"
+
+pass "unready SNI tray clicks do not take HyprlandFocusGrab"


### PR DESCRIPTION
## Summary

Skip the tray HyprlandFocusGrab until the StatusNotifierItem menu has children.

Fixes #10676.

Unready SNIs (IconName/Menu Get still failing) have no menu handle. `openTrayMenu` used to call `item.display()` on that arm and set `trayMenuOpen` whenever a handle existed, so a click during app startup took the grab on an empty PopupCard.

Return without `display()` when there is no menu. Open the popup only once `QsMenuOpener` has children, and close it if those children drop to zero.

## Testing

- `tray-unready-sni-test.sh` FAIL on pinned quattro (display on unready) / PASS on this SHA
- Neighbor `tray-test.sh` PASS
