### PR TITLE
Name the cause when libfprint cannot drive the fingerprint reader

### DIFF
--- a/bin/omarchy-setup-security-fingerprint
+++ b/bin/omarchy-setup-security-fingerprint
@@ -6,6 +6,28 @@
 set -e
 
 
+# Readers that libfprint has no driver for, but that the community's
+# reverse-engineered python-validity daemon does drive. omarchy-hw-fingerprint
+# matches these on vendor ID (06cb and 138a are both on its list), so setup gets
+# all the way to enrollment before fprintd reports "No devices available" --
+# indistinguishable from a bad swipe, so the generic "please try again" sends
+# people into a retry loop that cannot succeed. Name the real cause instead.
+#
+# The list is python-validity's own udev match set, from its
+# 94-validity-sensors.rules.
+validity_readers=" 06cb:009a 138a:0090 138a:0097 "
+
+has_validity_reader() {
+  local dev vendor product
+  for dev in "${OMARCHY_USB_DEVICES_PATH:-/sys/bus/usb/devices}"/*; do
+    [[ -r $dev/idVendor && -r $dev/idProduct ]] || continue
+    vendor=$(<"$dev/idVendor")
+    product=$(<"$dev/idProduct")
+    [[ $validity_readers == *" $vendor:$product "* ]] && return 0
+  done
+  return 1
+}
+
 setup_pam_config() {
   # A clamshell gate runs before pam_fprintd in every stack: when the lid is
   # shut the reader is unreachable, so it skips fingerprint (success=1) and PAM
@@ -106,6 +128,13 @@ if sudo fprintd-enroll "$USER"; then
     echo -e "\e[31m\nVerification failed. You may want to try enrolling again.\e[0m"
   fi
 else
-  echo -e "\e[31m\nEnrollment failed. Please try again.\e[0m"
+  if has_validity_reader; then
+    echo -e "\e[31m\nEnrollment failed: libfprint has no driver for this reader.\e[0m"
+    echo "It is a Synaptics/Validity sensor that only the community"
+    echo "python-validity driver can talk to, so retrying will not help:"
+    echo "  https://github.com/uunicorn/python-validity"
+  else
+    echo -e "\e[31m\nEnrollment failed. Please try again.\e[0m"
+  fi
   exit 1
 fi


### PR DESCRIPTION
`omarchy-hw-fingerprint` matches readers on vendor ID, and `06cb` and `138a` are both on its list. Three of those devices — `06cb:009a`, `138a:0090` and `138a:0097` — have no libfprint driver at all; only the community's reverse-engineered [python-validity](https://github.com/uunicorn/python-validity) daemon talks to them.

So `omarchy setup security fingerprint` detects a reader, installs `libfprint-git`, and runs all the way to enrollment before fprintd reports `No devices available`. That surfaces as:

```
Enrollment failed. Please try again.
```

which is indistinguishable from a bad swipe, and sends people into a retry loop that cannot succeed. The script already anticipates this shape of failure — the comment above `setup_pam_config` notes that an Elan MOC sensor outside the elanmoc table "gets this far and then fails to enroll" — this just names the cause for the three devices where it's knowable up front.

### Change

On enrollment failure, check for those three IDs and say what's actually wrong:

```
Enrollment failed: libfprint has no driver for this reader.
It is a Synaptics/Validity sensor that only the community
python-validity driver can talk to, so retrying will not help:
  https://github.com/uunicorn/python-validity
```

Only the failure message changes. Nothing new is installed, the supported path is untouched, and the device list is python-validity's own udev match set from `94-validity-sensors.rules` rather than a guess.

### Verification

Tested on a ThinkPad T480 with `06cb:009a` (Synaptics Metallica MIS Touch), where the reader does work once python-validity is driving it — `fprintd-list` goes from "No devices available" to "found 1 devices", and enrollment and `fprintd-verify` then succeed.

The helper honours `OMARCHY_USB_DEVICES_PATH`, so it is testable the same way `omarchy-hw-fingerprint` is:

- real sysfs on that machine → matches
- device tree containing only an unrelated `1234:5678` → declines
- empty device tree → declines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CqYR76DqmNVGYtGYUpyJmv
