### PR TITLE
Render media widget bar text with NativeRendering for consistency with other bar widgets

### DIFF
--- a/shell/plugins/services/media/BarWidget.qml
+++ b/shell/plugins/services/media/BarWidget.qml
@@ -38,6 +38,7 @@ BarWidget {
       color: activePlayer && activePlayer.isPlaying ? root.bar.barForeground : Qt.darker(root.bar.barForeground, 1.5)
       font.family: root.bar.fontFamily
       font.pixelSize: Style.font.body
+      renderType: Text.NativeRendering
       Behavior on color {
         enabled: !root.bar || root.bar.foregroundAnimationEnabled
         ColorAnimation { duration: 160 }
@@ -59,6 +60,7 @@ BarWidget {
         color: root.bar.barForeground
         font.family: root.bar.fontFamily
         font.pixelSize: Style.font.body
+        renderType: Text.NativeRendering
         anchors.verticalCenter: parent.verticalCenter
 
         property bool needsScroll: implicitWidth > scrollClip.width


### PR DESCRIPTION
## Problem

The media widget's bar text (play glyph + scrolling title) looks
slightly different from other bar widgets (clock, network, audio…)
even though they all use the same font family (`bar.fontFamily`) and
the same size (`Style.font.body`).

## Cause

Every widget routed through `WidgetButton` renders its label with
`renderType: Text.NativeRendering`. The media widget's bar-row `Text`
elements use QML's default `Text.QtRendering`, a different
rasterizer whose output is visibly different at small bar font sizes.

## Fix

Add `renderType: Text.NativeRendering` to the two bar-row `Text`
elements (`glyph` and `labelText`) in
`shell/plugins/services/media/BarWidget.qml` — 2 lines, no behavior
change beyond the rasterizer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)