### PR TITLE
Toggle keybindings with Super+K

### DIFF
--- a/bin/omarchy-menu-keybindings
+++ b/bin/omarchy-menu-keybindings
@@ -654,7 +654,7 @@ dispatch_binding() {
 
 if [[ $1 == "--print" || $1 == "-p" ]]; then
   output_keybindings
-else
+elif [[ $(omarchy-shell shell call omarchy.menu closeDmenu Keybindings) != "ok" ]]; then
   records=$(output_binding_records)
   selection=$(cut -f1 <<<"$records" |
     omarchy-menu-select 'Keybindings' -- --width 800 --height 500)

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -35,6 +35,12 @@ Item {
     root.cancel()
   }
 
+  function closeDmenu(prompt) {
+    if (!root.opened || !root.dmenuActive || root.dmenuPrompt !== prompt) return "noop"
+    root.cancel()
+    return "ok"
+  }
+
   function refresh() {
     defaultMenuFile.reload()
     userMenuFile.reload()


### PR DESCRIPTION
Close the keybindings menu when Super+K is pressed again. Leave other menus and `--print` unchanged.

Verified opening, closing, and reopening in the live shell. Menu/keybindings tests pass. Ran `./test/all`; five environment/cleanup failures passed on rerun.
