### PR TITLE
Harden FIDO2 setup against cached sudo reuse

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ Three documentation trees, split by genre and audience:
 - Prefer `(( ))` over numeric operators inside `[[ ]]` (e.g., `(( count < 50 ))`, not `[[ $count -lt 50 ]]`)
 - Prefer a full `if`/`else` conditional for simple two-path control flow; don't rely on `exec` or `exit` in one branch to make following statements unreachable
 - For strings/paths with spaces, quote them instead of escaping spaces with `\ ` (e.g., `"$APP_DIR/Disk Usage.desktop"`, not `$APP_DIR/Disk\ Usage.desktop`)
-- Shebangs must use `#!/bin/bash` consistently (never `#!/usr/bin/env bash`)
+- Shebangs must use `#!/bin/bash` consistently (never `#!/usr/bin/env bash`). A security-sensitive entrypoint may use the exact `#!/bin/bash -p` form only when it must suppress `BASH_ENV` and exported-function startup injection before its first command; that exception must be explained at the boundary and covered by a regression that rejects an ordinary Bash launch with a decoy `-p` argument.
 - Scripts under `install/` and `migrations/` may be sourced and intentionally omit shebangs
 
 # Command Naming

--- a/bin/omarchy
+++ b/bin/omarchy
@@ -1,4 +1,12 @@
-#!/bin/bash
+#!/bin/bash -p
+
+# The public router can dispatch security-sensitive commands. Its shebang must
+# take effect before Bash can process inherited startup hooks, and an ordinary
+# Bash launch with a decoy -p argument must not reach a command that opens a
+# reusable sudo authorization window.
+security_entrypoint=$(/usr/bin/readlink -e -- "${BASH_SOURCE[0]}") || exit 126
+source "${security_entrypoint%/*}/omarchy-security-functions" || exit 126
+omarchy_security_require_privileged_bash_startup || exit 126
 
 set -o pipefail
 

--- a/bin/omarchy
+++ b/bin/omarchy
@@ -6,7 +6,7 @@
 # reusable sudo authorization window.
 security_entrypoint=$(/usr/bin/readlink -e -- "${BASH_SOURCE[0]}") || exit 126
 source "${security_entrypoint%/*}/omarchy-security-functions" || exit 126
-omarchy_security_require_privileged_bash_startup || exit 126
+omarchy_security_require_privileged_bash_startup "$security_entrypoint" || exit 126
 
 set -o pipefail
 

--- a/bin/omarchy
+++ b/bin/omarchy
@@ -10,7 +10,7 @@ omarchy_security_require_privileged_bash_startup "$security_entrypoint" || exit 
 
 set -o pipefail
 
-OMARCHY_BIN_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+OMARCHY_BIN_DIR=$(cd -- "$(/usr/bin/dirname -- "${BASH_SOURCE[0]}")" && pwd)
 METADATA_SCAN_LIMIT=80
 
 COMMAND_KEYS=()

--- a/bin/omarchy-launch-floating-terminal-with-presentation
+++ b/bin/omarchy-launch-floating-terminal-with-presentation
@@ -5,9 +5,11 @@
 
 # Export the current theme's gum styling so gum widgets match the active theme
 # even after a theme switch (the inherited environment is captured at login).
-source omarchy-restart-gum
+source "$OMARCHY_PATH/bin/omarchy-restart-gum"
 
 cmd="$*"
-presentation_script="omarchy-show-logo; $cmd; if (( \$? != 130 )); then omarchy-show-done; fi"
+logo_command=$(printf '%q' "$OMARCHY_PATH/bin/omarchy-show-logo")
+done_command=$(printf '%q' "$OMARCHY_PATH/bin/omarchy-show-done")
+presentation_script="$logo_command; $cmd; if (( \$? != 130 )); then $done_command; fi"
 
 exec setsid uwsm-app -- xdg-terminal-exec --app-id=org.omarchy.terminal --title=Omarchy -e bash -c "$presentation_script"

--- a/bin/omarchy-launch-floating-terminal-with-presentation
+++ b/bin/omarchy-launch-floating-terminal-with-presentation
@@ -1,17 +1,34 @@
-#!/bin/bash
+#!/bin/bash -p
 
 # omarchy:summary=Launch a floating terminal with the Omarchy presentation wrapper
 # omarchy:args=[--cold-sudo] <command>
 
+# The shebang's -p must take effect before Bash can process inherited startup
+# hooks that would otherwise run ahead of cold-sudo invalidation.
+if [[ $- != *p* ]]; then
+  echo "Refusing an unsafe Bash startup for the presentation wrapper." >&2
+  exit 126
+fi
+
+security_entrypoint=$(/usr/bin/readlink -e -- "${BASH_SOURCE[0]}") || exit 126
+source "${security_entrypoint%/*}/omarchy-security-functions" || exit 126
+omarchy_security_require_privileged_bash_startup || exit 126
+omarchy_security_require_source_root "$security_entrypoint" || exit 126
+
 # Security-sensitive flows can revoke any reusable sudo authorization before
 # presentation helpers or the terminal launcher get a chance to run.
 if [[ ${1:-} == "--cold-sudo" ]]; then
+  omarchy_security_sanitize_bash_environment "$0" "$@" || exit 126
+  PATH="$OMARCHY_PATH/bin:/usr/local/bin:/usr/bin:/bin"
+  export PATH
+
   if ! /usr/bin/sudo -k >/dev/null; then
     echo "Unable to launch with a cold sudo credential state." >&2
     exit 1
   fi
 
   shift
+  cold_sudo=true
 fi
 
 # Export the current theme's gum styling so gum widgets match the active theme
@@ -23,4 +40,8 @@ logo_command=$(printf '%q' "$OMARCHY_PATH/bin/omarchy-show-logo")
 done_command=$(printf '%q' "$OMARCHY_PATH/bin/omarchy-show-done")
 presentation_script="$logo_command; $cmd; if (( \$? != 130 )); then $done_command; fi"
 
-exec setsid uwsm-app -- xdg-terminal-exec --app-id=org.omarchy.terminal --title=Omarchy -e bash -c "$presentation_script"
+if [[ ${cold_sudo:-false} == "true" ]]; then
+  exec /usr/bin/setsid /usr/bin/uwsm-app -- /usr/bin/xdg-terminal-exec --app-id=org.omarchy.terminal --title=Omarchy -e /usr/bin/bash -p -c "$presentation_script"
+else
+  exec setsid uwsm-app -- xdg-terminal-exec --app-id=org.omarchy.terminal --title=Omarchy -e bash -c "$presentation_script"
+fi

--- a/bin/omarchy-launch-floating-terminal-with-presentation
+++ b/bin/omarchy-launch-floating-terminal-with-presentation
@@ -1,7 +1,18 @@
 #!/bin/bash
 
 # omarchy:summary=Launch a floating terminal with the Omarchy presentation wrapper
-# omarchy:args=<command>
+# omarchy:args=[--cold-sudo] <command>
+
+# Security-sensitive flows can revoke any reusable sudo authorization before
+# presentation helpers or the terminal launcher get a chance to run.
+if [[ ${1:-} == "--cold-sudo" ]]; then
+  if ! /usr/bin/sudo -k >/dev/null; then
+    echo "Unable to launch with a cold sudo credential state." >&2
+    exit 1
+  fi
+
+  shift
+fi
 
 # Export the current theme's gum styling so gum widgets match the active theme
 # even after a theme switch (the inherited environment is captured at login).

--- a/bin/omarchy-launch-floating-terminal-with-presentation
+++ b/bin/omarchy-launch-floating-terminal-with-presentation
@@ -12,13 +12,13 @@ fi
 
 security_entrypoint=$(/usr/bin/readlink -e -- "${BASH_SOURCE[0]}") || exit 126
 source "${security_entrypoint%/*}/omarchy-security-functions" || exit 126
-omarchy_security_require_privileged_bash_startup || exit 126
+omarchy_security_require_privileged_bash_startup "$security_entrypoint" || exit 126
 omarchy_security_require_source_root "$security_entrypoint" || exit 126
 
 # Security-sensitive flows can revoke any reusable sudo authorization before
 # presentation helpers or the terminal launcher get a chance to run.
 if [[ ${1:-} == "--cold-sudo" ]]; then
-  omarchy_security_sanitize_bash_environment "$0" "$@" || exit 126
+  omarchy_security_sanitize_bash_environment "$security_entrypoint" "$@" || exit 126
   PATH="$OMARCHY_PATH/bin:/usr/local/bin:/usr/bin:/bin"
   export PATH
 

--- a/bin/omarchy-launch-floating-terminal-with-presentation
+++ b/bin/omarchy-launch-floating-terminal-with-presentation
@@ -1,7 +1,7 @@
 #!/bin/bash -p
 
 # omarchy:summary=Launch a floating terminal with the Omarchy presentation wrapper
-# omarchy:args=[--cold-sudo] <command>
+# omarchy:args=[--cold-sudo] <command> [args...]
 
 # The shebang's -p must take effect before Bash can process inherited startup
 # hooks that would otherwise run ahead of cold-sudo invalidation.
@@ -35,7 +35,12 @@ fi
 # even after a theme switch (the inherited environment is captured at login).
 source "$OMARCHY_PATH/bin/omarchy-restart-gum"
 
-cmd="$*"
+if [[ ${cold_sudo:-false} == "true" ]]; then
+  printf -v cmd '%q ' "$@"
+  cmd=${cmd% }
+else
+  cmd="$*"
+fi
 logo_command=$(printf '%q' "$OMARCHY_PATH/bin/omarchy-show-logo")
 done_command=$(printf '%q' "$OMARCHY_PATH/bin/omarchy-show-done")
 presentation_script="$logo_command; $cmd; if (( \$? != 130 )); then $done_command; fi"

--- a/bin/omarchy-pkg-add
+++ b/bin/omarchy-pkg-add
@@ -1,17 +1,41 @@
 #!/bin/bash
 
 # omarchy:summary=Install Arch packages if they are missing
-# omarchy:args=<packages...>
+# omarchy:args=[--revoke-sudo] <packages...>
 # omarchy:examples=omarchy pkg add jq ripgrep
 # omarchy:requires-sudo=true
 
+revoke_sudo=false
+if [[ ${1:-} == "--revoke-sudo" ]]; then
+  revoke_sudo=true
+  shift
+fi
+
+install_status=0
 if omarchy-pkg-missing "$@"; then
   if (( EUID == 0 )); then
-    pacman -S --noconfirm --needed "$@" || exit 1
+    if pacman -S --noconfirm --needed "$@"; then
+      install_status=0
+    else
+      install_status=$?
+    fi
   else
-    sudo pacman -S --noconfirm --needed "$@" || exit 1
+    if sudo pacman -S --noconfirm --needed "$@"; then
+      install_status=0
+    else
+      install_status=$?
+    fi
   fi
 fi
+
+if [[ $revoke_sudo == "true" ]]; then
+  if ! sudo -k >/dev/null; then
+    echo "Failed to invalidate sudo credentials after package installation." >&2
+    exit 1
+  fi
+fi
+
+(( install_status == 0 )) || exit "$install_status"
 
 for pkg in "$@"; do
   # Secondary check to handle states where pacman doesn't actually register an error

--- a/bin/omarchy-restart-gum
+++ b/bin/omarchy-restart-gum
@@ -11,8 +11,10 @@ _omarchy_gum_env="$HOME/.local/state/omarchy/current/theme/gum_env.lua"
 
 if [[ -f $_omarchy_gum_env ]]; then
   while IFS=$'\t' read -r _omarchy_gum_key _omarchy_gum_value; do
-    [[ -n $_omarchy_gum_key && -n $_omarchy_gum_value ]] && export "$_omarchy_gum_key=$_omarchy_gum_value"
-  done < <(awk -F'"' '/hl\.env\("[A-Z0-9_]+", "[^"]+"\)/ { print $2 "\t" $4 }' "$_omarchy_gum_env")
+    if [[ $_omarchy_gum_key =~ ^(FOREGROUND|BACKGROUND|BORDER_(FOREGROUND|BACKGROUND)|GUM_[A-Z0-9_]+)$ && -n $_omarchy_gum_value ]]; then
+      export "$_omarchy_gum_key=$_omarchy_gum_value"
+    fi
+  done < <(/usr/bin/awk -F'"' '/hl\.env\("[A-Z0-9_]+", "[^"]+"\)/ { print $2 "\t" $4 }' "$_omarchy_gum_env")
 fi
 
 unset _omarchy_gum_env _omarchy_gum_key _omarchy_gum_value

--- a/bin/omarchy-security-functions
+++ b/bin/omarchy-security-functions
@@ -9,14 +9,22 @@ if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
 fi
 
 omarchy_security_require_privileged_bash_startup() {
-  [[ $- == *p* ]] || return 1
+  local script=${1:-}
+
+  [[ $- == *p* && -n $script ]] || return 1
+  # Privileged mode alone is insufficient: a parent `bash -p -c` can define
+  # callbacks and then source the protected script. Require Bash's script
+  # operand to resolve to this exact entrypoint as well.
   /usr/bin/env -i /usr/bin/bash -p -c '
     mapfile -d "" -t argv <"/proc/$1/cmdline" || exit 1
     executable=$(/usr/bin/readlink -e -- "/proc/$1/exe") || exit 1
+    script_index=2
+    [[ ${argv[script_index]:-} == "--" ]] && script_index=3
+    script=$(/usr/bin/readlink -e -- "${argv[script_index]:-}") || exit 1
     [[ $executable == "/usr/bin/bash" &&
       ( ${argv[0]:-} == "/bin/bash" || ${argv[0]:-} == "/usr/bin/bash" ) &&
-      ${argv[1]:-} == "-p" ]]
-  ' omarchy-bash-startup "$$"
+      ${argv[1]:-} == "-p" && $script == "$2" ]]
+  ' omarchy-bash-startup "$$" "$script"
 }
 
 omarchy_security_sanitize_bash_environment() {

--- a/bin/omarchy-security-functions
+++ b/bin/omarchy-security-functions
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# omarchy:hidden=true
+# omarchy:summary=Provide internal helpers for command-scoped sudo authentication
+
+if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
+  echo "omarchy-security-functions is an internal function library." >&2
+  exit 64
+fi
+
+omarchy_security_require_privileged_bash_startup() {
+  [[ $- == *p* ]] || return 1
+  /usr/bin/env -i /usr/bin/bash -p -c '
+    mapfile -d "" -t argv <"/proc/$1/cmdline" || exit 1
+    executable=$(/usr/bin/readlink -e -- "/proc/$1/exe") || exit 1
+    [[ $executable == "/usr/bin/bash" &&
+      ( ${argv[0]:-} == "/bin/bash" || ${argv[0]:-} == "/usr/bin/bash" ) &&
+      ${argv[1]:-} == "-p" ]]
+  ' omarchy-bash-startup "$$"
+}
+
+omarchy_security_sanitize_bash_environment() {
+  local script=$1
+  shift
+  local entry name environment_fd environment_pid
+  local -a unsets=()
+
+  # Read the raw environment: privileged Bash ignores exported functions, but
+  # leaves their records for ordinary child interpreters to import later.
+  exec {environment_fd}< <(/usr/bin/env -0)
+  environment_pid=$!
+  while IFS= read -r -d '' entry <&"$environment_fd"; do
+    name=${entry%%=*}
+    case "$name" in
+      BASH_ENV|ENV|SHELLOPTS|BASHOPTS|PS4|CDPATH|GLOBIGNORE|BASH_FUNC_*%%)
+        unsets+=(-u "$name")
+        ;;
+    esac
+  done
+  exec {environment_fd}<&-
+  wait "$environment_pid" || return 1
+  if (( ${#unsets[@]} > 0 )); then
+    exec /usr/bin/env "${unsets[@]}" /usr/bin/bash -p -- "$script" "$@"
+  fi
+}
+
+omarchy_security_require_source_root() {
+  local command_source command_name=${1##*/}
+  command_source=$(/usr/bin/readlink -e -- "$1") || return 1
+
+  # A runtime root selects the code used by this invocation. Accept the
+  # canonical checkout containing the entrypoint or the package's bin links.
+  if [[ ${OMARCHY_PATH:-} != /* || $(/usr/bin/realpath -e -- "$OMARCHY_PATH") != "$OMARCHY_PATH" ]] ||
+    ! { [[ $command_source == "$OMARCHY_PATH/bin/$command_name" ]] ||
+      [[ $OMARCHY_PATH == "/usr/share/omarchy" && $command_source == "/usr/bin/$command_name" ]]; }; then
+    echo "OMARCHY_PATH does not match this Omarchy command." >&2
+    return 1
+  fi
+}

--- a/bin/omarchy-security-functions
+++ b/bin/omarchy-security-functions
@@ -45,15 +45,30 @@ omarchy_security_sanitize_bash_environment() {
 }
 
 omarchy_security_require_source_root() {
-  local command_source command_name=${1##*/}
+  local command_source command_name=${1##*/} package_command="" runtime_command="" runtime_root=""
   command_source=$(/usr/bin/readlink -e -- "$1") || return 1
+  runtime_root=$(/usr/bin/realpath -e -- "${OMARCHY_PATH:-}" 2>/dev/null) || runtime_root=""
+  if [[ -n $runtime_root ]]; then
+    runtime_command=$(/usr/bin/readlink -e -- "$runtime_root/bin/$command_name" 2>/dev/null) || runtime_command=""
+  fi
+  package_command=$(/usr/bin/readlink -e -- "/usr/share/omarchy/bin/$command_name" 2>/dev/null) || package_command=""
 
-  # A runtime root selects the code used by this invocation. Accept the
-  # canonical checkout containing the entrypoint or the package's bin links.
-  if [[ ${OMARCHY_PATH:-} != /* || $(/usr/bin/realpath -e -- "$OMARCHY_PATH") != "$OMARCHY_PATH" ]] ||
-    ! { [[ $command_source == "$OMARCHY_PATH/bin/$command_name" ]] ||
-      [[ $OMARCHY_PATH == "/usr/share/omarchy" && $command_source == "/usr/bin/$command_name" ]]; }; then
+  # The Quattro live-upgrade shim leaves existing sessions pointing at a
+  # user-owned compatibility tree whose bin entries resolve to /usr/bin.
+  # Accept that alias only when it resolves to this exact packaged command,
+  # then discard the mutable alias before any runtime helpers are selected.
+  if [[ $runtime_command != "$command_source" ]]; then
     echo "OMARCHY_PATH does not match this Omarchy command." >&2
     return 1
   fi
+
+  if [[ $command_source == "/usr/bin/$command_name" && $package_command == "$command_source" ]]; then
+    OMARCHY_PATH=/usr/share/omarchy
+  elif [[ $command_source == "$runtime_root/bin/$command_name" ]]; then
+    OMARCHY_PATH="$runtime_root"
+  else
+    echo "OMARCHY_PATH does not match this Omarchy command." >&2
+    return 1
+  fi
+  export OMARCHY_PATH
 }

--- a/bin/omarchy-setup-security-fido2
+++ b/bin/omarchy-setup-security-fido2
@@ -12,12 +12,12 @@ fi
 
 security_entrypoint=$(/usr/bin/readlink -e -- "${BASH_SOURCE[0]}") || exit 126
 source "${security_entrypoint%/*}/omarchy-security-functions" || exit 126
-omarchy_security_require_privileged_bash_startup || exit 126
+omarchy_security_require_privileged_bash_startup "$security_entrypoint" || exit 126
 
 set -e
 set -o pipefail
 
-omarchy_security_sanitize_bash_environment "$0" "$@" || exit 126
+omarchy_security_sanitize_bash_environment "$security_entrypoint" "$@" || exit 126
 omarchy_security_require_source_root "$security_entrypoint" || exit 126
 
 # Do not let user-controlled PATH entries run while package authorization may
@@ -82,18 +82,33 @@ check_fido2_hardware() {
   return 0
 }
 
-setup_pam_config() {
-  # Configure sudo
+inspect_pam_config() {
+  configure_sudo_pam=false
+  polkit_pam_action=""
+
   if ! /usr/bin/grep -q pam_u2f.so /etc/pam.d/sudo; then
+    configure_sudo_pam=true
+  fi
+
+  if [[ -f /etc/pam.d/polkit-1 ]]; then
+    if ! /usr/bin/grep -q pam_u2f.so /etc/pam.d/polkit-1; then
+      polkit_pam_action=configure
+    fi
+  else
+    polkit_pam_action=create
+  fi
+}
+
+apply_pam_config() {
+  if [[ $configure_sudo_pam == "true" ]]; then
     echo "Configuring sudo for FIDO2 authentication..."
     /usr/bin/sudo sed -i '1i auth    sufficient pam_u2f.so cue authfile=/etc/fido2/fido2' /etc/pam.d/sudo
   fi
 
-  # Configure polkit
-  if [[ -f /etc/pam.d/polkit-1 ]] && ! /usr/bin/grep -q 'pam_u2f.so' /etc/pam.d/polkit-1; then
+  if [[ $polkit_pam_action == "configure" ]]; then
     echo "Configuring polkit for FIDO2 authentication..."
     /usr/bin/sudo sed -i '1i auth      sufficient pam_u2f.so cue authfile=/etc/fido2/fido2' /etc/pam.d/polkit-1
-  elif [[ ! -f /etc/pam.d/polkit-1 ]]; then
+  elif [[ $polkit_pam_action == "create" ]]; then
     echo "Creating polkit configuration with FIDO2 authentication..."
     /usr/bin/sudo tee /etc/pam.d/polkit-1 >/dev/null <<'EOF'
 auth      sufficient pam_u2f.so cue authfile=/etc/fido2/fido2
@@ -110,7 +125,7 @@ echo -e "\e[32mSetting up FIDO2 device for authentication.\n\e[0m"
 
 # Install required packages
 echo "Installing required packages..."
-"$OMARCHY_PATH/bin/omarchy-pkg-add" libfido2 pam-u2f
+"$OMARCHY_PATH/bin/omarchy-pkg-add" --revoke-sudo libfido2 pam-u2f
 
 # Package installation may have opened a reusable sudo timestamp. Close it
 # before running either FIDO2 utility in the user process.
@@ -143,7 +158,9 @@ if [[ -L $authfile || ( -e $authfile && ! -f $authfile ) ]]; then
   exit 1
 fi
 
+registration_needed=false
 if [[ ! -f $authfile ]]; then
+  registration_needed=true
   echo -e "\e[32m\nLet's setup your device by confirming on the device now.\e[0m"
   echo -e "Touch your FIDO2 key when it lights up...\n"
 
@@ -151,7 +168,14 @@ if [[ ! -f $authfile ]]; then
     echo -e "\e[31m\nFIDO2 registration failed. Please try again.\e[0m"
     exit 1
   fi
+fi
 
+# Finish every unprivileged external probe before opening the configuration
+# sudo window. From the first privileged write through the invalidation below,
+# only shell builtins and fixed sudo invocations may run in this process.
+inspect_pam_config
+
+if [[ $registration_needed == "true" ]]; then
   /usr/bin/sudo install -d -m 755 -o root -g root "$authdir"
 
   # A unique sibling created by root cannot be replaced by another process
@@ -182,7 +206,7 @@ else
 fi
 
 # Configure PAM
-setup_pam_config
+apply_pam_config
 
 # The configuration sudo timestamp must not satisfy the authentication test.
 if ! invalidate_sudo_credentials; then

--- a/bin/omarchy-setup-security-fido2
+++ b/bin/omarchy-setup-security-fido2
@@ -1,10 +1,24 @@
-#!/bin/bash
+#!/bin/bash -p
 
 # omarchy:summary=Set up FIDO2 authentication for sudo and polkit
 # omarchy:requires-sudo=true
 
+# The shebang's -p must take effect before Bash can process inherited startup
+# hooks that would otherwise run ahead of FIDO2's sudo isolation.
+if [[ $- != *p* ]]; then
+  echo "Refusing an unsafe Bash startup for FIDO2 setup." >&2
+  exit 126
+fi
+
+security_entrypoint=$(/usr/bin/readlink -e -- "${BASH_SOURCE[0]}") || exit 126
+source "${security_entrypoint%/*}/omarchy-security-functions" || exit 126
+omarchy_security_require_privileged_bash_startup || exit 126
+
 set -e
 set -o pipefail
+
+omarchy_security_sanitize_bash_environment "$0" "$@" || exit 126
+omarchy_security_require_source_root "$security_entrypoint" || exit 126
 
 # Do not let user-controlled PATH entries run while package authorization may
 # still be reusable by a child process.

--- a/bin/omarchy-setup-security-fido2
+++ b/bin/omarchy-setup-security-fido2
@@ -6,9 +6,61 @@
 set -e
 set -o pipefail
 
+# Do not let user-controlled PATH entries run while package authorization may
+# still be reusable by a child process.
+PATH="$OMARCHY_PATH/bin:/usr/local/bin:/usr/bin:/bin"
+export PATH
+
+authdir=/etc/fido2
+authfile=/etc/fido2/fido2
+stage=""
+
+safe_stage_path() {
+  local candidate=$1
+  local prefix="$authfile.new."
+  local suffix
+
+  [[ $candidate == "$prefix"* ]] || return 1
+  suffix=${candidate#"$prefix"}
+  [[ $suffix =~ ^[[:alnum:]]{6}$ ]]
+}
+
+invalidate_sudo_credentials() {
+  /usr/bin/sudo -k >/dev/null
+}
+
+cleanup_fido2_setup() {
+  local status=$?
+
+  trap - EXIT HUP INT TERM
+
+  if safe_stage_path "$stage"; then
+    if ! /usr/bin/sudo rm -f -- "$stage"; then
+      echo "Failed to remove the incomplete FIDO2 registration." >&2
+      (( status != 0 )) || status=1
+    fi
+  fi
+
+  if ! invalidate_sudo_credentials; then
+    echo "Failed to invalidate sudo credentials after FIDO2 setup." >&2
+    (( status != 0 )) || status=1
+  fi
+
+  exit "$status"
+}
+
+trap cleanup_fido2_setup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+if ! invalidate_sudo_credentials; then
+  echo "Unable to start FIDO2 setup with a cold sudo credential state." >&2
+  exit 1
+fi
 
 check_fido2_hardware() {
-  tokens=$(fido2-token -L 2>/dev/null)
+  tokens=$(/usr/bin/fido2-token -L 2>/dev/null)
   if [[ -z $tokens ]]; then
     echo -e "\e[31m\nNo FIDO2 device detected. Please plug it in (you may need to unlock it as well).\e[0m"
     return 1
@@ -18,18 +70,18 @@ check_fido2_hardware() {
 
 setup_pam_config() {
   # Configure sudo
-  if ! grep -q pam_u2f.so /etc/pam.d/sudo; then
+  if ! /usr/bin/grep -q pam_u2f.so /etc/pam.d/sudo; then
     echo "Configuring sudo for FIDO2 authentication..."
-    sudo sed -i '1i auth    sufficient pam_u2f.so cue authfile=/etc/fido2/fido2' /etc/pam.d/sudo
+    /usr/bin/sudo sed -i '1i auth    sufficient pam_u2f.so cue authfile=/etc/fido2/fido2' /etc/pam.d/sudo
   fi
 
   # Configure polkit
-  if [[ -f /etc/pam.d/polkit-1 ]] && ! grep -q 'pam_u2f.so' /etc/pam.d/polkit-1; then
+  if [[ -f /etc/pam.d/polkit-1 ]] && ! /usr/bin/grep -q 'pam_u2f.so' /etc/pam.d/polkit-1; then
     echo "Configuring polkit for FIDO2 authentication..."
-    sudo sed -i '1i auth      sufficient pam_u2f.so cue authfile=/etc/fido2/fido2' /etc/pam.d/polkit-1
+    /usr/bin/sudo sed -i '1i auth      sufficient pam_u2f.so cue authfile=/etc/fido2/fido2' /etc/pam.d/polkit-1
   elif [[ ! -f /etc/pam.d/polkit-1 ]]; then
     echo "Creating polkit configuration with FIDO2 authentication..."
-    sudo tee /etc/pam.d/polkit-1 >/dev/null <<'EOF'
+    /usr/bin/sudo tee /etc/pam.d/polkit-1 >/dev/null <<'EOF'
 auth      sufficient pam_u2f.so cue authfile=/etc/fido2/fido2
 auth      required pam_unix.so
 
@@ -44,15 +96,18 @@ echo -e "\e[32mSetting up FIDO2 device for authentication.\n\e[0m"
 
 # Install required packages
 echo "Installing required packages..."
-omarchy-pkg-add libfido2 pam-u2f
+"$OMARCHY_PATH/bin/omarchy-pkg-add" libfido2 pam-u2f
+
+# Package installation may have opened a reusable sudo timestamp. Close it
+# before running either FIDO2 utility in the user process.
+if ! invalidate_sudo_credentials; then
+  echo "Unable to isolate FIDO2 setup from package authorization." >&2
+  exit 1
+fi
 
 if ! check_fido2_hardware; then
   exit 1
 fi
-
-# Create the pamu2fcfg file
-authdir=/etc/fido2
-authfile=/etc/fido2/fido2
 
 # install -d follows a symlink here and applies the mode and ownership to
 # whatever it points at, so the credential would be staged and published inside
@@ -75,55 +130,34 @@ if [[ -L $authfile || ( -e $authfile && ! -f $authfile ) ]]; then
 fi
 
 if [[ ! -f $authfile ]]; then
-  sudo install -d -m 755 -o root -g root "$authdir"
   echo -e "\e[32m\nLet's setup your device by confirming on the device now.\e[0m"
   echo -e "Touch your FIDO2 key when it lights up...\n"
 
+  if ! credential=$(/usr/bin/pamu2fcfg) || [[ -z $credential ]]; then
+    echo -e "\e[31m\nFIDO2 registration failed. Please try again.\e[0m"
+    exit 1
+  fi
+
+  /usr/bin/sudo install -d -m 755 -o root -g root "$authdir"
+
   # A unique sibling created by root cannot be replaced by another process
-  # running as this user. Stream pamu2fcfg into it instead of asking root to
-  # reopen a caller-owned path: an observed temporary name could otherwise be
-  # replaced with a symlink before the privileged copy. The final rename is
-  # atomic, and -T refuses a directory at the destination. Mode 644 keeps the
-  # root-owned global authfile readable when pam_u2f uses openasuser; only root
-  # can still rewrite it.
-  stage=""
-
-  # mktemp's output is an operand for four privileged commands below, one of
-  # them an rm. Take only the name this script asked for rather than whatever
-  # came back on stdout.
-  safe_stage_path() {
-    local candidate=$1
-    local prefix="$authfile.new."
-    local suffix
-
-    [[ $candidate == "$prefix"* ]] || return 1
-    suffix=${candidate#"$prefix"}
-    [[ $suffix =~ ^[[:alnum:]]{6}$ ]]
-  }
-
-  cleanup_stage() {
-    local status=$?
-
-    if safe_stage_path "$stage"; then
-      sudo rm -f -- "$stage" || true
-    fi
-
-    return "$status"
-  }
-
-  trap cleanup_stage EXIT
-  stage=$(sudo mktemp "$authfile.new.XXXXXX")
+  # running as this user. Capture pamu2fcfg while sudo is cold, then stream its
+  # result into that sibling instead of asking root to reopen a caller-owned
+  # path: an observed temporary name could otherwise be replaced with a symlink
+  # before the privileged copy. The final rename is atomic, and -T refuses a
+  # directory at the destination. Mode 644 keeps the root-owned global authfile
+  # readable when pam_u2f uses openasuser; only root can still rewrite it.
+  stage=$(/usr/bin/sudo mktemp "$authfile.new.XXXXXX")
 
   if ! safe_stage_path "$stage" || [[ ! -f $stage || -L $stage ]]; then
     echo -e "\e[31m\nCould not create a safe staging file beside $authfile.\e[0m"
     exit 1
   fi
 
-  if pamu2fcfg | sudo tee "$stage" >/dev/null && [[ -s $stage ]]; then
-    sudo chmod 644 "$stage"
-    sudo mv -Tf "$stage" "$authfile"
+  if printf '%s\n' "$credential" | /usr/bin/sudo tee "$stage" >/dev/null && [[ -s $stage ]]; then
+    /usr/bin/sudo chmod 644 "$stage"
+    /usr/bin/sudo mv -Tf "$stage" "$authfile"
     stage=""
-    trap - EXIT
     echo -e "\e[32mFIDO2 device registered successfully!\e[0m"
   else
     echo -e "\e[31m\nFIDO2 registration failed. Please try again.\e[0m"
@@ -136,11 +170,17 @@ fi
 # Configure PAM
 setup_pam_config
 
+# The configuration sudo timestamp must not satisfy the authentication test.
+if ! invalidate_sudo_credentials; then
+  echo "Unable to start the FIDO2 authentication test with a cold sudo credential state." >&2
+  exit 1
+fi
+
 # Test with sudo
 echo -e "\nTesting FIDO2 authentication with sudo..."
 echo -e "Touch your FIDO2 key when prompted.\n"
 
-if sudo echo "FIDO2 authentication test successful"; then
+if /usr/bin/sudo echo "FIDO2 authentication test successful"; then
   echo -e "\e[32m\nPerfect! FIDO2 authentication is now configured.\e[0m"
   echo "You can use your FIDO2 key for sudo and polkit authentication."
 else

--- a/config/omarchy/extensions/omarchy-menu.jsonc
+++ b/config/omarchy/extensions/omarchy-menu.jsonc
@@ -9,6 +9,7 @@
   //   icon        Nerd Font glyph shown in the icon column.
   //   label       Visible row title.
   //   action      Shell command to run. If omitted, the row is a submenu.
+  //   actionArgv  Command and string arguments as an array, run without a shell. It takes precedence over action; use [] to clear an inherited argv action.
   //   target      Existing submenu id to open. Use for links/aliases.
   //   provider    Name of a shell-defined runtime row source (e.g. "fonts").
   //   aliases     alternate `omarchy menu summon <name>` routes; also searchable.
@@ -20,6 +21,7 @@
   // "personal": {"icon":"","label":"Personal"},
   // "personal.notes": {"icon":"󰎞","label":"Notes","action":"omarchy-launch-editor ~/notes"},
   // "personal.files": {"icon":"","label":"Files","action":"uwsm-app -- nautilus ~/Documents"},
+  // "personal.safe": {"icon":"","label":"Safe command","actionArgv":["$OMARCHY_PATH/bin/omarchy-version"]},
   //
   // provider can only reference row sources the shell already defines (the
   // providers map in Menu.qml). Static submenus only need dotted ids.

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -180,7 +180,7 @@
   "setup.security": {"icon":"","label":"Security"},
   "setup.config": {"icon":"","label":"Config"},
   "setup.security.fingerprint": {"icon":"󰈷","label":"Fingerprint","when":"omarchy-hw-fingerprint","action":"omarchy-launch-floating-terminal-with-presentation omarchy-setup-security-fingerprint"},
-  "setup.security.fido2": {"icon":"","label":"Fido2","action":"omarchy-launch-floating-terminal-with-presentation omarchy-setup-security-fido2"},
+  "setup.security.fido2": {"icon":"","label":"Fido2","action":"\"$OMARCHY_PATH/bin/omarchy-launch-floating-terminal-with-presentation\" --cold-sudo \"$OMARCHY_PATH/bin/omarchy-setup-security-fido2\""},
   "setup.security.sshd": {"icon":"󰣀","label":"SSHD","action":"omarchy-launch-floating-terminal-with-presentation omarchy-setup-security-sshd"},
   "setup.security.passwordless-sudo": {"icon":"󰟵","label":"Passwordless Sudo","action":"omarchy-launch-floating-terminal-with-presentation omarchy-sudo-passwordless"},
   "setup.security.sudoless-docker": {"icon":"󰡨","label":"Sudoless Docker","when":"omarchy-sudo-docker --configured","action":"omarchy-launch-floating-terminal-with-presentation omarchy-setup-security-sudoless-docker"},

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -180,7 +180,7 @@
   "setup.security": {"icon":"","label":"Security"},
   "setup.config": {"icon":"","label":"Config"},
   "setup.security.fingerprint": {"icon":"󰈷","label":"Fingerprint","when":"omarchy-hw-fingerprint","action":"omarchy-launch-floating-terminal-with-presentation omarchy-setup-security-fingerprint"},
-  "setup.security.fido2": {"icon":"","label":"Fido2","action":"\"$OMARCHY_PATH/bin/omarchy-launch-floating-terminal-with-presentation\" --cold-sudo \"$OMARCHY_PATH/bin/omarchy-setup-security-fido2\""},
+  "setup.security.fido2": {"icon":"","label":"Fido2","actionArgv":["$OMARCHY_PATH/bin/omarchy-launch-floating-terminal-with-presentation","--cold-sudo","$OMARCHY_PATH/bin/omarchy-setup-security-fido2"]},
   "setup.security.sshd": {"icon":"󰣀","label":"SSHD","action":"omarchy-launch-floating-terminal-with-presentation omarchy-setup-security-sshd"},
   "setup.security.passwordless-sudo": {"icon":"󰟵","label":"Passwordless Sudo","action":"omarchy-launch-floating-terminal-with-presentation omarchy-sudo-passwordless"},
   "setup.security.sudoless-docker": {"icon":"󰡨","label":"Sudoless Docker","when":"omarchy-sudo-docker --configured","action":"omarchy-launch-floating-terminal-with-presentation omarchy-setup-security-sudoless-docker"},

--- a/docs/menu.md
+++ b/docs/menu.md
@@ -26,7 +26,7 @@ is no separate parent field to keep in sync — where an entry appears follows
 from what it is called (an explicit `parent` is accepted but nothing shipped
 uses one).
 
-Kind is inferred rather than declared: an entry with `action` is an action,
+Kind is inferred rather than declared: an entry with `action` or `actionArgv` is an action,
 one with `target` is a link to another submenu, and anything else is a
 submenu. The fields:
 
@@ -37,11 +37,14 @@ submenu. The fields:
 | `label` | Visible row title; defaults to the id |
 | `title` | Header text when the submenu is open; defaults to `label`. Lets a row read "Browser" under Defaults while the open menu says "Default Browser" |
 | `action` | Shell command to run, detached, when selected |
+| `actionArgv` | Command and arguments to run directly without a shell; a leading `$OMARCHY_PATH` token in an argument expands to the runtime root |
 | `target` | Existing submenu id to open; makes the row a link |
 | `provider` | Runtime row source for this submenu (see Providers) |
 | `aliases` | Alternate `omarchy menu summon <name>` routes; also searchable |
 | `description` | Subtitle shown while searching, and extra search text matched by whole word |
 | `when` / `checked` / `disabled` | Shell conditions (see Guards) |
+
+Use `actionArgv` for fixed security-sensitive commands that must not run login-shell startup files before their own entrypoint. Each array element remains one argument, including paths with spaces.
 
 Do not add `aliases` to new entries. They are reserved for established
 alternate names users already type (`power-menu`, `settings`), kept for

--- a/docs/menu.md
+++ b/docs/menu.md
@@ -26,9 +26,7 @@ is no separate parent field to keep in sync — where an entry appears follows
 from what it is called (an explicit `parent` is accepted but nothing shipped
 uses one).
 
-Kind is inferred rather than declared: an entry with `action` or `actionArgv` is an action,
-one with `target` is a link to another submenu, and anything else is a
-submenu. The fields:
+Kind is inferred rather than declared: an entry with `action` or `actionArgv` is an action, one with `target` is a link to another submenu, and anything else is a submenu. The fields:
 
 | Field | Meaning |
 |---|---|
@@ -37,14 +35,14 @@ submenu. The fields:
 | `label` | Visible row title; defaults to the id |
 | `title` | Header text when the submenu is open; defaults to `label`. Lets a row read "Browser" under Defaults while the open menu says "Default Browser" |
 | `action` | Shell command to run, detached, when selected |
-| `actionArgv` | Command and arguments to run directly without a shell; a leading `$OMARCHY_PATH` token in an argument expands to the runtime root |
+| `actionArgv` | Array of a command and its arguments to run directly without a shell; a leading `$OMARCHY_PATH` token in an argument expands to the runtime root |
 | `target` | Existing submenu id to open; makes the row a link |
 | `provider` | Runtime row source for this submenu (see Providers) |
 | `aliases` | Alternate `omarchy menu summon <name>` routes; also searchable |
 | `description` | Subtitle shown while searching, and extra search text matched by whole word |
 | `when` / `checked` / `disabled` | Shell conditions (see Guards) |
 
-Use `actionArgv` for fixed security-sensitive commands that must not run login-shell startup files before their own entrypoint. Each array element remains one argument, including paths with spaces.
+Use `actionArgv` for fixed security-sensitive commands that must not run login-shell startup files before their own entrypoint. Every element must be a string and the command must be nonempty; otherwise the vector is ignored. Each later string remains one argument, including empty strings and paths with spaces. When an entry has both fields, `actionArgv` takes precedence; set it to `[]` explicitly when replacing an argv action with a shell `action` in a user override.
 
 Do not add `aliases` to new entries. They are reserved for established
 alternate names users already type (`power-menu`, `settings`), kept for

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -134,11 +134,15 @@ Item {
     resultProc.running = true
   }
 
-  function runAction(action) {
-    var command = String(action || "")
-    if (!command) return
-
-    Util.execDetached(command)
+  function runAction(action, actionArgv) {
+    var argv = MenuModel.expandActionArgv(actionArgv, root.omarchyPath)
+    if (argv.length > 0) {
+      Quickshell.execDetached(argv)
+    } else {
+      var command = String(action || "")
+      if (!command) return
+      Util.execDetached(command)
+    }
   }
 
   // Menu rows only surface their detail while a search is narrowing them;
@@ -822,10 +826,11 @@ Item {
   function applySelected(id, action) {
     if (!id) { cancel(); return }
 
+    var entry = root.item(id)
     applySerial = requestSerial
     opened = false
     filterText = ""
-    root.runAction(action)
+    root.runAction(action, entry ? entry.actionArgv : [])
   }
 
   function cancel() {
@@ -898,9 +903,9 @@ Item {
     // If the resolved id is an action (i.e. the user invoked an alias for
     // a leaf, e.g. `omarchy menu summon screenrecord-stop`), run it directly
     // instead of opening an action with no children.
-    if (entry && entry.kind === "action" && entry.action) {
+    if (entry && entry.kind === "action") {
       root.cancel()
-      root.runAction(entry.action)
+      root.runAction(entry.action, entry.actionArgv)
       return "ok"
     }
     // If it's a link (a redirect to another menu), follow the link.

--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -11,8 +11,11 @@ function normalizeAliases(value) {
 }
 
 function normalizeActionArgv(value) {
-  if (!Array.isArray(value)) return []
-  return value.filter(function(argument) { return typeof argument === "string" && argument.length > 0 })
+  if (!Array.isArray(value) || typeof value[0] !== "string" || !value[0]) return []
+  for (var i = 0; i < value.length; i++) {
+    if (typeof value[i] !== "string") return []
+  }
+  return value.slice()
 }
 
 function expandActionArgv(value, omarchyPath) {
@@ -37,6 +40,7 @@ function normalizeItem(id, raw) {
   var kind = value.action || actionArgv.length > 0 ? "action" : (value.target ? "link" : "menu")
 
   return {
+    _definedFields: Object.keys(value),
     id: id,
     parent: parent,
     kind: kind,
@@ -91,11 +95,24 @@ function mergeMenuSources(defaultItems, userItems) {
       var entry = src[i]
       if (!entry || !entry.id) continue
       if (!nextItems[entry.id]) nextOrder.push(entry.id)
-      var prior = nextItems[entry.id] || {}
+      var prior = nextItems[entry.id] || null
       var merged = {}
-      for (var k in prior) merged[k] = prior[k]
-      for (var k2 in entry) merged[k2] = entry[k2]
+      if (prior) {
+        for (var k in prior) merged[k] = prior[k]
+      }
+
+      if (s === 1 && prior && Array.isArray(entry._definedFields)) {
+        for (var f = 0; f < entry._definedFields.length; f++) {
+          var field = entry._definedFields[f]
+          if (field !== "kind" && Object.prototype.hasOwnProperty.call(entry, field)) merged[field] = entry[field]
+        }
+      } else {
+        for (var k2 in entry) merged[k2] = entry[k2]
+      }
+
+      delete merged._definedFields
       merged.id = entry.id
+      merged.kind = merged.action || normalizeActionArgv(merged.actionArgv).length > 0 ? "action" : (merged.target ? "link" : "menu")
       nextItems[entry.id] = merged
     }
   }

--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -10,15 +10,31 @@ function normalizeAliases(value) {
   return []
 }
 
+function normalizeActionArgv(value) {
+  if (!Array.isArray(value)) return []
+  return value.filter(function(argument) { return typeof argument === "string" && argument.length > 0 })
+}
+
+function expandActionArgv(value, omarchyPath) {
+  var argv = normalizeActionArgv(value)
+  var token = "$OMARCHY_PATH"
+  return argv.map(function(argument) {
+    if (argument === token || argument.indexOf(token + "/") === 0)
+      return String(omarchyPath || "") + argument.slice(token.length)
+    return argument
+  })
+}
+
 function normalizeItem(id, raw) {
   var value = raw || {}
   var aliases = normalizeAliases(value.aliases)
+  var actionArgv = normalizeActionArgv(value.actionArgv)
   var parent = value.parent
   if (parent === undefined)
     parent = id.indexOf(".") >= 0 ? id.split(".").slice(0, -1).join(".") : "root"
   if (id === "root") parent = ""
 
-  var kind = value.action ? "action" : (value.target ? "link" : "menu")
+  var kind = value.action || actionArgv.length > 0 ? "action" : (value.target ? "link" : "menu")
 
   return {
     id: id,
@@ -31,6 +47,7 @@ function normalizeItem(id, raw) {
     target: value.target || "",
     description: value.description || "",
     action: value.action || "",
+    actionArgv: actionArgv,
     provider: value.provider || "",
     aliases: aliases,
     when: value.when || "",
@@ -84,7 +101,7 @@ function mergeMenuSources(defaultItems, userItems) {
   }
 
   if (!nextItems.root) {
-    nextItems.root = { id: "root", parent: "", kind: "menu", icon: "", iconFont: "", label: "Go", title: "", target: "", description: "", aliases: [], when: "", checked: "", disabled: "", action: "", provider: "" }
+    nextItems.root = { id: "root", parent: "", kind: "menu", icon: "", iconFont: "", label: "Go", title: "", target: "", description: "", aliases: [], when: "", checked: "", disabled: "", action: "", actionArgv: [], provider: "" }
     nextOrder.unshift("root")
   }
   for (var k3 = 0; k3 < nextOrder.length; k3++) nextItems[nextOrder[k3]].order = k3
@@ -496,6 +513,8 @@ if (typeof module !== "undefined") {
     guardScript: guardScript,
     stripJsonc: stripJsonc,
     normalizeAliases: normalizeAliases,
+    normalizeActionArgv: normalizeActionArgv,
+    expandActionArgv: expandActionArgv,
     normalizeItem: normalizeItem,
     parseMenuJsonc: parseMenuJsonc,
     mergeMenuSources: mergeMenuSources,

--- a/test/cli
+++ b/test/cli
@@ -124,7 +124,7 @@ assert_output_contains "bare root command with children renders help" "$output" 
 assert_output_contains "bare toggle help includes child route" "$output" "omarchy toggle nightlight"
 
 output=$("$CLI" pkg --help)
-assert_output_contains "package group includes pkg add fallback route" "$output" "omarchy pkg add <packages...>"
+assert_output_contains "package group includes pkg add fallback route" "$output" "omarchy pkg add [--revoke-sudo] <packages...>"
 
 output=$("$CLI" restart --help)
 assert_output_contains "restart group includes inferred commands" "$output" "omarchy restart btop"
@@ -227,7 +227,7 @@ pass "aliases are included in JSON metadata"
 
 output=$("$CLI" pkg add --help)
 assert_output_contains "pkg add help resolves" "$output" "omarchy-pkg-add"
-assert_output_contains "pkg add help shows direct route" "$output" "omarchy pkg add <packages...>"
+assert_output_contains "pkg add help shows direct route" "$output" "omarchy pkg add [--revoke-sudo] <packages...>"
 
 output=$("$CLI" system reboot --help)
 assert_output_contains "system command help is safe" "$output" "omarchy-system-reboot"

--- a/test/shell.d/floating-terminal-test.sh
+++ b/test/shell.d/floating-terminal-test.sh
@@ -48,6 +48,8 @@ gum_state=$(
 pass "gum theme loading cannot replace execution-control environment variables"
 
 launcher="$ROOT/bin/omarchy-launch-floating-terminal-with-presentation"
+grep -Fq 'omarchy_security_sanitize_bash_environment "$security_entrypoint" "$@"' "$launcher" ||
+  fail "presentation wrapper re-executes through its canonical entrypoint"
 cold_root="$tmp_dir/omarchy root"
 launcher_copy="$cold_root/bin/omarchy-launch-floating-terminal-with-presentation"
 sudo_invalidated="$tmp_dir/sudo-invalidated"
@@ -68,6 +70,10 @@ unsafe_startup_status=0
 /usr/bin/bash "$launcher_copy" -p >/dev/null 2>&1 || unsafe_startup_status=$?
 (( unsafe_startup_status == 126 )) ||
   fail "presentation wrapper rejects an ordinary Bash launch with a decoy -p argument" "got status $unsafe_startup_status"
+sourced_startup_status=0
+/usr/bin/bash -p -c 'source "$1"' omarchy-source-test "$launcher_copy" >/dev/null 2>&1 || sourced_startup_status=$?
+(( sourced_startup_status == 126 )) ||
+  fail "presentation wrapper rejects being sourced by a privileged parent shell" "got status $sourced_startup_status"
 pass "presentation wrapper requires a verified privileged Bash startup"
 
 mismatched_root_status=0

--- a/test/shell.d/floating-terminal-test.sh
+++ b/test/shell.d/floating-terminal-test.sh
@@ -28,15 +28,53 @@ pass "floating terminal launches Omarchy terminal"
   fail "floating terminal fixes the completion callback to the Omarchy tree" "$launch"
 pass "floating terminal presentation callbacks bypass the user PATH"
 
+gum_home="$tmp_dir/gum-home"
+mkdir -p "$gum_home/.local/state/omarchy/current/theme"
+cat >"$gum_home/.local/state/omarchy/current/theme/gum_env.lua" <<'LUA'
+hl.env("FOREGROUND", "7")
+hl.env("GUM_INPUT_PROMPT_FOREGROUND", "6")
+hl.env("PATH", "/theme-controlled")
+hl.env("BASH_ENV", "/theme-controlled/bash-env")
+LUA
+
+gum_state=$(
+  HOME="$gum_home" PATH="/usr/bin:/bin" BASH_ENV="/inherited/bash-env" /usr/bin/bash -p -c '
+    source "$1"
+    printf "%s\t%s\t%s\t%s\n" "$PATH" "$BASH_ENV" "$FOREGROUND" "$GUM_INPUT_PROMPT_FOREGROUND"
+  ' omarchy-gum-test "$ROOT/bin/omarchy-restart-gum"
+)
+[[ $gum_state == $'/usr/bin:/bin\t/inherited/bash-env\t7\t6' ]] ||
+  fail "gum theme loading exports only presentation variables" "$gum_state"
+pass "gum theme loading cannot replace execution-control environment variables"
+
 launcher="$ROOT/bin/omarchy-launch-floating-terminal-with-presentation"
-launcher_copy="$tmp_dir/launcher"
 cold_root="$tmp_dir/omarchy"
+launcher_copy="$cold_root/bin/omarchy-launch-floating-terminal-with-presentation"
 sudo_invalidated="$tmp_dir/sudo-invalidated"
 mkdir -p "$cold_root/bin"
 
 occurrences=$(grep -Foc '/usr/bin/sudo' "$launcher") || occurrences=0
 (( occurrences == 1 )) || fail "floating terminal names fixed sudo exactly once" "found $occurrences occurrences"
-sed "s|/usr/bin/sudo|$tmp_dir/sudo|" "$launcher" >"$launcher_copy"
+occurrences=$(grep -Foc '/usr/bin/setsid' "$launcher") || occurrences=0
+(( occurrences == 1 )) || fail "cold floating terminal names fixed setsid exactly once" "found $occurrences occurrences"
+sed -e "s|/usr/bin/sudo|$tmp_dir/sudo|" \
+  -e "s|/usr/bin/setsid|$tmp_dir/setsid|" \
+  "$launcher" >"$launcher_copy"
+cp "$ROOT/bin/omarchy-security-functions" "$cold_root/bin/omarchy-security-functions"
+
+[[ $(head -n 1 "$launcher") == '#!/bin/bash -p' ]] ||
+  fail "presentation wrapper requests privileged Bash at the kernel boundary"
+unsafe_startup_status=0
+/usr/bin/bash "$launcher_copy" -p >/dev/null 2>&1 || unsafe_startup_status=$?
+(( unsafe_startup_status == 126 )) ||
+  fail "presentation wrapper rejects an ordinary Bash launch with a decoy -p argument" "got status $unsafe_startup_status"
+pass "presentation wrapper requires a verified privileged Bash startup"
+
+mismatched_root_status=0
+OMARCHY_PATH="$tmp_dir/mismatched-root" /usr/bin/bash -p "$launcher_copy" >/dev/null 2>&1 || mismatched_root_status=$?
+(( mismatched_root_status == 126 )) ||
+  fail "presentation wrapper rejects a mismatched Omarchy source root" "got status $mismatched_root_status"
+pass "presentation wrapper binds runtime helpers to its own source root"
 
 cat >"$tmp_dir/sudo" <<'SCRIPT'
 #!/bin/bash
@@ -59,10 +97,24 @@ done
 
 chmod +x "$launcher_copy" "$tmp_dir/sudo" "$cold_root/bin"/*
 : >"$TEST_LOG"
-TEST_SUDO_INVALIDATED="$sudo_invalidated" OMARCHY_PATH="$cold_root" "$launcher_copy" --cold-sudo "echo hello"
+startup_poison="$tmp_dir/cold-bash-env"
+poison_calls="$tmp_dir/poison-calls"
+cat >"$startup_poison" <<'SCRIPT'
+if [[ -e $TEST_SUDO_INVALIDATED ]]; then
+  printf '%s\n' bash-env-after-sudo-invalidation >>"$TEST_POISON_CALLS"
+fi
+SCRIPT
+
+/usr/bin/env TEST_LOG="$TEST_LOG" TEST_POISON_CALLS="$poison_calls" \
+  TEST_SUDO_INVALIDATED="$sudo_invalidated" OMARCHY_PATH="$cold_root" \
+  BASH_ENV="$startup_poison" ENV="$startup_poison" \
+  'BASH_FUNC_printf%%=() { if [[ -e $TEST_SUDO_INVALIDATED ]]; then builtin echo exported-printf-after-sudo-invalidation >>"$TEST_POISON_CALLS"; fi; builtin printf "$@"; }' \
+  "$launcher_copy" --cold-sudo "echo hello"
 
 mapfile -t calls <"$TEST_LOG"
 [[ ${calls[0]:-} == $'sudo\t-k' ]] || fail "cold presentation launch invalidates sudo first" "$(<"$TEST_LOG")"
 [[ ${calls[1]:-} == "restart-gum" ]] || fail "cold presentation launch invalidates sudo before theming" "$(<"$TEST_LOG")"
 [[ ${calls[2]:-} == $'setsid\t'* ]] || fail "cold presentation launch invalidates sudo before terminal launch" "$(<"$TEST_LOG")"
-pass "cold presentation launch revokes sudo before pre-entry callbacks"
+[[ ! -s $poison_calls ]] ||
+  fail "cold presentation launch preserves inherited Bash callbacks" "$(<"$poison_calls")"
+pass "cold presentation launch sanitizes Bash state and revokes sudo before pre-entry callbacks"

--- a/test/shell.d/floating-terminal-test.sh
+++ b/test/shell.d/floating-terminal-test.sh
@@ -9,7 +9,7 @@ trap 'rm -rf "$tmp_dir"' EXIT
 
 cat >"$tmp_dir/setsid" <<'SCRIPT'
 #!/bin/bash
-printf '%s\n' "$*" >"$TEST_LOG"
+printf 'setsid\t%s\n' "$*" >>"$TEST_LOG"
 SCRIPT
 chmod +x "$tmp_dir/setsid"
 
@@ -18,7 +18,7 @@ export PATH="$tmp_dir:$ROOT/bin:$PATH"
 
 OMARCHY_PATH="$ROOT" "$ROOT/bin/omarchy-launch-floating-terminal-with-presentation" "echo hello"
 
-launch=$(<"$TEST_LOG")
+launch=$(tail -n 1 "$TEST_LOG")
 [[ $launch == *"xdg-terminal-exec --app-id=org.omarchy.terminal"* ]] || fail "floating terminal launches Omarchy terminal" "$launch"
 pass "floating terminal launches Omarchy terminal"
 
@@ -27,3 +27,42 @@ pass "floating terminal launches Omarchy terminal"
 [[ $launch == *"then $ROOT/bin/omarchy-show-done; fi"* ]] ||
   fail "floating terminal fixes the completion callback to the Omarchy tree" "$launch"
 pass "floating terminal presentation callbacks bypass the user PATH"
+
+launcher="$ROOT/bin/omarchy-launch-floating-terminal-with-presentation"
+launcher_copy="$tmp_dir/launcher"
+cold_root="$tmp_dir/omarchy"
+sudo_invalidated="$tmp_dir/sudo-invalidated"
+mkdir -p "$cold_root/bin"
+
+occurrences=$(grep -Foc '/usr/bin/sudo' "$launcher") || occurrences=0
+(( occurrences == 1 )) || fail "floating terminal names fixed sudo exactly once" "found $occurrences occurrences"
+sed "s|/usr/bin/sudo|$tmp_dir/sudo|" "$launcher" >"$launcher_copy"
+
+cat >"$tmp_dir/sudo" <<'SCRIPT'
+#!/bin/bash
+printf 'sudo\t%s\n' "$*" >>"$TEST_LOG"
+: >"$TEST_SUDO_INVALIDATED"
+SCRIPT
+
+cat >"$cold_root/bin/omarchy-restart-gum" <<'SCRIPT'
+#!/bin/bash
+if [[ ! -e $TEST_SUDO_INVALIDATED ]]; then
+  printf 'restart-gum-before-sudo\n' >>"$TEST_LOG"
+else
+  printf 'restart-gum\n' >>"$TEST_LOG"
+fi
+SCRIPT
+
+for command in omarchy-show-logo omarchy-show-done; do
+  printf '#!/bin/bash\nexit 0\n' >"$cold_root/bin/$command"
+done
+
+chmod +x "$launcher_copy" "$tmp_dir/sudo" "$cold_root/bin"/*
+: >"$TEST_LOG"
+TEST_SUDO_INVALIDATED="$sudo_invalidated" OMARCHY_PATH="$cold_root" "$launcher_copy" --cold-sudo "echo hello"
+
+mapfile -t calls <"$TEST_LOG"
+[[ ${calls[0]:-} == $'sudo\t-k' ]] || fail "cold presentation launch invalidates sudo first" "$(<"$TEST_LOG")"
+[[ ${calls[1]:-} == "restart-gum" ]] || fail "cold presentation launch invalidates sudo before theming" "$(<"$TEST_LOG")"
+[[ ${calls[2]:-} == $'setsid\t'* ]] || fail "cold presentation launch invalidates sudo before terminal launch" "$(<"$TEST_LOG")"
+pass "cold presentation launch revokes sudo before pre-entry callbacks"

--- a/test/shell.d/floating-terminal-test.sh
+++ b/test/shell.d/floating-terminal-test.sh
@@ -16,8 +16,14 @@ chmod +x "$tmp_dir/setsid"
 export TEST_LOG="$tmp_dir/log"
 export PATH="$tmp_dir:$ROOT/bin:$PATH"
 
-"$ROOT/bin/omarchy-launch-floating-terminal-with-presentation" "echo hello"
+OMARCHY_PATH="$ROOT" "$ROOT/bin/omarchy-launch-floating-terminal-with-presentation" "echo hello"
 
 launch=$(<"$TEST_LOG")
 [[ $launch == *"xdg-terminal-exec --app-id=org.omarchy.terminal"* ]] || fail "floating terminal launches Omarchy terminal" "$launch"
 pass "floating terminal launches Omarchy terminal"
+
+[[ $launch == *"$ROOT/bin/omarchy-show-logo; echo hello;"* ]] ||
+  fail "floating terminal fixes the logo callback to the Omarchy tree" "$launch"
+[[ $launch == *"then $ROOT/bin/omarchy-show-done; fi"* ]] ||
+  fail "floating terminal fixes the completion callback to the Omarchy tree" "$launch"
+pass "floating terminal presentation callbacks bypass the user PATH"

--- a/test/shell.d/floating-terminal-test.sh
+++ b/test/shell.d/floating-terminal-test.sh
@@ -48,7 +48,7 @@ gum_state=$(
 pass "gum theme loading cannot replace execution-control environment variables"
 
 launcher="$ROOT/bin/omarchy-launch-floating-terminal-with-presentation"
-cold_root="$tmp_dir/omarchy"
+cold_root="$tmp_dir/omarchy root"
 launcher_copy="$cold_root/bin/omarchy-launch-floating-terminal-with-presentation"
 sudo_invalidated="$tmp_dir/sudo-invalidated"
 mkdir -p "$cold_root/bin"
@@ -75,6 +75,19 @@ OMARCHY_PATH="$tmp_dir/mismatched-root" /usr/bin/bash -p "$launcher_copy" >/dev/
 (( mismatched_root_status == 126 )) ||
   fail "presentation wrapper rejects a mismatched Omarchy source root" "got status $mismatched_root_status"
 pass "presentation wrapper binds runtime helpers to its own source root"
+
+linked_root="$tmp_dir/linked Omarchy root"
+ln -s "$cold_root" "$linked_root"
+normalized_root=$(
+  OMARCHY_PATH="$linked_root" /usr/bin/bash -p -c '
+    source "$1"
+    omarchy_security_require_source_root "$2"
+    printf "%s\n" "$OMARCHY_PATH"
+  ' omarchy-source-root-test "$cold_root/bin/omarchy-security-functions" "$launcher_copy"
+)
+[[ $normalized_root == "$cold_root" ]] ||
+  fail "presentation wrapper accepts a matching symlinked runtime root" "$normalized_root"
+pass "presentation wrapper normalizes a matching symlinked runtime root"
 
 cat >"$tmp_dir/sudo" <<'SCRIPT'
 #!/bin/bash
@@ -109,12 +122,16 @@ SCRIPT
   TEST_SUDO_INVALIDATED="$sudo_invalidated" OMARCHY_PATH="$cold_root" \
   BASH_ENV="$startup_poison" ENV="$startup_poison" \
   'BASH_FUNC_printf%%=() { if [[ -e $TEST_SUDO_INVALIDATED ]]; then builtin echo exported-printf-after-sudo-invalidation >>"$TEST_POISON_CALLS"; fi; builtin printf "$@"; }' \
-  "$launcher_copy" --cold-sudo "echo hello"
+  "$launcher_copy" --cold-sudo "$cold_root/bin/omarchy-setup-security-fido2" "argument with spaces"
 
 mapfile -t calls <"$TEST_LOG"
 [[ ${calls[0]:-} == $'sudo\t-k' ]] || fail "cold presentation launch invalidates sudo first" "$(<"$TEST_LOG")"
 [[ ${calls[1]:-} == "restart-gum" ]] || fail "cold presentation launch invalidates sudo before theming" "$(<"$TEST_LOG")"
 [[ ${calls[2]:-} == $'setsid\t'* ]] || fail "cold presentation launch invalidates sudo before terminal launch" "$(<"$TEST_LOG")"
+printf -v escaped_setup '%q' "$cold_root/bin/omarchy-setup-security-fido2"
+printf -v escaped_argument '%q' "argument with spaces"
+[[ ${calls[2]:-} == *"$escaped_setup $escaped_argument;"* ]] ||
+  fail "cold presentation launch preserves command arguments and paths with spaces" "${calls[2]:-}"
 [[ ! -s $poison_calls ]] ||
   fail "cold presentation launch preserves inherited Bash callbacks" "$(<"$poison_calls")"
-pass "cold presentation launch sanitizes Bash state and revokes sudo before pre-entry callbacks"
+pass "cold presentation launch sanitizes Bash state, preserves argv, and revokes sudo before pre-entry callbacks"

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -30,6 +30,7 @@ assertEqual(parsed.length, 3, 'menu parses JSONC with comments and trailing comm
 assertDeepEqual(
   parsed.find(item => item.id === 'style.theme'),
   {
+    _definedFields: ['label', 'aliases', 'description', 'action'],
     id: 'style.theme',
     parent: 'style',
     kind: 'action',
@@ -58,16 +59,43 @@ const merged = menu.mergeMenuSources(parsed, user)
 assertEqual(merged.items['style.theme'].label, 'Theme picker', 'menu user entries override default entries')
 assertEqual(merged.items['style.theme'].order, 2, 'menu preserves original order on override')
 assert(merged.items.root, 'menu injects root when merging sources')
+assert(!('_definedFields' in merged.items['style.theme']), 'menu removes merge metadata from the runtime model')
+
+const secureDefaults = [
+  menu.normalizeItem('setup.security.fido2', {
+    label: 'FIDO2',
+    actionArgv: ['$OMARCHY_PATH/bin/omarchy-launch-floating-terminal-with-presentation', '$OMARCHY_PATH/bin/omarchy-setup-security-fido2', '']
+  })
+]
+const legacyOverride = [
+  menu.normalizeItem('setup.security.fido2', { label: 'Security key', action: 'legacy-shell-action' })
+]
+const secureMerged = menu.mergeMenuSources(secureDefaults, legacyOverride)
+assertDeepEqual(
+  secureMerged.items['setup.security.fido2'].actionArgv,
+  ['$OMARCHY_PATH/bin/omarchy-launch-floating-terminal-with-presentation', '$OMARCHY_PATH/bin/omarchy-setup-security-fido2', ''],
+  'menu preserves a default argv action when an older user entry overrides other fields'
+)
+assertEqual(secureMerged.items['setup.security.fido2'].action, 'legacy-shell-action', 'menu preserves explicitly overridden legacy fields')
+
+const shellOverride = [
+  menu.normalizeItem('setup.security.fido2', { action: 'custom-shell-action', actionArgv: [] })
+]
+const shellMerged = menu.mergeMenuSources(secureDefaults, shellOverride)
+assertDeepEqual(shellMerged.items['setup.security.fido2'].actionArgv, [], 'menu lets a user explicitly clear a default argv action')
+assertEqual(shellMerged.items['setup.security.fido2'].action, 'custom-shell-action', 'menu uses an explicit shell action after argv is cleared')
 
 assertEqual(menu.slugify('Power Saver!'), 'power-saver', 'menu slugifies provider rows')
 assertDeepEqual(
   menu.expandActionArgv(
-    ['$OMARCHY_PATH/bin/command', '--flag', 'argument with spaces'],
+    ['$OMARCHY_PATH/bin/command', '--flag', '', 'argument with spaces'],
     '/tmp/Omarchy root'
   ),
-  ['/tmp/Omarchy root/bin/command', '--flag', 'argument with spaces'],
-  'menu expands the runtime root without collapsing command arguments'
+  ['/tmp/Omarchy root/bin/command', '--flag', '', 'argument with spaces'],
+  'menu expands the runtime root without collapsing or dropping command arguments'
 )
+assertDeepEqual(menu.expandActionArgv(['', 'argument'], '/tmp/root'), [], 'menu rejects an argv action without a command')
+assertDeepEqual(menu.expandActionArgv(['command', 42, '--flag'], '/tmp/root'), [], 'menu rejects an argv action containing a non-string argument')
 assertEqual(menu.pathFor(merged.items, 'style.theme'), 'Style › Theme picker', 'menu builds item paths')
 assertEqual(menu.parentPathFor(merged.items, 'style.theme'), 'Style', 'menu builds parent paths')
 assert(menu.isDescendantOf(merged.items, 'style.theme', 'style'), 'menu detects descendants')

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -40,6 +40,7 @@ assertDeepEqual(
     target: '',
     description: 'appearance colors',
     action: 'omarchy-theme-set',
+    actionArgv: [],
     provider: '',
     aliases: ['theme'],
     when: '',
@@ -59,6 +60,14 @@ assertEqual(merged.items['style.theme'].order, 2, 'menu preserves original order
 assert(merged.items.root, 'menu injects root when merging sources')
 
 assertEqual(menu.slugify('Power Saver!'), 'power-saver', 'menu slugifies provider rows')
+assertDeepEqual(
+  menu.expandActionArgv(
+    ['$OMARCHY_PATH/bin/command', '--flag', 'argument with spaces'],
+    '/tmp/Omarchy root'
+  ),
+  ['/tmp/Omarchy root/bin/command', '--flag', 'argument with spaces'],
+  'menu expands the runtime root without collapsing command arguments'
+)
 assertEqual(menu.pathFor(merged.items, 'style.theme'), 'Style › Theme picker', 'menu builds item paths')
 assertEqual(menu.parentPathFor(merged.items, 'style.theme'), 'Style', 'menu builds parent paths')
 assert(menu.isDescendantOf(merged.items, 'style.theme', 'style'), 'menu detects descendants')
@@ -324,10 +333,15 @@ assert(
   defaultById['setup.security.passwordless-sudo'].action.includes('omarchy-sudo-passwordless'),
   'menu places Passwordless Sudo under Setup > Security'
 )
-assertEqual(
-  defaultById['setup.security.fido2'].action,
-  '"$OMARCHY_PATH/bin/omarchy-launch-floating-terminal-with-presentation" --cold-sudo "$OMARCHY_PATH/bin/omarchy-setup-security-fido2"',
-  'menu revokes cached sudo before any FIDO2 presentation callback'
+assertDeepEqual(
+  defaultById['setup.security.fido2'].actionArgv,
+  ['$OMARCHY_PATH/bin/omarchy-launch-floating-terminal-with-presentation', '--cold-sudo', '$OMARCHY_PATH/bin/omarchy-setup-security-fido2'],
+  'menu preserves the FIDO2 launch as command arguments'
+)
+assert(
+  !defaultById['setup.security.fido2'].action
+    && /if \(argv\.length > 0\) \{\s*Quickshell\.execDetached\(argv\)/.test(menuQml),
+  'menu launches FIDO2 directly without an outer login shell callback'
 )
 assert(
   !defaultById['trigger.toggle.direct-boot'] && !defaultById['trigger.toggle.passwordless-sudo'],

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -324,6 +324,11 @@ assert(
   defaultById['setup.security.passwordless-sudo'].action.includes('omarchy-sudo-passwordless'),
   'menu places Passwordless Sudo under Setup > Security'
 )
+assertEqual(
+  defaultById['setup.security.fido2'].action,
+  '"$OMARCHY_PATH/bin/omarchy-launch-floating-terminal-with-presentation" --cold-sudo "$OMARCHY_PATH/bin/omarchy-setup-security-fido2"',
+  'menu revokes cached sudo before any FIDO2 presentation callback'
+)
 assert(
   !defaultById['trigger.toggle.direct-boot'] && !defaultById['trigger.toggle.passwordless-sudo'],
   'menu removes the relocated toggles from Trigger > Toggle'

--- a/test/shell.d/pkg-add-test.sh
+++ b/test/shell.d/pkg-add-test.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+stub_bin="$test_tmp/bin"
+call_log="$test_tmp/calls.log"
+poison_log="$test_tmp/poison.log"
+sudo_ticket="$test_tmp/sudo-ticket"
+mkdir -p "$stub_bin"
+
+cleanup() {
+  rm -rf "$test_tmp"
+  return 0
+}
+trap cleanup EXIT
+
+cat >"$stub_bin/omarchy-pkg-missing" <<'SH'
+#!/bin/bash
+
+exit "$TEST_MISSING_STATUS"
+SH
+
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+
+printf 'sudo' >>"$TEST_CALL_LOG"
+printf '\t%s' "$@" >>"$TEST_CALL_LOG"
+printf '\n' >>"$TEST_CALL_LOG"
+
+if [[ ${1:-} == "-k" ]]; then
+  (( $# == 1 )) || exit 96
+  if (( TEST_REVOKE_STATUS != 0 )); then
+    exit "$TEST_REVOKE_STATUS"
+  fi
+  rm -f "$TEST_SUDO_TICKET"
+  exit 0
+fi
+
+if [[ ${1:-} != "pacman" || ${2:-} != "-S" || ${3:-} != "--noconfirm" || ${4:-} != "--needed" ]]; then
+  exit 97
+fi
+
+: >"$TEST_SUDO_TICKET"
+exit "$TEST_INSTALL_STATUS"
+SH
+
+cat >"$stub_bin/pacman" <<'SH'
+#!/bin/bash
+
+printf 'pacman' >>"$TEST_CALL_LOG"
+printf '\t%s' "$@" >>"$TEST_CALL_LOG"
+printf '\n' >>"$TEST_CALL_LOG"
+
+if [[ -e $TEST_SUDO_TICKET ]]; then
+  printf '%s\n' pacman-query-with-live-sudo >>"$TEST_POISON_LOG"
+  exit 94
+fi
+
+[[ ${1:-} == "-Q" && $# == 2 ]] || exit 95
+exit "$TEST_QUERY_STATUS"
+SH
+
+chmod +x "$stub_bin/omarchy-pkg-missing" "$stub_bin/sudo" "$stub_bin/pacman"
+
+run_pkg_add() {
+  local install_status=${1:-0}
+  local revoke_status=${2:-0}
+  local query_status=${3:-0}
+  local missing_status=${4:-0}
+  local status
+
+  : >"$call_log"
+  : >"$poison_log"
+  rm -f "$sudo_ticket"
+
+  if TEST_CALL_LOG="$call_log" TEST_INSTALL_STATUS="$install_status" \
+    TEST_MISSING_STATUS="$missing_status" TEST_POISON_LOG="$poison_log" \
+    TEST_QUERY_STATUS="$query_status" TEST_REVOKE_STATUS="$revoke_status" \
+    TEST_SUDO_TICKET="$sudo_ticket" PATH="$stub_bin:/usr/bin:/bin" \
+    "$ROOT/bin/omarchy-pkg-add" --revoke-sudo libfido2 pam-u2f >/dev/null 2>&1; then
+    status=0
+  else
+    status=$?
+  fi
+
+  return "$status"
+}
+
+run_pkg_add || fail "package installation succeeds with credential revocation"
+mapfile -t calls <"$call_log"
+[[ ${calls[0]:-} == $'sudo\tpacman\t-S\t--noconfirm\t--needed\tlibfido2\tpam-u2f' ]] ||
+  fail "package helper installs the requested packages" "$(cat "$call_log")"
+[[ ${calls[1]:-} == $'sudo\t-k' ]] ||
+  fail "package helper revokes sudo immediately after installation" "$(cat "$call_log")"
+[[ ${calls[2]:-} == $'pacman\t-Q\tlibfido2' && ${calls[3]:-} == $'pacman\t-Q\tpam-u2f' ]] ||
+  fail "package helper checks registration only after revoking sudo" "$(cat "$call_log")"
+(( ${#calls[@]} == 4 )) || fail "package helper makes only the expected calls" "$(cat "$call_log")"
+[[ ! -e $sudo_ticket ]] || fail "package helper leaves no reusable sudo credentials"
+[[ ! -s $poison_log ]] || fail "package checks run while sudo credentials remain live" "$(cat "$poison_log")"
+pass "package helper revokes sudo before post-installation callbacks"
+
+install_failure=0
+run_pkg_add 42 || install_failure=$?
+(( install_failure == 42 )) || fail "package helper preserves installation failure status" "got status $install_failure"
+grep -Fxq $'sudo\t-k' "$call_log" || fail "package helper revokes sudo after a failed installation" "$(cat "$call_log")"
+! grep -Fq $'pacman\t-Q' "$call_log" || fail "package helper skips registration checks after a failed installation" "$(cat "$call_log")"
+[[ ! -e $sudo_ticket ]] || fail "failed package installation leaves no reusable sudo credentials"
+pass "package helper revokes sudo and propagates package installation failures"
+
+revoke_failure=0
+run_pkg_add 0 55 || revoke_failure=$?
+(( revoke_failure != 0 )) || fail "package helper fails when sudo credentials cannot be revoked"
+! grep -Fq $'pacman\t-Q' "$call_log" || fail "package helper runs no post-installation callbacks after failed revocation" "$(cat "$call_log")"
+pass "package helper stops when sudo credential revocation fails"

--- a/test/shell.d/plymouth-set-test.sh
+++ b/test/shell.d/plymouth-set-test.sh
@@ -110,10 +110,12 @@ cat >"$stub_dir/omarchy-plymouth-switcher" <<'STUB'
 printf '%s\n' "$OMARCHY_TEST_UNLOCK_NAME"
 STUB
 
-# Run the real presentation wrapper while replacing only its terminal launcher.
+# Run a source-identical presentation wrapper while replacing only its terminal launcher.
 # The launcher stub executes the final `bash -c` locally instead of opening a
 # terminal window.
-ln -s "$ROOT/bin/omarchy-launch-floating-terminal-with-presentation" "$stub_dir/omarchy-launch-floating-terminal-with-presentation"
+cp "$ROOT/bin/omarchy-launch-floating-terminal-with-presentation" "$stub_dir/bin/omarchy-launch-floating-terminal-with-presentation"
+cp "$ROOT/bin/omarchy-security-functions" "$stub_dir/bin/omarchy-security-functions"
+ln -s "$stub_dir/bin/omarchy-launch-floating-terminal-with-presentation" "$stub_dir/omarchy-launch-floating-terminal-with-presentation"
 
 cat >"$stub_dir/bin/omarchy-restart-gum" <<'STUB'
 #!/bin/bash

--- a/test/shell.d/plymouth-set-test.sh
+++ b/test/shell.d/plymouth-set-test.sh
@@ -92,7 +92,7 @@ unlock_action=$(node -e '
 [[ -n $unlock_action ]] || fail "the shipped menu still carries a style.unlock action"
 
 stub_dir="$test_tmp/stubs"
-mkdir -p "$stub_dir"
+mkdir -p "$stub_dir/bin"
 
 canary="$test_tmp/canary"
 set_args="$test_tmp/set-args"
@@ -115,7 +115,7 @@ STUB
 # terminal window.
 ln -s "$ROOT/bin/omarchy-launch-floating-terminal-with-presentation" "$stub_dir/omarchy-launch-floating-terminal-with-presentation"
 
-cat >"$stub_dir/omarchy-restart-gum" <<'STUB'
+cat >"$stub_dir/bin/omarchy-restart-gum" <<'STUB'
 #!/bin/bash
 :
 STUB
@@ -144,15 +144,16 @@ printf 'ran\n' >"$OMARCHY_TEST_RESET_MARKER"
 STUB
 
 for command in omarchy-show-logo omarchy-show-done; do
-  printf '#!/bin/bash\nexit 0\n' >"$stub_dir/$command"
+  printf '#!/bin/bash\nexit 0\n' >"$stub_dir/bin/$command"
 done
 
-chmod +x "$stub_dir"/*
+chmod +x "$stub_dir"/* "$stub_dir/bin"/*
 
 run_unlock_action() {
   rm -f "$canary" "$set_args" "$reset_marker"
 
   PATH="$stub_dir:$PATH" \
+    OMARCHY_PATH="$stub_dir" \
     OMARCHY_TEST_UNLOCK_NAME="$1" \
     OMARCHY_TEST_SET_ARGS="$set_args" \
     OMARCHY_TEST_RESET_MARKER="$reset_marker" \

--- a/test/shell.d/security-fido2-test.sh
+++ b/test/shell.d/security-fido2-test.sh
@@ -45,6 +45,10 @@ unsafe_router_status=0
 /usr/bin/bash "$router" -p >/dev/null 2>&1 || unsafe_router_status=$?
 (( unsafe_router_status == 126 )) ||
   fail "the public Omarchy router rejects an ordinary Bash launch with a decoy -p argument" "got status $unsafe_router_status"
+sourced_router_status=0
+/usr/bin/bash -p -c 'source "$1"' omarchy-source-test "$router" >/dev/null 2>&1 || sourced_router_status=$?
+(( sourced_router_status == 126 )) ||
+  fail "the public Omarchy router rejects being sourced by a privileged parent shell" "got status $sourced_router_status"
 pass "the public Omarchy router reaches FIDO2 dispatch without inherited Bash startup hooks"
 
 # The setup installs to an absolute path no unprivileged suite can write, and an
@@ -65,6 +69,8 @@ pass "setup names its FIDO2 paths once each, and the test drives a retargeted co
 occurrences=$(grep -Fxc 'PATH="$OMARCHY_PATH/bin:/usr/local/bin:/usr/bin:/bin"' "$setup") || occurrences=0
 (( occurrences == 1 )) ||
   fail "FIDO2 setup defines one trusted command path" "found $occurrences occurrences"
+grep -Fq 'omarchy_security_sanitize_bash_environment "$security_entrypoint" "$@"' "$setup" ||
+  fail "FIDO2 setup re-executes through its canonical entrypoint"
 
 sed -e "s|^authdir=/etc/fido2$|authdir=$authdir|" \
   -e "s|^authfile=/etc/fido2/fido2$|authfile=$authfile|" \
@@ -72,6 +78,7 @@ sed -e "s|^authdir=/etc/fido2$|authdir=$authdir|" \
   -e "s|/usr/bin/sudo|$stub_bin/sudo|g" \
   -e "s|/usr/bin/fido2-token|$stub_bin/fido2-token|g" \
   -e "s|/usr/bin/pamu2fcfg|$stub_bin/pamu2fcfg|g" \
+  -e "s|/usr/bin/grep|$stub_bin/grep|g" \
   -e "s|\"\$OMARCHY_PATH/bin/omarchy-pkg-add\"|\"$stub_bin/omarchy-pkg-add\"|" \
   "$setup" >"$setup_copy"
 cp "$security_functions" "$stub_bin/omarchy-security-functions"
@@ -82,6 +89,10 @@ unsafe_startup_status=0
 /usr/bin/bash "$setup_copy" -p </dev/null >/dev/null 2>&1 || unsafe_startup_status=$?
 (( unsafe_startup_status == 126 )) ||
   fail "FIDO2 setup rejects an ordinary Bash launch with a decoy -p argument" "got status $unsafe_startup_status"
+sourced_startup_status=0
+/usr/bin/bash -p -c 'source "$1"' omarchy-source-test "$setup_copy" >/dev/null 2>&1 || sourced_startup_status=$?
+(( sourced_startup_status == 126 )) ||
+  fail "FIDO2 setup rejects being sourced by a privileged parent shell" "got status $sourced_startup_status"
 pass "FIDO2 setup requires a verified privileged Bash startup"
 
 mismatched_root_status=0
@@ -289,10 +300,26 @@ fi
 echo '/dev/hidraw0: vendor=0x1050, product=0x0407 (Yubico YubiKey)'
 SH
 
+cat >"$stub_bin/grep" <<'SH'
+#!/bin/bash
+
+if [[ -e $TEST_SUDO_TICKET ]]; then
+  printf '%s\n' grep-with-live-sudo >>"$TEST_POISON_CALLS"
+  exit 94
+fi
+
+exec /usr/bin/grep "$@"
+SH
+
 cat >"$stub_bin/omarchy-pkg-add" <<'SH'
 #!/bin/bash
 
+if (( $# != 3 )) || [[ $1 != "--revoke-sudo" || $2 != "libfido2" || $3 != "pam-u2f" ]]; then
+  exit 92
+fi
+
 "$TEST_SUDO_STUB" package-authorize
+"$TEST_SUDO_STUB" -k
 SH
 
 # Record what pamu2fcfg's stdout actually targets. The fixed implementation
@@ -339,7 +366,7 @@ exit 93
 SH
 done
 
-chmod +x "$stub_bin/mktemp" "$stub_bin/sudo" "$stub_bin/fido2-token" \
+chmod +x "$stub_bin/mktemp" "$stub_bin/sudo" "$stub_bin/fido2-token" "$stub_bin/grep" \
   "$stub_bin/omarchy-pkg-add" "$stub_bin/pamu2fcfg" "$poison_bin"/*
 
 reset_run() {

--- a/test/shell.d/security-fido2-test.sh
+++ b/test/shell.d/security-fido2-test.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
 setup="$ROOT/bin/omarchy-setup-security-fido2"
+security_functions="$ROOT/bin/omarchy-security-functions"
 
 test_tmp=$(mktemp -d)
 stub_bin="$test_tmp/bin"
@@ -14,11 +15,12 @@ calls="$test_tmp/calls.log"
 pamu_targets="$test_tmp/pamu-targets.log"
 bare_mktemp="$test_tmp/bare-mktemp.log"
 poison_calls="$test_tmp/poison-calls.log"
+startup_poison="$test_tmp/bash-env"
 sudo_ticket="$test_tmp/sudo-ticket"
 credential="tester:credential-handle,public-key,es256,+presence"
 authdir="$test_tmp/etc-fido2"
 authfile="$authdir/fido2"
-setup_copy="$test_tmp/setup.sh"
+setup_copy="$stub_bin/omarchy-setup-security-fido2"
 mkdir -p "$stub_bin" "$poison_bin"
 
 cleanup() {
@@ -54,6 +56,21 @@ sed -e "s|^authdir=/etc/fido2$|authdir=$authdir|" \
   -e "s|/usr/bin/pamu2fcfg|$stub_bin/pamu2fcfg|g" \
   -e "s|\"\$OMARCHY_PATH/bin/omarchy-pkg-add\"|\"$stub_bin/omarchy-pkg-add\"|" \
   "$setup" >"$setup_copy"
+cp "$security_functions" "$stub_bin/omarchy-security-functions"
+
+[[ $(head -n 1 "$setup") == '#!/bin/bash -p' ]] ||
+  fail "FIDO2 setup requests privileged Bash at the kernel boundary"
+unsafe_startup_status=0
+/usr/bin/bash "$setup_copy" -p </dev/null >/dev/null 2>&1 || unsafe_startup_status=$?
+(( unsafe_startup_status == 126 )) ||
+  fail "FIDO2 setup rejects an ordinary Bash launch with a decoy -p argument" "got status $unsafe_startup_status"
+pass "FIDO2 setup requires a verified privileged Bash startup"
+
+mismatched_root_status=0
+OMARCHY_PATH="$test_tmp/mismatched-root" /usr/bin/bash -p "$setup_copy" </dev/null >/dev/null 2>&1 || mismatched_root_status=$?
+(( mismatched_root_status == 126 )) ||
+  fail "FIDO2 setup rejects a mismatched Omarchy source root" "got status $mismatched_root_status"
+pass "FIDO2 setup binds runtime helpers to its own source root"
 
 grep -Fxq "PATH=\"$stub_bin:$ROOT/bin:/usr/bin:/bin\"" "$setup_copy" ||
   fail "the test redirects the trusted FIDO2 command path"
@@ -64,6 +81,12 @@ grep -Fq "$stub_bin/fido2-token -L" "$setup_copy" ||
 grep -Fq "$stub_bin/pamu2fcfg" "$setup_copy" ||
   fail "the test redirects the fixed credential generator"
 pass "FIDO2 setup limits command lookup and fixes its security-sensitive executables"
+
+cat >"$startup_poison" <<'SH'
+if [[ -e $TEST_SUDO_TICKET ]]; then
+  printf '%s\n' bash-env-with-live-sudo >>"$TEST_POISON_CALLS"
+fi
+SH
 
 # The setup must not create a caller-owned named file for pamu2fcfg. A bare
 # mktemp is therefore a test failure; only the sudo stub below may invoke the
@@ -318,13 +341,19 @@ invoke_setup() {
   local mktemp_mode="${4:-normal}"
   local status
 
-  if TEST_AUTHDIR="$authdir" TEST_AUTHFILE="$authfile" TEST_BARE_MKTEMP="$bare_mktemp" \
+  if /usr/bin/env \
+    TEST_AUTHDIR="$authdir" TEST_AUTHFILE="$authfile" TEST_BARE_MKTEMP="$bare_mktemp" \
     TEST_CREDENTIAL="$credential" TEST_FAIL_CHMOD="$fail_chmod" TEST_FAIL_MV="$fail_mv" \
     TEST_LOG="$calls" TEST_MKTEMP_MODE="$mktemp_mode" TEST_PAMU_MODE="$pamu_mode" \
     TEST_PAMU_TARGETS="$pamu_targets" TEST_POISON_CALLS="$poison_calls" \
     TEST_STAGES="$stages" TEST_SUDO_STUB="$stub_bin/sudo" TEST_SUDO_TICKET="$sudo_ticket" \
-    TEST_TMP="$test_tmp" PATH="$poison_bin:$stub_bin:$ROOT/bin:$PATH" \
-    bash "$setup_copy" </dev/null >/dev/null; then
+    TEST_TMP="$test_tmp" OMARCHY_PATH="$test_tmp" PATH="$poison_bin:$stub_bin:$ROOT/bin:$PATH" \
+    BASH_ENV="$startup_poison" ENV="$startup_poison" \
+    SHELLOPTS=braceexpand:hashall:interactive-comments:xtrace \
+    'PS4=$(if [[ -e $TEST_SUDO_TICKET ]]; then builtin printf "%s\n" xtrace-with-live-sudo >>"$TEST_POISON_CALLS"; fi)' \
+    'BASH_FUNC_echo%%=() { if [[ -e $TEST_SUDO_TICKET ]]; then builtin printf "%s\n" exported-echo-with-live-sudo >>"$TEST_POISON_CALLS"; fi; builtin echo "$@"; }' \
+    'BASH_FUNC_printf%%=() { if [[ -e $TEST_SUDO_TICKET ]]; then builtin echo exported-printf-with-live-sudo >>"$TEST_POISON_CALLS"; fi; builtin printf "$@"; }' \
+    /usr/bin/bash -p "$setup_copy" </dev/null >/dev/null; then
     status=0
   else
     status=$?
@@ -336,7 +365,7 @@ invoke_setup() {
     fail "FIDO2 setup invalidates sudo credentials before returning" "$(cat "$calls")"
   [[ ! -e $sudo_ticket ]] || fail "FIDO2 setup leaves no reusable sudo credentials"
   [[ ! -s $poison_calls ]] ||
-    fail "FIDO2 setup executes a user-PATH callback" "$(cat "$poison_calls")"
+    fail "FIDO2 setup executes an inherited or user-PATH callback" "$(cat "$poison_calls")"
 
   return "$status"
 }
@@ -465,7 +494,7 @@ grep -Fxq $'sudo\tmv\t-Tf\t'"$stage_path"$'\t'"$authfile" "$calls" ||
 [[ $(stat -c %a "$authfile") == "644" ]] ||
   fail "the published authfile is mode 644" "got: $(stat -c %a "$authfile")"
 pass "FIDO2 setup pipes the credential into a unique root-created stage and publishes it atomically"
-pass "FIDO2 utilities run cold and setup revokes sudo before returning"
+pass "FIDO2 utilities run with sanitized Bash state and setup revokes sudo before returning"
 
 # A chmod failure happens after a complete credential has been written but
 # before publication. It must abort the setup and leave the EXIT trap armed.

--- a/test/shell.d/security-fido2-test.sh
+++ b/test/shell.d/security-fido2-test.sh
@@ -8,15 +8,18 @@ setup="$ROOT/bin/omarchy-setup-security-fido2"
 
 test_tmp=$(mktemp -d)
 stub_bin="$test_tmp/bin"
+poison_bin="$test_tmp/poison-bin"
 stages="$test_tmp/stages.log"
 calls="$test_tmp/calls.log"
 pamu_targets="$test_tmp/pamu-targets.log"
 bare_mktemp="$test_tmp/bare-mktemp.log"
+poison_calls="$test_tmp/poison-calls.log"
+sudo_ticket="$test_tmp/sudo-ticket"
 credential="tester:credential-handle,public-key,es256,+presence"
 authdir="$test_tmp/etc-fido2"
 authfile="$authdir/fido2"
 setup_copy="$test_tmp/setup.sh"
-mkdir -p "$stub_bin"
+mkdir -p "$stub_bin" "$poison_bin"
 
 cleanup() {
   rm -rf "$test_tmp"
@@ -39,8 +42,28 @@ occurrences=$(grep -Fxc 'authfile=/etc/fido2/fido2' "$setup") || occurrences=0
   fail "the setup names its authfile exactly once" "found $occurrences occurrences"
 pass "setup names its FIDO2 paths once each, and the test drives a retargeted copy"
 
+occurrences=$(grep -Fxc 'PATH="$OMARCHY_PATH/bin:/usr/local/bin:/usr/bin:/bin"' "$setup") || occurrences=0
+(( occurrences == 1 )) ||
+  fail "FIDO2 setup defines one trusted command path" "found $occurrences occurrences"
+
 sed -e "s|^authdir=/etc/fido2$|authdir=$authdir|" \
-  -e "s|^authfile=/etc/fido2/fido2$|authfile=$authfile|" "$setup" >"$setup_copy"
+  -e "s|^authfile=/etc/fido2/fido2$|authfile=$authfile|" \
+  -e "s|^PATH=\"\$OMARCHY_PATH/bin:/usr/local/bin:/usr/bin:/bin\"$|PATH=\"$stub_bin:$ROOT/bin:/usr/bin:/bin\"|" \
+  -e "s|/usr/bin/sudo|$stub_bin/sudo|g" \
+  -e "s|/usr/bin/fido2-token|$stub_bin/fido2-token|g" \
+  -e "s|/usr/bin/pamu2fcfg|$stub_bin/pamu2fcfg|g" \
+  -e "s|\"\$OMARCHY_PATH/bin/omarchy-pkg-add\"|\"$stub_bin/omarchy-pkg-add\"|" \
+  "$setup" >"$setup_copy"
+
+grep -Fxq "PATH=\"$stub_bin:$ROOT/bin:/usr/bin:/bin\"" "$setup_copy" ||
+  fail "the test redirects the trusted FIDO2 command path"
+grep -Fq "$stub_bin/sudo -k" "$setup_copy" ||
+  fail "the test redirects fixed sudo invocations"
+grep -Fq "$stub_bin/fido2-token -L" "$setup_copy" ||
+  fail "the test redirects the fixed hardware probe"
+grep -Fq "$stub_bin/pamu2fcfg" "$setup_copy" ||
+  fail "the test redirects the fixed credential generator"
+pass "FIDO2 setup limits command lookup and fixes its security-sensitive executables"
 
 # The setup must not create a caller-owned named file for pamu2fcfg. A bare
 # mktemp is therefore a test failure; only the sudo stub below may invoke the
@@ -71,13 +94,21 @@ reject() {
   exit 97
 }
 
-if [[ ${TEST_TMP:-} != /* || ${TEST_AUTHDIR:-} != "$TEST_TMP/etc-fido2" || ${TEST_AUTHFILE:-} != "$TEST_AUTHDIR/fido2" || ${TEST_STAGES:-} != "$TEST_TMP/stages.log" || ${TEST_LOG:-} != "$TEST_TMP/calls.log" || ! ${TEST_FAIL_CHMOD:-} =~ ^[01]$ || ! ${TEST_FAIL_MV:-} =~ ^[01]$ ]]; then
+if [[ ${TEST_TMP:-} != /* || ${TEST_AUTHDIR:-} != "$TEST_TMP/etc-fido2" || ${TEST_AUTHFILE:-} != "$TEST_AUTHDIR/fido2" || ${TEST_STAGES:-} != "$TEST_TMP/stages.log" || ${TEST_LOG:-} != "$TEST_TMP/calls.log" || ${TEST_SUDO_TICKET:-} != "$TEST_TMP/sudo-ticket" || ${TEST_POISON_CALLS:-} != "$TEST_TMP/poison-calls.log" || ! ${TEST_FAIL_CHMOD:-} =~ ^[01]$ || ! ${TEST_FAIL_MV:-} =~ ^[01]$ ]]; then
   reject "$@"
 fi
 
 printf 'sudo' >>"$TEST_LOG"
 printf '\t%s' "$@" >>"$TEST_LOG"
 printf '\n' >>"$TEST_LOG"
+
+if [[ ${1:-} == "-k" ]]; then
+  (( $# == 1 )) || reject "$@"
+  /usr/bin/rm -f -- "$TEST_SUDO_TICKET"
+  exit 0
+fi
+
+: >"$TEST_SUDO_TICKET"
 
 safe_stage_path() {
   local candidate=$1
@@ -98,6 +129,9 @@ recorded_stage() {
 }
 
 case "${1:-}" in
+  package-authorize)
+    (( $# == 1 )) || reject "$@"
+    ;;
   install)
     if (( $# != 9 )) || [[ $2 != "-d" || $3 != "-m" || $4 != "755" || $5 != "-o" || $6 != "root" || $7 != "-g" || $8 != "root" || $9 != "$TEST_AUTHDIR" ]]; then
       reject "$@"
@@ -206,20 +240,33 @@ SH
 cat >"$stub_bin/fido2-token" <<'SH'
 #!/bin/bash
 
+if [[ -e $TEST_SUDO_TICKET ]]; then
+  printf '%s\n' fido2-token-with-live-sudo >>"$TEST_POISON_CALLS"
+  exit 94
+fi
+
 echo '/dev/hidraw0: vendor=0x1050, product=0x0407 (Yubico YubiKey)'
 SH
 
 cat >"$stub_bin/omarchy-pkg-add" <<'SH'
 #!/bin/bash
+
+"$TEST_SUDO_STUB" package-authorize
 SH
 
 # Record what pamu2fcfg's stdout actually targets. The fixed implementation
-# gives it a pipe to privileged tee; refusing a regular-file descriptor keeps a
-# regression from writing credential bytes into a caller-owned named file.
+# captures it through a pipe while sudo is cold; refusing a regular-file
+# descriptor keeps a regression from writing credential bytes into a
+# caller-owned named file.
 cat >"$stub_bin/pamu2fcfg" <<'SH'
 #!/bin/bash
 
 set -euo pipefail
+
+if [[ -e $TEST_SUDO_TICKET ]]; then
+  printf '%s\n' pamu2fcfg-with-live-sudo >>"$TEST_POISON_CALLS"
+  exit 94
+fi
 
 target=$(readlink /proc/self/fd/1)
 printf '%s\n' "$target" >>"$TEST_PAMU_TARGETS"
@@ -242,14 +289,25 @@ case "$TEST_PAMU_MODE" in
 esac
 SH
 
+for command in omarchy-pkg-add fido2-token pamu2fcfg; do
+  cat >"$poison_bin/$command" <<'SH'
+#!/bin/bash
+
+printf '%s\n' "${0##*/}" >>"$TEST_POISON_CALLS"
+exit 93
+SH
+done
+
 chmod +x "$stub_bin/mktemp" "$stub_bin/sudo" "$stub_bin/fido2-token" \
-  "$stub_bin/omarchy-pkg-add" "$stub_bin/pamu2fcfg"
+  "$stub_bin/omarchy-pkg-add" "$stub_bin/pamu2fcfg" "$poison_bin"/*
 
 reset_run() {
   : >"$calls"
   : >"$stages"
   : >"$pamu_targets"
   : >"$bare_mktemp"
+  : >"$poison_calls"
+  rm -f "$sudo_ticket"
   rm -rf "$authdir"
 }
 
@@ -258,13 +316,29 @@ invoke_setup() {
   local fail_chmod="${2:-0}"
   local fail_mv="${3:-0}"
   local mktemp_mode="${4:-normal}"
+  local status
 
-  TEST_AUTHDIR="$authdir" TEST_AUTHFILE="$authfile" TEST_BARE_MKTEMP="$bare_mktemp" \
+  if TEST_AUTHDIR="$authdir" TEST_AUTHFILE="$authfile" TEST_BARE_MKTEMP="$bare_mktemp" \
     TEST_CREDENTIAL="$credential" TEST_FAIL_CHMOD="$fail_chmod" TEST_FAIL_MV="$fail_mv" \
     TEST_LOG="$calls" TEST_MKTEMP_MODE="$mktemp_mode" TEST_PAMU_MODE="$pamu_mode" \
-    TEST_PAMU_TARGETS="$pamu_targets" TEST_STAGES="$stages" TEST_TMP="$test_tmp" \
-    PATH="$stub_bin:$ROOT/bin:$PATH" \
-    bash "$setup_copy" </dev/null >/dev/null
+    TEST_PAMU_TARGETS="$pamu_targets" TEST_POISON_CALLS="$poison_calls" \
+    TEST_STAGES="$stages" TEST_SUDO_STUB="$stub_bin/sudo" TEST_SUDO_TICKET="$sudo_ticket" \
+    TEST_TMP="$test_tmp" PATH="$poison_bin:$stub_bin:$ROOT/bin:$PATH" \
+    bash "$setup_copy" </dev/null >/dev/null; then
+    status=0
+  else
+    status=$?
+  fi
+
+  [[ $(head -n 1 "$calls") == $'sudo\t-k' ]] ||
+    fail "FIDO2 setup begins with cold sudo credentials" "$(cat "$calls")"
+  [[ $(tail -n 1 "$calls") == $'sudo\t-k' ]] ||
+    fail "FIDO2 setup invalidates sudo credentials before returning" "$(cat "$calls")"
+  [[ ! -e $sudo_ticket ]] || fail "FIDO2 setup leaves no reusable sudo credentials"
+  [[ ! -s $poison_calls ]] ||
+    fail "FIDO2 setup executes a user-PATH callback" "$(cat "$poison_calls")"
+
+  return "$status"
 }
 
 run_setup() {
@@ -376,7 +450,7 @@ assert_pipe_target
 grep -Fxq $'sudo\tmktemp\t'"$authfile.new.XXXXXX" "$calls" ||
   fail "FIDO2 setup asks root to create a unique sibling stage" "$(cat "$calls")"
 grep -Fxq $'sudo\ttee\t'"$stage_path" "$calls" ||
-  fail "pamu2fcfg is piped into the exact privileged stage" "$(cat "$calls")"
+  fail "the captured credential is written into the exact privileged stage" "$(cat "$calls")"
 grep -Fxq $'sudo\tchmod\t644\t'"$stage_path" "$calls" ||
   fail "FIDO2 setup makes the completed authfile PAM-readable" "$(cat "$calls")"
 grep -Fxq $'sudo\tmv\t-Tf\t'"$stage_path"$'\t'"$authfile" "$calls" ||
@@ -391,6 +465,7 @@ grep -Fxq $'sudo\tmv\t-Tf\t'"$stage_path"$'\t'"$authfile" "$calls" ||
 [[ $(stat -c %a "$authfile") == "644" ]] ||
   fail "the published authfile is mode 644" "got: $(stat -c %a "$authfile")"
 pass "FIDO2 setup pipes the credential into a unique root-created stage and publishes it atomically"
+pass "FIDO2 utilities run cold and setup revokes sudo before returning"
 
 # A chmod failure happens after a complete credential has been written but
 # before publication. It must abort the setup and leave the EXIT trap armed.
@@ -422,33 +497,37 @@ grep -Fxq $'sudo\tmv\t-Tf\t'"$failed_stage"$'\t'"$authfile" "$calls" ||
 assert_failed_stage_cleanup
 pass "FIDO2 setup propagates mv failure and cleans its privileged stage"
 
-# Emit a valid credential and then fail. Without pipefail, tee's success masks
-# pamu2fcfg's status and the nonempty file would be published.
+# Emit a valid credential and then fail. The command substitution must preserve
+# pamu2fcfg's failure and prevent its output from reaching privileged staging.
 reset_run
 if invoke_setup fail >/dev/null 2>&1; then
   fail "a failing pamu2fcfg pipeline fails setup"
 fi
 assert_pipe_target
-assert_failed_stage_cleanup
+[[ ! -s $stages ]] || fail "a failing pamu2fcfg creates no privileged stage"
+! grep -Fq $'sudo\tinstall\t' "$calls" ||
+  fail "a failing pamu2fcfg reaches no privileged write" "$(cat "$calls")"
 ! grep -Fq $'sudo\tchmod\t' "$calls" ||
   fail "a failed pamu2fcfg result is never prepared for publication" "$(cat "$calls")"
 ! grep -Fq $'sudo\tmv\t' "$calls" ||
   fail "a failed pamu2fcfg result is never published" "$(cat "$calls")"
-pass "FIDO2 setup propagates pamu2fcfg failure and cleans its privileged stage"
+pass "FIDO2 setup rejects a failed credential before privileged staging"
 
-# A successful pipeline can still produce no credential. Reject that before
-# chmod or rename, and clean the exact stage just as on command failure.
+# A successful pamu2fcfg invocation can still produce no credential. Reject
+# that result before creating a privileged stage.
 reset_run
 if invoke_setup empty >/dev/null 2>&1; then
   fail "an empty pamu2fcfg result fails setup"
 fi
 assert_pipe_target
-assert_failed_stage_cleanup
+[[ ! -s $stages ]] || fail "an empty pamu2fcfg result creates no privileged stage"
+! grep -Fq $'sudo\tinstall\t' "$calls" ||
+  fail "an empty pamu2fcfg result reaches no privileged write" "$(cat "$calls")"
 ! grep -Fq $'sudo\tchmod\t' "$calls" ||
   fail "an empty pamu2fcfg result is never prepared for publication" "$(cat "$calls")"
 ! grep -Fq $'sudo\tmv\t' "$calls" ||
   fail "an empty pamu2fcfg result is never published" "$(cat "$calls")"
-pass "FIDO2 setup rejects an empty credential and cleans its privileged stage"
+pass "FIDO2 setup rejects an empty credential before privileged staging"
 
 # mktemp's output is an operand for a privileged tee, chmod, mv and rm. Take
 # only the name this script asked for: a stage path outside that shape must stop

--- a/test/shell.d/security-fido2-test.sh
+++ b/test/shell.d/security-fido2-test.sh
@@ -37,10 +37,17 @@ router_poison_calls="$test_tmp/router-poison-calls"
 cat >"$router_poison" <<'SH'
 printf '%s\n' router-bash-env >>"$TEST_ROUTER_POISON_CALLS"
 SH
-BASH_ENV="$router_poison" TEST_ROUTER_POISON_CALLS="$router_poison_calls" OMARCHY_PATH="$ROOT" \
+cat >"$poison_bin/dirname" <<'SH'
+#!/bin/bash
+printf '%s\n' router-path-dirname >>"$TEST_ROUTER_POISON_CALLS"
+exec /usr/bin/dirname "$@"
+SH
+chmod +x "$poison_bin/dirname"
+BASH_ENV="$router_poison" TEST_ROUTER_POISON_CALLS="$router_poison_calls" \
+  OMARCHY_PATH="$ROOT" PATH="$poison_bin:/usr/bin:/bin" \
   "$router" setup security fido2 --help >/dev/null
 [[ ! -e $router_poison_calls ]] ||
-  fail "the public Omarchy router executes an inherited Bash startup hook" "$(<"$router_poison_calls")"
+  fail "the public Omarchy router executes a pre-dispatch user callback" "$(<"$router_poison_calls")"
 unsafe_router_status=0
 /usr/bin/bash "$router" -p >/dev/null 2>&1 || unsafe_router_status=$?
 (( unsafe_router_status == 126 )) ||
@@ -49,7 +56,7 @@ sourced_router_status=0
 /usr/bin/bash -p -c 'source "$1"' omarchy-source-test "$router" >/dev/null 2>&1 || sourced_router_status=$?
 (( sourced_router_status == 126 )) ||
   fail "the public Omarchy router rejects being sourced by a privileged parent shell" "got status $sourced_router_status"
-pass "the public Omarchy router reaches FIDO2 dispatch without inherited Bash startup hooks"
+pass "the public Omarchy router resolves the FIDO2 route without inherited Bash startup hooks or PATH utilities"
 
 # The setup installs to an absolute path no unprivileged suite can write, and an
 # environment override in the shipped command would hand its privileged install

--- a/test/shell.d/security-fido2-test.sh
+++ b/test/shell.d/security-fido2-test.sh
@@ -6,6 +6,7 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
 setup="$ROOT/bin/omarchy-setup-security-fido2"
 security_functions="$ROOT/bin/omarchy-security-functions"
+router="$ROOT/bin/omarchy"
 
 test_tmp=$(mktemp -d)
 stub_bin="$test_tmp/bin"
@@ -28,6 +29,23 @@ cleanup() {
   return 0
 }
 trap cleanup EXIT
+
+[[ $(head -n 1 "$router") == '#!/bin/bash -p' ]] ||
+  fail "the public Omarchy router requests privileged Bash at the kernel boundary"
+router_poison="$test_tmp/router-bash-env"
+router_poison_calls="$test_tmp/router-poison-calls"
+cat >"$router_poison" <<'SH'
+printf '%s\n' router-bash-env >>"$TEST_ROUTER_POISON_CALLS"
+SH
+BASH_ENV="$router_poison" TEST_ROUTER_POISON_CALLS="$router_poison_calls" OMARCHY_PATH="$ROOT" \
+  "$router" setup security fido2 --help >/dev/null
+[[ ! -e $router_poison_calls ]] ||
+  fail "the public Omarchy router executes an inherited Bash startup hook" "$(<"$router_poison_calls")"
+unsafe_router_status=0
+/usr/bin/bash "$router" -p >/dev/null 2>&1 || unsafe_router_status=$?
+(( unsafe_router_status == 126 )) ||
+  fail "the public Omarchy router rejects an ordinary Bash launch with a decoy -p argument" "got status $unsafe_router_status"
+pass "the public Omarchy router reaches FIDO2 dispatch without inherited Bash startup hooks"
 
 # The setup installs to an absolute path no unprivileged suite can write, and an
 # environment override in the shipped command would hand its privileged install


### PR DESCRIPTION
## Summary

- invalidate cached sudo credentials before user-process FIDO2 callbacks and when setup exits
- resolve sensitive utilities and presentation callbacks through trusted fixed paths
- preserve atomic root-owned credential staging with cleanup across failure paths

## Tests

- ./test/shell.d/security-fido2-test.sh
- bash test/shell.d/floating-terminal-test.sh
- ./test/shell.d/plymouth-set-test.sh
- ./test/cli
- bash syntax checks and git diff --check

Reported-by: Sean https://github.com/shuber Huber