### PR TITLE
Stop the hybrid-GPU checks keeping the discrete GPU awake

### DIFF
--- a/bin/omarchy-hw-hybrid-gpu
+++ b/bin/omarchy-hw-hybrid-gpu
@@ -2,8 +2,27 @@
 
 # omarchy:summary=Detect whether the system has an active hybrid GPU configuration
 
+# Count display-class devices from the cached sysfs IDs rather than lspci. lspci reads PCI
+# config space, which resumes a runtime-suspended GPU -- the same reason omarchy-hw-nvidia
+# and omarchy-hw-nvidia-gsp already avoid it. That matters more here than anywhere else:
+# this check runs on a hybrid laptop, where the dGPU it is asking about is usually asleep,
+# and the result feeds session environment during Hyprland's config load.
+#
+# 0x03* covers VGA (0x0300), 3D (0x0302) and Display (0x0380) controllers, matching what
+# the previous `lspci | grep -E 'VGA|3D|Display'` counted.
+pci_devices_path="${OMARCHY_PCI_DEVICES_PATH:-/sys/bus/pci/devices}"
+
 multiple_gpus() {
-  (($(lspci | grep -cE 'VGA|3D|Display') >= 2))
+  local device count=0
+
+  shopt -s nullglob
+
+  for device in "$pci_devices_path"/*; do
+    [[ -r $device/class ]] || continue
+    [[ $(< "$device/class") == 0x03* ]] && ((count++))
+  done
+
+  ((count >= 2))
 }
 
 if omarchy-cmd-present supergfxctl; then

--- a/default/hypr/nvidia.lua
+++ b/default/hypr/nvidia.lua
@@ -3,17 +3,29 @@ local paths = require("default.hypr.paths")
 local nvidia = paths.omarchy_path .. "/bin/omarchy-hw-nvidia"
 local nvidia_gsp = paths.omarchy_path .. "/bin/omarchy-hw-nvidia-gsp"
 local nvidia_without_gsp = paths.omarchy_path .. "/bin/omarchy-hw-nvidia-without-gsp"
+local hybrid_gpu = paths.omarchy_path .. "/bin/omarchy-hw-hybrid-gpu"
 
--- These detectors read cached sysfs IDs rather than shelling out to lspci.
--- lspci reads PCI config space, which resumes a runtime-suspended GPU, and on a
--- hybrid laptop that wake alone outlasts Hyprland's 1.5s config reload budget.
+-- These detectors read cached sysfs IDs rather than shelling out to lspci. lspci reads
+-- PCI config space, which resumes a runtime-suspended GPU, and on a hybrid laptop that
+-- wake alone outlasts Hyprland's 1.5s config reload budget.
 if o.shell_succeeds(o.shell_quote(nvidia)) then
-  if o.shell_succeeds(o.shell_quote(nvidia_gsp)) then
-    hl.env("NVD_BACKEND", "direct")
-    hl.env("LIBVA_DRIVER_NAME", "nvidia")
-    hl.env("__GLX_VENDOR_LIBRARY_NAME", "nvidia")
-  elseif o.shell_succeeds(o.shell_quote(nvidia_without_gsp)) then
-    hl.env("NVD_BACKEND", "egl")
-    hl.env("__GLX_VENDOR_LIBRARY_NAME", "nvidia")
+  -- On a hybrid laptop the panel hangs off the iGPU and the dGPU is meant to stay
+  -- suspended until something asks for it. Pointing GLX at the NVIDIA vendor library
+  -- makes EVERY OpenGL client render on the dGPU, so it wakes at login and never gets
+  -- to sleep again -- a constant battery cost for no visible gain, since the frames
+  -- still have to be copied back to the iGPU to reach the display.
+  --
+  -- Leave the Mesa/iGPU default in place there and let the discrete card be opted into
+  -- per application (prime-run, or __NV_PRIME_RENDER_OFFLOAD=1). Desktops where NVIDIA
+  -- actually drives the display are unaffected: they are not hybrid, so this is skipped.
+  if not o.shell_succeeds(o.shell_quote(hybrid_gpu)) then
+    if o.shell_succeeds(o.shell_quote(nvidia_gsp)) then
+      hl.env("NVD_BACKEND", "direct")
+      hl.env("LIBVA_DRIVER_NAME", "nvidia")
+      hl.env("__GLX_VENDOR_LIBRARY_NAME", "nvidia")
+    elseif o.shell_succeeds(o.shell_quote(nvidia_without_gsp)) then
+      hl.env("NVD_BACKEND", "egl")
+      hl.env("__GLX_VENDOR_LIBRARY_NAME", "nvidia")
+    end
   end
 end

--- a/test/shell.d/hw-hybrid-gpu-test.sh
+++ b/test/shell.d/hw-hybrid-gpu-test.sh
@@ -28,18 +28,33 @@ esac
 printf '%s\n' "${SUPPORTED_MODES:-Integrated Hybrid}"
 STUB
 
-cat >"$fake_bin/lspci" <<'STUB'
-#!/bin/bash
-
-for _ in $(seq "${GPU_COUNT:-1}"); do
-  echo "0000:00:02.0 VGA compatible controller: Stub GPU"
-done
-STUB
-
 chmod +x "$fake_bin"/*
 
+# The detector counts display-class devices from sysfs rather than parsing lspci, so the
+# GPU count is expressed as PCI device fixtures. 0x0300 is VGA, 0x0380 Display; 0x0200
+# (ethernet) is present throughout to prove non-display devices are not counted.
+write_pci_devices() {
+  local count=${GPU_COUNT:-1} index=0
+
+  rm -rf "$test_tmp/devices"
+  mkdir -p "$test_tmp/devices/0000:00:1f.6"
+  printf '0x8086\n' >"$test_tmp/devices/0000:00:1f.6/vendor"
+  printf '0x020000\n' >"$test_tmp/devices/0000:00:1f.6/class"
+
+  while ((index < count)); do
+    local slot
+    slot=$(printf '0000:%02x:00.0' "$index")
+    mkdir -p "$test_tmp/devices/$slot"
+    printf '0x10de\n' >"$test_tmp/devices/$slot/vendor"
+    printf '0x030000\n' >"$test_tmp/devices/$slot/class"
+    index=$((index + 1))
+  done
+}
+
 hybrid_gpu() {
-  PATH="$fake_bin:$PATH" timeout --kill-after=1s 10s bash "$ROOT/bin/omarchy-hw-hybrid-gpu"
+  write_pci_devices
+  PATH="$fake_bin:$PATH" OMARCHY_PCI_DEVICES_PATH="$test_tmp/devices" \
+    timeout --kill-after=1s 10s bash "$ROOT/bin/omarchy-hw-hybrid-gpu"
 }
 
 hybrid_gpu ||
@@ -89,3 +104,12 @@ chmod +x "$fake_bin/omarchy-cmd-present"
 GPU_COUNT=2 hybrid_gpu ||
   fail "hybrid GPU detection counts GPUs without supergfxctl"
 pass "hybrid GPU detection counts GPUs without supergfxctl"
+
+GPU_COUNT=2 hybrid_gpu ||
+  fail "hybrid GPU detection counts GPUs from sysfs without reading PCI config space"
+pass "hybrid GPU detection counts GPUs from sysfs without reading PCI config space"
+
+# Comments in the detector explain why lspci is avoided, so only inspect real code.
+grep -v '^[[:space:]]*#' "$ROOT/bin/omarchy-hw-hybrid-gpu" | grep -q 'lspci' &&
+  fail "hybrid GPU detection avoids lspci, which resumes a suspended GPU"
+pass "hybrid GPU detection avoids lspci, which resumes a suspended GPU"


### PR DESCRIPTION
On a hybrid laptop the discrete GPU is meant to stay runtime-suspended until something asks for it. Two things in Omarchy stop that happening. They are separate bugs, but the second depends on the first being fixed, so they are here together as two commits.

### Count GPUs from sysfs instead of lspci

`omarchy-hw-hybrid-gpu` counted GPUs with `lspci | grep -cE 'VGA|3D|Display'`. `lspci` reads PCI config space, and the kernel has to runtime-resume a suspended device to answer:

```
lspci
 => pci_read_config
 => pci_config_pm_runtime_get
 => __pm_runtime_resume        # the card powers up to serve the read
 => rpm_resume: 0000:01:00.0
```

So the detector woke the very card it was asking about, and the card then stayed powered for the driver's autosuspend tail (~18s on the machine below) before settling back to D3cold.

That matters because the Omarchy shell re-runs its menu-state probes, and this is one of them:

```
lspci
 <- omarchy-hw-hybrid-gpu
 <- bash -lc <menu state script>
 <- quickshell -n -p /usr/share/omarchy/shell
 <- omarchy-launch-shell
 <- Hyprland
```

Counting display-class devices from the cached sysfs IDs gives the same answer without touching config space. `0x03*` covers VGA (`0x0300`), 3D (`0x0302`) and Display (`0x0380`) — the same set the `lspci` grep matched. `omarchy-hw-nvidia` and `omarchy-hw-nvidia-gsp` already avoid `lspci` for exactly this reason; this brings the third detector in line.

The test now expresses the GPU count as PCI device fixtures under `OMARCHY_PCI_DEVICES_PATH` instead of stubbing `lspci`, keeps an ethernet device in the fixture to prove non-display classes are not counted, and asserts the detector has no `lspci` call outside comments.

### Don't pin GLX to NVIDIA on hybrid laptops

`nvidia.lua` sets `__GLX_VENDOR_LIBRARY_NAME=nvidia` whenever an NVIDIA card is present. On a hybrid laptop that points **every** OpenGL client at the discrete GPU, but the panel hangs off the integrated GPU — so the frames still have to be copied back to reach the display. The card wakes at login and never idles again: a constant battery cost for no visible gain.

This skips the pin when `omarchy-hw-hybrid-gpu` reports a hybrid system, leaving the Mesa default in place and letting the discrete card be opted into per application (`prime-run`, or `__NV_PRIME_RENDER_OFFLOAD=1`). Desktops where NVIDIA actually drives the display are not hybrid, so they are unaffected.

This is also why the ordering matters: the guard calls `omarchy-hw-hybrid-gpu` during Hyprland's config load, which is only safe once that detector has stopped resuming the GPU.

### Testing

- `test/shell.d/hw-hybrid-gpu-test.sh` passes (10 assertions, including two new ones), at **each** commit independently.
- `./test/shell` shows no new failures. Four files fail on this machine, but they fail identically on unmodified `quattro`: `config`, `snapper` and `unowned-system-paths` need an `omarchy-pkgs` checkout that is not present, and `locate` is unrelated (see below).
- Verified on an Alienware x16 R2 (Intel Core Ultra 7 155H + RTX 4070, `nvidia` 580.x, RTD3). With both changes the discrete GPU reaches and stays at `D3cold` while idle instead of being woken by the shell's periodic probes.

### Unrelated, noticed while testing

`test/shell.d/locate-test.sh` does `rglob("*")` over `bin/`, `install/` and `migrations/` and calls `read_text()` on every file, so it dies with a `UnicodeDecodeError` if any binary file is present in those trees. A stray `bin/__pycache__/*.pyc` (left by running `bin/omarchy-agent-usage-*`) is enough to trigger it. Not touched here since it is a separate concern — happy to send a follow-up if useful.