### PR TITLE
Allow web apps to open in the default browser

### DIFF
--- a/bin/omarchy-remove-launcher-entry
+++ b/bin/omarchy-remove-launcher-entry
@@ -67,7 +67,8 @@ desktop_name="${desktop_file##*/}"
 desktop_name="${desktop_name%.desktop}"
 exec_line="$(sed -n 's/^Exec=//p' "$desktop_file" | head -1)"
 
-if [[ $exec_line =~ omarchy-launch-webapp|omarchy-webapp-handler ]]; then
+if grep -qE '^X-Omarchy-WebApp=true' "$desktop_file" ||
+  [[ $exec_line =~ omarchy-launch-webapp|omarchy-webapp-handler ]]; then
   OMARCHY_REMOVE_NOTIFY=false omarchy-webapp-remove "$desktop_name"
   exit 0
 fi

--- a/bin/omarchy-webapp-install
+++ b/bin/omarchy-webapp-install
@@ -202,8 +202,19 @@ fi
 # Default Exec quotes the URL as one Exec-spec argument; the whole line then gets
 # the file-syntax escaping below (unescaped first at read time per spec, so the
 # layers compose). $CUSTOM_EXEC is a full command line, so it gets file-syntax only.
+# Interactive installs can open in a Chromium app window or the desktop default
+# browser; both still get X-Omarchy-WebApp so remove menus keep finding them.
 if [[ -n $CUSTOM_EXEC ]]; then
   EXEC_COMMAND=$CUSTOM_EXEC
+elif [[ $INTERACTIVE_MODE == "true" ]]; then
+  case $(gum choose "Chromium app window" "Default browser" --header "How should this web app open?") in
+  "Default browser")
+    EXEC_COMMAND="xdg-open $(desktop_exec_arg "$APP_URL")"
+    ;;
+  *)
+    EXEC_COMMAND="omarchy-launch-webapp $(desktop_exec_arg "$APP_URL")"
+    ;;
+  esac
 else
   EXEC_COMMAND="omarchy-launch-webapp $(desktop_exec_arg "$APP_URL")"
 fi
@@ -227,6 +238,7 @@ Terminal=false
 Type=Application
 Icon=$icon_field
 StartupNotify=true
+X-Omarchy-WebApp=true
 EOF
 
 # Add mime types if provided

--- a/bin/omarchy-webapp-remove
+++ b/bin/omarchy-webapp-remove
@@ -15,7 +15,7 @@ DESKTOP_DIR="$HOME/.local/share/applications/"
 # the ones a reconstructed path cannot reach.
 WEB_APP_PATHS=()
 while IFS= read -r -d '' file; do
-  if grep -q '^Exec=.*\(omarchy-launch-webapp\|omarchy-webapp-handler\).*' "$file"; then
+  if grep -qE '^(X-Omarchy-WebApp=true|Exec=.*(omarchy-launch-webapp|omarchy-webapp-handler))' "$file"; then
     WEB_APPS+=("$(basename "${file%.desktop}")")
     WEB_APP_PATHS+=("$file")
   fi

--- a/bin/omarchy-webapp-remove-all
+++ b/bin/omarchy-webapp-remove-all
@@ -12,7 +12,7 @@ echo "Scanning for web apps in $APP_DIR..."
 
 webapp_desktop_files=()
 while IFS= read -r -d '' file; do
-  if grep -q "Exec=omarchy-launch-webapp\|Exec=omarchy-webapp-handler" "$file" 2>/dev/null; then
+  if grep -qE '^(X-Omarchy-WebApp=true|Exec=.*(omarchy-launch-webapp|omarchy-webapp-handler))' "$file" 2>/dev/null; then
     webapp_desktop_files+=("$file")
   fi
 done < <(find "$APP_DIR" -maxdepth 1 -name "*.desktop" -print0 2>/dev/null)

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -290,7 +290,7 @@
   "remove.theme": {"icon":"󰸌","label":"Theme","action":"omarchy-theme-remove"},
   "remove.gaming": {"icon":"","label":"Gaming","title":"Remove"},
   "remove.browser": {"icon":"","label":"Browser","title":"Remove"},
-  "remove.webapp": {"icon":"","label":"Web App","when":"grep -qE '^Exec=.*(omarchy-launch-webapp|omarchy-webapp-handler)' $HOME/.local/share/applications/*.desktop","action":"omarchy-webapp-remove"},
+  "remove.webapp": {"icon":"","label":"Web App","when":"grep -qE '^(X-Omarchy-WebApp=true|Exec=.*(omarchy-launch-webapp|omarchy-webapp-handler))' $HOME/.local/share/applications/*.desktop","action":"omarchy-webapp-remove"},
   "remove.tui": {"icon":"","label":"TUI","when":"grep -qE '^Exec=.*(\\$TERMINAL|xdg-terminal-exec).*-e' $HOME/.local/share/applications/*.desktop","action":"omarchy-tui-remove"},
   "remove.windows": {"icon":"󰍲","label":"Windows","when":"[[ -f $HOME/.local/share/applications/windows-vm.desktop ]]","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-windows-vm remove'"},
   "remove.preinstalls": {"icon":"󰏓","label":"Preinstalls","when":"[[ ! -f $HOME/.local/state/omarchy/preinstalls-removed ]]","action":"omarchy-launch-floating-terminal-with-presentation omarchy-remove-preinstalls"},

--- a/migrations/1788959623.sh
+++ b/migrations/1788959623.sh
@@ -1,0 +1,14 @@
+echo "Mark Omarchy web app launchers so default-browser apps stay in the web app list"
+
+apps_dir="$HOME/.local/share/applications"
+[[ -d $apps_dir ]] || return 0
+
+shopt -s nullglob
+for file in "$apps_dir"/*.desktop; do
+  grep -q '^X-Omarchy-WebApp=true' "$file" && continue
+
+  if grep -qE '^Exec=.*(omarchy-launch-webapp|omarchy-webapp-handler)' "$file" ||
+    grep -qE '^Exec=xdg-open[[:space:]]+["'\'']?https?://' "$file"; then
+    printf 'X-Omarchy-WebApp=true\n' >>"$file"
+  fi
+done

--- a/test/shell.d/webapp-install-test.sh
+++ b/test/shell.d/webapp-install-test.sh
@@ -29,6 +29,8 @@ desktop=$(desktop_for Example)
 grep -Fxq 'Name=Example' "$desktop" || fail "webapp install writes the app name"
 grep -Fxq 'Exec=omarchy-launch-webapp "https://example.com"' "$desktop" ||
   fail "webapp install launches the https URL" "$(cat "$desktop")"
+grep -Fxq 'X-Omarchy-WebApp=true' "$desktop" ||
+  fail "webapp install marks the launcher as an Omarchy web app" "$(cat "$desktop")"
 pass "webapp install writes an https desktop entry"
 
 if install_webapp "Plain" "example.org/app" "webapp" >"$tmpdir/out" 2>"$tmpdir/err"; then
@@ -122,3 +124,53 @@ grep -Fq 'must be http or https' "$tmpdir/err" ||
   fail "interactive webapp install refuses before fetching the URL" "$(cat "$tmpdir/curl-log")"
 [[ ! -e $(desktop_for Evil) ]] || fail "interactive webapp install writes no desktop file"
 pass "interactive webapp install refuses a bad URL before fetching it"
+
+# Interactive installs ask how to open the app. Choosing the default browser
+# must still leave an Omarchy web-app marker so remove menus keep finding it.
+printf 'Browser\nhttps://example.com/\nDefault browser\n' >"$tmpdir/answers"
+: >"$tmpdir/gum-count"
+: >"$tmpdir/curl-log"
+
+# Icon fetch should succeed so gum is not asked for an icon URL before the
+# browser choice; answer curl with a tiny PNG when writing -o.
+cat >"$stubs/curl" <<'CURL'
+#!/bin/bash
+out=""
+prev=""
+for arg in "$@"; do
+  [[ $prev == "-o" ]] && out="$arg"
+  prev="$arg"
+done
+if [[ -n $out ]]; then
+  printf '%s' 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==' | base64 -d >"$out"
+  exit 0
+fi
+exit 1
+CURL
+chmod +x "$stubs/curl"
+
+if ! GUM_ANSWERS="$tmpdir/answers" GUM_COUNT="$tmpdir/gum-count" \
+  PATH="$stubs:$PATH" HOME="$home" "$ROOT/bin/omarchy-webapp-install" \
+  >"$tmpdir/out" 2>"$tmpdir/err"; then
+  fail "interactive webapp install accepts default browser" "$(cat "$tmpdir/err")"
+fi
+
+browser_desktop=$(desktop_for Browser)
+grep -Fxq 'Exec=xdg-open "https://example.com/"' "$browser_desktop" ||
+  fail "interactive webapp install writes xdg-open for default browser" "$(cat "$browser_desktop")"
+grep -Fxq 'X-Omarchy-WebApp=true' "$browser_desktop" ||
+  fail "interactive default-browser install keeps the Omarchy web app marker" "$(cat "$browser_desktop")"
+pass "interactive webapp install can open with the default browser"
+
+# Remove must discover default-browser launchers via the marker, not Exec alone.
+printf '#!/bin/bash\n:\n' >"$stubs/update-desktop-database"
+printf '#!/bin/bash\n:\n' >"$stubs/omarchy-notification-send"
+chmod +x "$stubs/update-desktop-database" "$stubs/omarchy-notification-send"
+
+if ! HOME="$home" PATH="$stubs:$PATH" OMARCHY_REMOVE_NOTIFY=false \
+  "$ROOT/bin/omarchy-webapp-remove" "Browser" >"$tmpdir/out" 2>"$tmpdir/err"; then
+  fail "webapp remove finds a default-browser web app" "$(cat "$tmpdir/err")"
+fi
+[[ ! -e $browser_desktop ]] ||
+  fail "webapp remove deletes a default-browser web app"
+pass "webapp remove finds default-browser launchers via X-Omarchy-WebApp"

--- a/test/shell.d/webapp-name-test.sh
+++ b/test/shell.d/webapp-name-test.sh
@@ -95,10 +95,26 @@ pass "webapp install refuses a slashed name before fetching its icon"
 run_install "Example App" "https://example.com" hey >/dev/null
 [[ -f "$apps_dir/Example App.desktop" ]] ||
   fail "webapp install writes the launcher for an ordinary name"
+grep -Fxq 'X-Omarchy-WebApp=true' "$apps_dir/Example App.desktop" ||
+  fail "webapp install marks an ordinary launcher" "$(cat "$apps_dir/Example App.desktop")"
 run_remove "Example App" >/dev/null
 [[ -f "$apps_dir/Example App.desktop" ]] &&
   fail "webapp remove deletes the launcher it installed"
 pass "webapp install and remove round-trip an ordinary name"
+
+# Default-browser launchers only carry the marker (Exec is xdg-open). Removal
+# must still find them the same way the Omarchy menu does.
+cat >"$apps_dir/Default Browser App.desktop" <<'DESKTOP'
+[Desktop Entry]
+Name=Default Browser App
+Exec=xdg-open "https://example.com/"
+Type=Application
+X-Omarchy-WebApp=true
+DESKTOP
+run_remove "Default Browser App" >/dev/null
+[[ -f "$apps_dir/Default Browser App.desktop" ]] &&
+  fail "webapp remove deletes a marker-only default-browser launcher"
+pass "webapp remove finds marker-only default-browser launchers"
 
 # Anything installed by an older version can still be nested. Removal has to
 # reach it, which a path rebuilt from the displayed name never could.


### PR DESCRIPTION
## Summary

Interactive web app installs can now choose how the launcher opens:

- **Chromium app window** — existing behavior via `omarchy-launch-webapp` (standalone Chromium `--app=` window)
- **Default browser** — opens with `xdg-open` so the site uses whatever browser the user set as default (Firefox, Helium, Chrome, etc.)

Both kinds of launcher stay on Omarchy’s **Remove → Web App** list (and related remove paths), because identity is no longer tied solely to `Exec=omarchy-launch-webapp`.

### Why

Today every interactively created web app is forced through Chromium app mode. That is great for “app-like” sites, but it is a poor fit when someone wants:

- their real default browser (cookies, extensions, profiles, password manager)
- sites that behave better outside Chromium `--app=` mode
- a normal browser tab/window instead of a stripped app window

People who hand-edit `.desktop` files to `xdg-open` hit a second problem: Omarchy only treated launchers as web apps when `Exec=` matched `omarchy-launch-webapp` / `omarchy-webapp-handler`. After switching to `xdg-open`, those apps **disappeared from Remove → Web App** even though they were still Omarchy-installed web apps. This change fixes that class of breakage and makes the default-browser option a first-class path.

### How

1. **`omarchy-webapp-install` (interactive only)**  
   After name / URL / icon, asks via `gum choose`:
   - `Chromium app window` → `Exec=omarchy-launch-webapp "<url>"`
   - `Default browser` → `Exec=xdg-open "<url>"`  
   Non-interactive calls (`omarchy-webapp-install name url icon [custom-exec] [mime-types]`) are unchanged: still default to `omarchy-launch-webapp`, and still honor an explicit custom exec. Installer scripts that create web apps keep working with no argument changes.

2. **`X-Omarchy-WebApp=true` marker**  
   Every launcher written by `omarchy-webapp-install` now includes this desktop-entry key. Detection becomes:

   ```text
   X-Omarchy-WebApp=true
   OR
   Exec=.*(omarchy-launch-webapp|omarchy-webapp-handler)
   ```

   so:
   - new Chromium and default-browser apps are both discoverable
   - older Chromium-only launchers without the marker still work
   - random `xdg-open` desktop files are **not** treated as Omarchy web apps unless marked

3. **Call sites updated to the same detection rule**
   - `bin/omarchy-webapp-remove`
   - `bin/omarchy-webapp-remove-all`
   - `bin/omarchy-remove-launcher-entry`
   - `default/omarchy/omarchy-menu.jsonc` (`remove.webapp` `when`)

4. **Migration** (`migrations/1788959623.sh`)  
   On update, tags existing user launchers under `~/.local/share/applications/` that already look like Omarchy web apps:
   - `Exec` uses `omarchy-launch-webapp` / `omarchy-webapp-handler`, or
   - `Exec` is `xdg-open` with an `http(s)` URL  

   so people who already switched some apps to the default browser get them back on the remove list without reinstalling.

5. **Tests**  
   Extended `test/shell.d/webapp-install-test.sh` and `webapp-name-test.sh` to cover:
   - marker written on normal installs
   - interactive default-browser → `xdg-open` + marker
   - remove discovering marker-only / default-browser launchers

## Test plan

- [x] `bash test/shell.d/webapp-install-test.sh`
- [x] `bash test/shell.d/webapp-name-test.sh`
- [x] Manual: Install → Web App → choose **Default browser** → app launches via default browser and appears under Remove → Web App
- [x] Manual: Install → Web App → choose **Chromium app window** → still opens as Chromium `--app=` and remains removable
- [x] Manual: previously `xdg-open`-edited web apps reappear under Remove → Web App after marking / migration logic
- [ ] Reviewer: run `./test/shell` (or `./test/all`) on a clean tree if desired


Made with [Cursor](https://cursor.com)