### PR TITLE
Clamp notification cards to the width their container has

### DIFF
--- a/shell/plugins/notifications/Service.qml
+++ b/shell/plugins/notifications/Service.qml
@@ -1041,6 +1041,11 @@ Item {
             NotificationCard {
               id: card
               anchors.right: parent.right
+              // The placement margins are the column's inset from both screen
+              // edges, so what is left is the room a card actually has.
+              maxWidth: popupWindow.width
+                        - popupWindow.popupPlacement.margins.left
+                        - popupWindow.popupPlacement.margins.right
               app: cardSlot.app
               appIcon: cardSlot.appIcon
               summary: cardSlot.summary

--- a/shell/plugins/notifications/components/NotificationCard.qml
+++ b/shell/plugins/notifications/components/NotificationCard.qml
@@ -30,6 +30,9 @@ BorderSurface {
   // System monospace font injected by the container.
   property string fontFamily: ""
 
+  // Maximum width, injected by the container. 0 is unconstrained.
+  property real maxWidth: 0
+
   readonly property bool hovered: hoverTracker.hovered
 
   signal closeRequested()
@@ -63,7 +66,8 @@ BorderSurface {
     return Quickshell.iconPath(value, true)
   }
 
-  implicitWidth: Style.space(380)
+  // Clamped so a card cannot outgrow its container on a narrow screen.
+  implicitWidth: maxWidth > 0 ? Math.min(Style.space(380), maxWidth) : Style.space(380)
   // Add vertical border insets so mainColumn (inset by border on top/left/right)
   // doesn't push content under the bottom edge.
   implicitHeight: mainColumn.implicitHeight + borderTop + borderBottom


### PR DESCRIPTION
Notification toasts overflow any screen narrower than the card.

`NotificationCard` sets `implicitWidth: Style.space(380)`. On a screen narrower than that the card is wider than the screen itself, and because the popup column is anchored **right**, the overflow lands on the **left** edge — so the border and the first character of every line are cut off:

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/SimonSchubert/omarchy-mobile/main/docs/screenshots/notifications-before.png" width="300"> | <img src="https://raw.githubusercontent.com/SimonSchubert/omarchy-mobile/main/docs/screenshots/notifications-after.png" width="300"> |

## The change

`NotificationCard.qml`'s header says it is *"Pure presentational"*, and `cornerRadius` and `fontFamily` are already injected by the container — so the width limit arrives the same way rather than the card reaching for `Screen`:

```qml
// NotificationCard.qml — 0 leaves the card at its natural width
property real maxWidth: 0
implicitWidth: maxWidth > 0 ? Math.min(Style.space(380), maxWidth) : Style.space(380)

// Service.qml — the container knows how much room it has
maxWidth: popupWindow.width
          - popupWindow.popupPlacement.margins.left
          - popupWindow.popupPlacement.margins.right
```

The margins come from `popupPlacement`, which the container already computes, so there is no magic factor — and it stays correct when the bar is on the right edge, where `margins.right` becomes the bar clearance rather than the gap.

## Why it is safe

- `maxWidth` defaults to `0`, which is treated as unconstrained, so any other caller of `NotificationCard` is unchanged.
- On a desktop the limit is far wider than 380, so `Math.min` returns `Style.space(380)` and the toast is identical to today's.
- The card stays presentational — it gains a property, not a dependency.

## Verification

Per `agents/skills/visual-verification.md`, checked in the running shell (`omarchy-restart-shell`, then `notify-send`) at both ends:

- **720x1440 at scale 2** (360 logical): cards clamp to 350, wrap, and keep their borders — the "after" image above.
- **1920x1080 at scale 1**: `maxWidth` is 1910, `Math.min` returns 380, toast unchanged.

Found while running Omarchy on a phone-shaped screen, but it is a narrow-screen robustness fix rather than a mobile-specific one — nothing in it is aware of the form factor.