### PR TITLE
Document that resize Super+Minus/Equal are physical AE11/AE12

### DIFF
--- a/manual/07-hotkeys.md
+++ b/manual/07-hotkeys.md
@@ -58,6 +58,8 @@ You can see all the main keyboard bindings with `Super + K` (Tmux bindings with 
 | `Ctrl + Alt + Tab`| Cycle focus forward through monitors |
 | `Ctrl + Alt + Shift + Tab`| Cycle focus backwards through monitors |
 
+Resize chords `Super + Minus` / `Super + Equal` (and Shift/Alt/Ctrl variants) are physical `code:20`/`code:21` (XKB `<AE11>`/`<AE12>`): US `-`/`=`; JIS `-`/`^`; Spanish `'`/`¡`. Shift follows those keys, not the printed `=` on JIS.
+
 ## System controls
 
 | Hotkey                  | Function              |

--- a/test/shell.d/hotkeys-resize-physical-test.sh
+++ b/test/shell.d/hotkeys-resize-physical-test.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+manual="$ROOT/manual/07-hotkeys.md"
+tiling="$ROOT/default/hypr/bindings/tiling.lua"
+
+grep -q 'Super + Minus' "$manual" || fail "manual still names Super + Minus"
+grep -q 'Super + Equal' "$manual" || fail "manual still names Super + Equal"
+grep -q 'code:20' "$manual" || fail "manual documents code:20 next to Minus/Equal"
+grep -q 'AE11' "$manual" || fail "manual documents AE11 next to Minus/Equal"
+grep -q 'code:21' "$manual" || fail "manual documents code:21 next to Equal"
+grep -q 'AE12' "$manual" || fail "manual documents AE12 next to Equal"
+
+grep -q 'SUPER + code:20' "$tiling" || fail "tiling.lua still binds SUPER + code:20"
+grep -q 'SUPER + code:21' "$tiling" || fail "tiling.lua still binds SUPER + code:21"
+if grep -E -q 'SUPER \+ MINUS|SUPER \+ EQUAL' "$tiling"; then
+  fail "tiling.lua retargeted resize to MINUS/EQUAL keysyms"
+fi
+
+pass "resize chords stay physical AE11/AE12 with documented aliases"


### PR DESCRIPTION
## Summary

Document that resize Super+Minus/Equal are physical AE11/AE12.

Fixes #10452.

The chords are bound as `code:20`/`code:21` in `tiling.lua`. The US names in `07-hotkeys.md` are aliases for those physical keys, not typed Minus/Equal. On JIS, `code:21` is `^` and Shift+- types `=`, so following the printed labels fires the vertical resize instead.

Keep the US names. Add one sentence that they are `code:20`/`code:21` (`<AE11>`/`<AE12>`), with JIS and Spanish printed keys. Do not retarget `tiling.lua` to MINUS/EQUAL keysyms. Super+K / menu-keybindings is a different surface.

## Testing

- `hotkeys-resize-physical-test.sh` FAIL on pinned quattro (Minus/Equal only) / PASS on this SHA (AE11/AE12 note present; tiling.lua keycodes unchanged)
