### PR TITLE
Make the Intel IPU6 camera work out of the box

### DIFF
--- a/bin/omarchy-hw-intel-ipu6
+++ b/bin/omarchy-hw-intel-ipu6
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# omarchy:summary=Detect whether the computer has an Intel IPU6 MIPI camera.
+
+[[ -d /sys/bus/pci/drivers/intel-ipu6 ]]

--- a/default/wireplumber/wireplumber.conf.d/ipu6-prefer-libcamera.conf
+++ b/default/wireplumber/wireplumber.conf.d/ipu6-prefer-libcamera.conf
@@ -1,0 +1,21 @@
+# Intel IPU6 exposes its sensor as dozens of raw Bayer /dev/video* nodes.
+# Browsers enumerate them and show a black or green frame. Turning the v4l2
+# monitor off leaves libcamera's software ISP as the only path to the sensor,
+# which is the one that produces a usable picture on this hardware. A USB
+# webcam still works: libcamera picks up UVC devices through its own uvcvideo
+# pipeline.
+#
+# This is deliberately the profile switch and not a monitor.v4l2.rules entry
+# setting device.disabled on the IPU6 device. Wireplumber's
+# monitors/v4l2/create-device.lua returns without calling transition:advance()
+# for a disabled device, so that async hook never completes and the event
+# dispatcher stalls for good. Everything queued behind it is dropped: the
+# libcamera camera node is never created, and if the sound card finishes
+# probing after that event its profile is never selected either, leaving the
+# machine with no camera and no built-in mic or speakers -- silently, with
+# only a log notice. Present in wireplumber 0.5.17 and master.
+wireplumber.profiles = {
+  main = {
+    monitor.v4l2 = disabled
+  }
+}

--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -19,6 +19,7 @@ run_logged "$OMARCHY_INSTALL/hardware/intel/thermald.sh"
 # and building all three against the stock kernel only to rebuild them against
 # linux-ptl and tear the first set down again cost ~25s of the install.
 run_logged "$OMARCHY_INSTALL/hardware/intel/ptl-kernel.sh"
+run_logged "$OMARCHY_INSTALL/hardware/intel/ipu6-camera.sh"
 run_logged "$OMARCHY_INSTALL/hardware/intel/ipu7-camera.sh"
 run_logged "$OMARCHY_INSTALL/hardware/intel/fred.sh"
 run_logged "$OMARCHY_INSTALL/hardware/intel/fix-wifi7-eht.sh"

--- a/install/hardware/intel/ipu6-camera.sh
+++ b/install/hardware/intel/ipu6-camera.sh
@@ -1,0 +1,11 @@
+# Install MIPI camera support for Intel IPU6 hardware
+#
+# The kernel drives IPU6 on its own, but only as raw Bayer /dev/video* nodes
+# that no browser or conferencing app can decode. libcamera's software ISP is
+# what turns them into a usable picture, and pipewire-libcamera is what puts
+# that in the PipeWire graph. Without both, an IPU6 laptop has no working
+# camera no matter which node you pick.
+
+if omarchy-hw-intel-ipu6; then
+  omarchy-pkg-add libcamera pipewire-libcamera
+fi

--- a/install/user/all.sh
+++ b/install/user/all.sh
@@ -8,6 +8,7 @@ run_logged "$OMARCHY_INSTALL/user/hardware/asus/fix-audio-mixer.sh"
 run_logged "$OMARCHY_INSTALL/user/hardware/asus/fix-mic.sh"
 run_logged "$OMARCHY_INSTALL/user/hardware/framework/fix-f13-amd-audio-input.sh"
 run_logged "$OMARCHY_INSTALL/user/hardware/dell/xps13-text-scaling.sh"
+run_logged "$OMARCHY_INSTALL/user/hardware/intel/ipu6-prefer-libcamera.sh"
 run_logged "$OMARCHY_INSTALL/user/hardware/fix-nouveau-cursor.sh"
 
 run_logged "$OMARCHY_INSTALL/user/default-keyring.sh"

--- a/install/user/hardware/intel/ipu6-prefer-libcamera.sh
+++ b/install/user/hardware/intel/ipu6-prefer-libcamera.sh
@@ -1,0 +1,8 @@
+# Route the IPU6 camera through libcamera instead of its raw v4l2 nodes, so
+# browsers stop picking a black or green Bayer node. See the drop-in for why
+# this disables the monitor rather than the device.
+
+if omarchy-hw-intel-ipu6; then
+  mkdir -p ~/.config/wireplumber/wireplumber.conf.d/
+  cp "$OMARCHY_PATH/default/wireplumber/wireplumber.conf.d/ipu6-prefer-libcamera.conf" ~/.config/wireplumber/wireplumber.conf.d/
+fi


### PR DESCRIPTION
## The problem

On IPU6 laptops — XPS 14/16 and most Meteor/Arrow Lake machines — Omarchy has no
usable camera out of the box. The kernel drives the sensor, but only as dozens of
raw Bayer `/dev/video*` nodes. Browsers enumerate those and show a black or green
frame. libcamera's software ISP is the only path that produces a picture, and
neither `libcamera` nor `pipewire-libcamera` is installed today.

IPU7 already gets hardware enablement in `install/hardware/intel/ipu7-camera.sh`.
This does the equivalent for IPU6, plus the WirePlumber side.

## What this does

- `bin/omarchy-hw-intel-ipu6` — gates on `/sys/bus/pci/drivers/intel-ipu6`. The
  driver name is version-specific, so it will not fire on the IPU7 hardware
  handled next door.
- `install/hardware/intel/ipu6-camera.sh` — installs `libcamera` and
  `pipewire-libcamera` when that gate passes.
- `default/wireplumber/wireplumber.conf.d/ipu6-prefer-libcamera.conf` — turns off
  the v4l2 monitor so libcamera owns the camera.
- `install/user/hardware/intel/ipu6-prefer-libcamera.sh` — copies the drop-in,
  mirroring the existing `asus/fix-audio-mixer.sh` pattern.
- Both registered in `install/hardware/all.sh` and `install/user/all.sh`.

USB webcams still work: libcamera picks up UVC devices through its own pipeline.

## Why the profile switch and not `device.disabled`

WirePlumber's docs suggest tagging the IPU6 device with `device.disabled` in
`monitor.v4l2.rules`. Please don't take that route here — it ships a silent
failure.

`monitors/v4l2/create-device.lua` returns from its `AsyncEventHook` step without
calling `transition:advance()` for a disabled device. The hook never completes,
so the event dispatcher stalls permanently and every event queued behind it is
dropped: the libcamera camera node is never created, and if the sound card
finishes probing after that event its profile is never selected either — leaving
the machine with no camera *and* no built-in mic or speakers. There is no error;
one log notice, then the daemon goes quiet.

Reported upstream, with the one-line fix:
https://gitlab.freedesktop.org/pipewire/wireplumber/-/issues/1010

Disabling the monitor at the profile level never enters that branch, so this is
correct both before and after upstream fixes it.

## Testing

Dell XPS 14 (DA14250, Arrow Lake, ov02c10 behind IPU6), kernel 7.2.3,
wireplumber 0.5.17, pipewire 1.6.8, libcamera 0.7.2. The gate returns true; with
the drop-in in place `wpctl status` shows a single `ov02c10 [libcamera]` device
and a "Built-in Front Camera" source, the raw `ipu6` nodes stay out of the graph,
and the camera works in Chrome. The drop-in is byte-identical, comments aside, to
the config that has been running on that machine.

Not tested on IPU7 hardware, and not tested with a USB webcam attached — UVC
should still arrive via libcamera, but I have not verified it.
