### PR TITLE
Label LimitRow as used and keep collector (est.)

### DIFF
--- a/shell/plugins/agents/Panel.qml
+++ b/shell/plugins/agents/Panel.qml
@@ -89,12 +89,18 @@ Panel {
   }
 
   function windowTitle(label) {
-    var text = String(label || "").toLowerCase()
-    if (text.indexOf("month") >= 0) return "Monthly"
-    if (windowIsLong(text)) return "Weekly"
-    if (text.indexOf("session") >= 0 || windowSpanMs(label) > 0) return "Session"
-    var plain = String(label || "").replace(/\s*\(.*\)\s*/, "").trim()
-    return plain === "" ? "Limit" : plain
+    var raw = String(label || "")
+    var text = raw.toLowerCase()
+    var estimated = /est\.?/i.test(raw)
+    var title
+    if (text.indexOf("month") >= 0) title = "Monthly"
+    else if (windowIsLong(text)) title = "Weekly"
+    else if (text.indexOf("session") >= 0 || windowSpanMs(label) > 0) title = "Session"
+    else {
+      var plain = raw.replace(/\s*\(.*\)\s*/, "").trim()
+      title = plain === "" ? "Limit" : plain
+    }
+    return estimated ? title + " (est.)" : title
   }
 
   // A collector that already knows which window a limit belongs to says so,
@@ -733,7 +739,7 @@ Panel {
         id: limitValue
         textFormat: Text.PlainText
         text: limitRow.window && limitRow.window.percent >= 0
-          ? Math.round(limitRow.window.percent * 100) + "%"
+          ? Math.round(limitRow.window.percent * 100) + "% used"
           : "—"
         color: limitRow.alarming ? root.urgent : root.foreground
         font.family: root.fontFamily

--- a/test/shell.d/agents-panel-test.sh
+++ b/test/shell.d/agents-panel-test.sh
@@ -14,4 +14,7 @@ assert(/if \(buttonCode === Qt\.RightButton\) root\.launchAgent\(\)/.test(panelS
 assert(/else if \(buttonCode === Qt\.MiddleButton\) root\.selectProvider\(root\.providerIndex \+ 1\)/.test(panelSource), 'agents middle click still advances the subscription')
 assert(/else root\.toggle\(\)/.test(panelSource), 'agents left click still toggles the panel')
 assert(!/if \(buttonCode === Qt\.RightButton\) root\.refreshNow\(\)/.test(panelSource), 'agents right click no longer refreshes')
+assert(/Math\.round\(limitRow\.window\.percent \* 100\) \+ "% used"/.test(panelSource), 'LimitRow percent states used')
+assert(/estimated \? title \+ " \(est\.\)" : title/.test(panelSource), 'windowTitle preserves est marker')
+assert(!/if \(text\.indexOf\("month"\) >= 0\) return "Monthly"/.test(panelSource), 'windowTitle no longer returns Monthly without est')
 JS


### PR DESCRIPTION
## Summary

Label Agents LIMITS meters as used and keep collector `(est.)` in the window title.

Fixes #10674.

LIMITS meters fill toward a cap (consumed) while BALANCE meters show what is left. LimitRow painted a bare `N%` so the two directions were unreadable. Collector labels like `Weekly (7-day, est.)` also lost the estimate marker in `windowTitle`.

Keep Meter fill-from-left and the prepaid remaining meter. Paint `N% used` on LimitRow and append ` (est.)` when the original label matches est.

## Testing

- `agents-panel-test.sh` FAIL on pinned quattro / PASS on this SHA
