### PR TITLE
Fix keybindings scanner hanging on Hyprland list getters

### DIFF
--- a/bin/omarchy-menu-keybindings
+++ b/bin/omarchy-menu-keybindings
@@ -68,20 +68,24 @@ parse_keycodes() {
 
 # Supplement `hyprctl binds` for Lua-only binds that Hyprland currently
 # reports as dispatcher __lua and without their original key for code: binds.
+#
+# The scan runs the user's hyprland.lua under a stub `hl`, so whatever the
+# config reads from the compositor at load time comes back as stub values. A
+# config the stub still cannot satisfy is cut off after this many seconds
+# rather than left spinning a core after the menu has closed.
+LUA_BIND_SCAN_TIMEOUT="${OMARCHY_KEYBINDINGS_SCAN_TIMEOUT:-10}"
+LUA_BIND_SCAN_STATUS=""
+
 build_lua_bind_cache() {
-  local modmask description key dispatcher arg cache_key
+  local modmask description key dispatcher arg cache_key scan
+
+  # One scan per menu: a second pass finds the same binds, or times out again.
+  [[ -n $LUA_BIND_SCAN_STATUS ]] && return "$LUA_BIND_SCAN_STATUS"
+  LUA_BIND_SCAN_STATUS=0
 
   omarchy-cmd-present lua || return 0
 
-  while IFS=$'\t' read -r modmask description key dispatcher arg; do
-    [[ -z $modmask || -z $description || -z $key ]] && continue
-
-    LUA_BIND_KEY_MAP["$modmask,$description"]="$key"
-    cache_key="$modmask,$description,$key"
-    LUA_BIND_DISPATCHER_MAP["$cache_key"]="$dispatcher"
-    LUA_BIND_ARG_MAP["$cache_key"]="$arg"
-  done < <(
-    lua <<'LUA'
+  scan=$(timeout -k 2 "$LUA_BIND_SCAN_TIMEOUT" lua <<'LUA'
 local modifiers = { SHIFT = 1, CTRL = 4, CONTROL = 4, ALT = 8, SUPER = 64 }
 
 local function split_keys(keys)
@@ -184,9 +188,17 @@ local function dsp_proxy(path)
   })
 end
 
+-- Stand-in for every compositor value the config reads while the scan only
+-- wants its binds. A numeric index answers nil so `ipairs` over a stub value
+-- ends at once: a config looping over the result of a getter the stub does
+-- not name would otherwise never return.
 local noop
 noop = setmetatable({}, {
-  __index = function()
+  __index = function(_, key)
+    if type(key) == "number" then
+      return nil
+    end
+
     return noop
   end,
   __call = function()
@@ -220,6 +232,17 @@ hl = setmetatable({
   get_config = function()
     return nil
   end,
+  -- The list getters answer real empty tables, so `#`, `ipairs` and `pairs`
+  -- all see the empty compositor a scan stands in for.
+  get_monitors = function()
+    return {}
+  end,
+  get_windows = function()
+    return {}
+  end,
+  get_workspaces = function()
+    return {}
+  end,
 }, {
   __index = function()
     return noop
@@ -238,6 +261,24 @@ if file then
 end
 LUA
   )
+  LUA_BIND_SCAN_STATUS=$?
+
+  if (( LUA_BIND_SCAN_STATUS == 124 )); then
+    echo "omarchy-menu-keybindings: Lua bind scan timed out after ${LUA_BIND_SCAN_TIMEOUT}s; binds declared after the cut-off are missing from the menu" >&2
+  elif (( LUA_BIND_SCAN_STATUS != 0 )) && [[ $DEBUG == "1" ]]; then
+    echo "[DEBUG] lua bind scan exited with status $LUA_BIND_SCAN_STATUS" >&2
+  fi
+
+  while IFS=$'\t' read -r modmask description key dispatcher arg; do
+    [[ -z $modmask || -z $description || -z $key ]] && continue
+
+    LUA_BIND_KEY_MAP["$modmask,$description"]="$key"
+    cache_key="$modmask,$description,$key"
+    LUA_BIND_DISPATCHER_MAP["$cache_key"]="$dispatcher"
+    LUA_BIND_ARG_MAP["$cache_key"]="$arg"
+  done <<<"$scan"
+
+  return "$LUA_BIND_SCAN_STATUS"
 }
 
 modmask_to_text() {
@@ -509,9 +550,10 @@ dedupe_binding_records() {
 }
 
 output_binding_records_uncached() {
-  local dynamic
+  local dynamic scanned
 
   build_lua_bind_cache
+  scanned=$?
   dynamic=$(dynamic_bindings)
 
   {
@@ -524,8 +566,10 @@ output_binding_records_uncached() {
     prioritize_entries
 
   # Fail when Hyprland reported no binds so the fallout of a broken hyprctl
-  # is never cached.
-  [[ -n $dynamic ]]
+  # is never cached, and when the Lua scan was cut off so a menu missing the
+  # binds declared after the cut-off is not served from cache until the next
+  # binding change.
+  [[ -n $dynamic ]] && (( scanned == 0 ))
 }
 
 keybindings_cache_key() {

--- a/test/shell.d/keybindings-menu-lua-scan-test.sh
+++ b/test/shell.d/keybindings-menu-lua-scan-test.sh
@@ -1,0 +1,164 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command lua
+require_command xkbcli
+require_command setsid
+
+# The keybindings menu learns about Lua-only binds by running the user's
+# hyprland.lua under a stub `hl`. Configs read compositor state at load time,
+# and the stub has to hand back something those reads can finish with: a loop
+# over hl.get_monitors() that never ended left a `lua` at 100% CPU behind every
+# SUPER + K until reboot.
+
+tmpdir=$(mktemp -d) && [[ -n $tmpdir && -d $tmpdir ]] ||
+  fail "the test gets a temporary directory to stub Hyprland in"
+trap 'rm -rf "$tmpdir"' EXIT
+
+home="$tmpdir/home"
+stub_bin="$tmpdir/bin"
+cache="$tmpdir/cache"
+config="$home/.config/hypr/hyprland.lua"
+mkdir -p "$home/.config/hypr" "$stub_bin"
+
+lua_bind() {
+  printf 'bind\n\tmodmask: %s\n\tsubmap: \n\tkey: %s\n\tkeycode: 0\n\tcatchall: false\n\tdescription: %s\n\tdispatcher: __lua\n\targ: \n' "$1" "$2" "$3"
+}
+
+stub_hyprctl() {
+  {
+    echo '#!/bin/bash'
+    echo 'case "$1" in'
+    echo '  binds) cat <<'"'"'BINDS'"'"''
+    cat
+    echo 'BINDS'
+    echo '  ;;'
+    echo '  devices) echo "active keymap: English (US)" ;;'
+    echo 'esac'
+  } >"$stub_bin/hyprctl"
+  chmod +x "$stub_bin/hyprctl"
+}
+
+# Runs the menu against the fixture config with a cold cache. The run gets a
+# session of its own, so a scanner it leaves behind can be told apart from any
+# other `lua` on the machine, and a background job in a shell without job
+# control is not a group leader, so setsid makes the job itself the leader.
+keybindings() {
+  local pid started
+
+  rm -rf "$cache"
+  started=$(date +%s)
+  setsid env -i PATH="$stub_bin:$ROOT/bin:$PATH" HOME="$home" \
+    XDG_CACHE_HOME="$cache" OMARCHY_PATH="$ROOT" "$@" \
+    bash "$ROOT/bin/omarchy-menu-keybindings" --print >"$tmpdir/stdout" 2>"$tmpdir/stderr" &
+  pid=$!
+  wait "$pid" || true
+
+  elapsed=$(( $(date +%s) - started ))
+  rendered=$(<"$tmpdir/stdout")
+  errors=$(<"$tmpdir/stderr")
+  survivors=$(ps -o pid=,comm= --sid "$pid" 2>/dev/null || true)
+}
+
+# Every list getter the stub names, one it does not, and the numeric-index
+# shapes a config reaches for. Under a real Hyprland each of these terminates;
+# under the stub they used to spin forever.
+cat >"$config" <<'LUA'
+local seen = 0
+
+for _, monitor in ipairs(hl.get_monitors()) do
+  seen = seen + 1
+end
+
+for _, window in ipairs(hl.get_windows()) do
+  seen = seen + 1
+end
+
+for _, workspace in ipairs(hl.get_workspaces()) do
+  seen = seen + 1
+end
+
+for _, plugin in ipairs(hl.get_loaded_plugins()) do
+  seen = seen + 1
+end
+
+for index = 1, #hl.get_windows() do
+  seen = seen + 1
+end
+
+local cursor = hl.get_loaded_plugins()[1]
+while cursor do
+  seen = seen + 1
+  cursor = cursor.next
+end
+
+if seen ~= 0 then
+  error("stub lists should be empty")
+end
+
+-- String keys still chain, so reads of a single stub value keep working.
+if hl.get_active_monitor().name == nil then
+  error("stub values should still answer string keys")
+end
+
+hl.bind("SUPER + W", hl.dsp.kill_active(), { description = "Close window" })
+hl.bind("SUPER + Q", hl.dsp.kill_active(), { description = "Close window" })
+hl.bind("SUPER + code:20", hl.dsp.workspace({ name = "special" }), { description = "Lua only bind" })
+LUA
+
+# Hyprland reports the two Close window chords as dispatcher __lua, so they
+# only share a row once the scan has recovered what they run; the code: bind
+# arrives without its key, which the scan supplies too.
+stub_hyprctl <<BINDS
+$(lua_bind 64 "SUPER + W" "Close window")
+$(lua_bind 64 "SUPER + Q" "Close window")
+$(lua_bind 64 "" "Lua only bind")
+BINDS
+
+keybindings
+(( elapsed < 5 )) || fail "iterating stub list getters terminates" "took ${elapsed}s"
+[[ -z $survivors ]] || fail "iterating stub list getters leaves no scanner behind" "$survivors"
+[[ $errors != *"scan failed"* && $errors != *"timed out"* ]] ||
+  fail "iterating stub list getters does not abort the scan" "$errors"
+pass "iterating stub list getters terminates"
+
+grep -q 'SUPER + W / SUPER + Q  *→ Close window' <<<"$rendered" ||
+  fail "binds declared after load-time loops are still discovered" "$rendered"
+grep -q 'SUPER + MINUS  *→ Lua only bind' <<<"$rendered" ||
+  fail "a code: key declared after load-time loops is still recovered" "$rendered"
+pass "binds declared after load-time loops are still discovered"
+
+[[ -n $(find "$cache/omarchy" -maxdepth 1 -name 'keybindings-*.records' 2>/dev/null) ]] ||
+  fail "a scan that finished is cached"
+pass "a scan that finished is cached"
+
+# A config the stub still cannot satisfy: nothing in this loop indexes a
+# number, so no stub value can end it. The scan has to be cut off, the menu
+# has to open anyway with what Hyprland reported, and the cut-off result must
+# not be cached, or every later press would serve the incomplete menu.
+cat >"$config" <<'LUA'
+hl.bind("SUPER + W", hl.dsp.kill_active(), { description = "Close window" })
+
+while hl.get_active_monitor() do
+end
+
+hl.bind("SUPER + Q", hl.dsp.kill_active(), { description = "Close window" })
+LUA
+
+keybindings OMARCHY_KEYBINDINGS_SCAN_TIMEOUT=2
+(( elapsed < 8 )) || fail "a scan that never finishes is cut off" "took ${elapsed}s"
+[[ -z $survivors ]] || fail "a cut-off scan leaves no scanner behind" "$survivors"
+pass "a scan that never finishes is cut off"
+
+[[ $errors == *"timed out after 2s"* ]] ||
+  fail "a cut-off scan says so on stderr" "$errors"
+(( $(grep -c '→ Close window$' <<<"$rendered") == 2 )) ||
+  fail "the menu still opens with what Hyprland reported after a cut-off scan" "$rendered"
+pass "the menu still opens after a cut-off scan"
+
+[[ -z $(find "$cache/omarchy" -maxdepth 1 -name 'keybindings*' 2>/dev/null) ]] ||
+  fail "a cut-off scan is not cached" "$(ls -A "$cache/omarchy")"
+pass "a cut-off scan is not cached"


### PR DESCRIPTION
## Problem

`omarchy-menu-keybindings` discovers Lua-only binds by running `~/.config/hypr/hyprland.lua` in a standalone `lua` under a stub `hl`. Every lookup the stub does not model answers a truthy sentinel that also answers every key with itself, so:

```lua
for _, window in ipairs(hl.get_windows()) do end  -- never returns
```

`ipairs` stops at the first `nil`, and the sentinel never produces one. The same holds for `hl.get_monitors()`, `hl.get_workspaces()`, and any other getter the stub does not name. `pcall` cannot help because nothing raises. The scan has no timeout, so every `SUPER + K` starts another scan and nothing reaps the previous one. On the machine this was found on, 11 `lua` processes had each held a full core for about 82 minutes; the Hyprland config loaded a module that reconciles window state with `ipairs(hl.get_windows())` at startup, which is fine against the real API.

Isolated reproduction, no user config involved:

```lua
local noop
noop = setmetatable({}, {
  __index = function() return noop end,
  __call = function() return noop end,
})
local hl = setmetatable({}, { __index = function() return noop end })

local count = 0
for _ in ipairs(hl.get_windows()) do
  count = count + 1
  if count == 10000 then break end
end
assert(count == 10000)
assert(hl.get_windows()[10001] == noop)
```

## Fix

- `hl.get_monitors`, `hl.get_windows` and `hl.get_workspaces` are stubbed with functions returning fresh empty tables, next to the existing `get_config` stub, so `#`, `ipairs` and `pairs` see an empty compositor.
- The sentinel's `__index` answers `nil` for numeric keys, so `ipairs` over a getter the stub does not name (`hl.get_loaded_plugins()` came up in the issue) ends too. String keys still chain, and nothing in the scanner indexes the sentinel numerically.
- The scan runs under `timeout -k 2 10` (overridable with `OMARCHY_KEYBINDINGS_SCAN_TIMEOUT`), so a config the stub still cannot satisfy cannot outlive the menu. `lua` installs no `SIGTERM` handler, so the child goes away and nothing is left behind.
- A cut-off scan is reported on stderr, runs only once per menu (the cache-miss path used to call the scanner twice: once to fill the cache and once more as the fallback when filling fails), and is never cached: `output_binding_records_uncached` now fails when the scan did not finish, so the menu still opens with what `hyprctl binds` reported but the next press scans again instead of serving an incomplete menu until the next binding change.

Existing fallback behaviour is unchanged: a scan that finishes is cached exactly as before, and a broken `hyprctl` still refuses the cache.

## Validation

New `test/shell.d/keybindings-menu-lua-scan-test.sh` runs the real script against a stubbed `hyprctl` and isolated fixture configs in a throwaway `HOME`, in its own session so a leftover `lua` is detectable:

- `ipairs` over all three getters, over an unnamed getter, a `#`-bounded numeric loop and a `while cursor do cursor = cursor.next end` walk all terminate, and two `hl.bind` calls declared after them are still discovered (the chords merge onto one row, and a `code:` key is recovered).
- A finished scan is cached.
- A `while hl.get_active_monitor() do end` fixture is cut off within the bound, says so on stderr, leaves no `lua` in the session, still renders Hyprland's binds, and leaves neither a records file nor a `keybindings.XXXXXX` temp file in the cache.

Results on this branch:

- `bash test/shell.d/keybindings-menu-lua-scan-test.sh`: 6 ok in ~2 s.
- The same test against the unpatched script hangs until killed and leaves a `lua` at 99% CPU behind, which is the reported failure.
- `bash test/shell.d/keybindings-menu-test.sh`: 15 ok.
- `bash test/shell.d/bin-style-test.sh`, `./test/cli`, `bash -n` on both files, `git diff --check`: pass.
- `./test/shell`: 233 of 237 files pass. The four failures (`config`, `snapper`, `unowned-system-paths`, `locate`) fail identically on unmodified `quattro` in this checkout: three need a sibling `omarchy-pkgs` checkout and `locate-test.sh` trips on a non-UTF-8 local file.

## Relation to #7564 and #8876

Both open PRs make the sentinel answer `nil` for numeric keys, and #7564 adds `timeout 10`. This change keeps that mechanism and closes what they leave open:

- **A cut-off scan is never cached.** With `timeout` alone, a scan that is killed still produces a records file: the success test is only whether `hyprctl binds` returned anything, so the incomplete result is promoted to the cache and every later press serves it, silently missing every bind declared after the cut-off, until the next binding change. Here the scanner's status feeds the cache decision.
- **A cut-off scan is reported.** `pcall` cannot report an externally killed process, so with `timeout` alone nothing is printed even under `DEBUG=1`. Here the timeout is named on stderr, which reaches the journal when the menu is launched from a bind.
- **The scan runs once per menu.** The cache-miss path called the scanner twice: once to fill the cache, then again as the fallback when filling fails. With a timeout that fallback would cost a second full wait. Here the second call returns the first scan's result.
- **The three documented list getters are named** with real empty tables, next to the existing `get_config` stub.
- **The regression test drives the real script** with a stubbed `hyprctl`, in its own session, and asserts the cut-off leaves no `lua` behind and nothing in the cache.


Fixes #7025

🤖 Generated with [Claude Code](https://claude.com/claude-code)
