### PR TITLE
Share cameras between apps through PipeWire and name whatever still locks one

### DIFF
--- a/bin/omarchy-camera-watch
+++ b/bin/omarchy-camera-watch
@@ -1,0 +1,121 @@
+#!/bin/bash
+
+# omarchy:summary=Warn when an app takes a camera over V4L2 and locks everyone else out
+# omarchy:hidden=true
+
+# A V4L2 camera streams to one process at a time: the first to map its buffers
+# owns it, and every other app then reports "no camera" with no hint why, which
+# reads like a broken webcam rather than a busy one. PipeWire lifts the limit by
+# opening the device once and fanning the frames out to any number of clients,
+# but only apps that ask for the camera through the portal go that way. So when
+# a process maps a camera itself, name it: that is the moment the rest of the
+# desktop lost the camera, and the toast says who to close and how to fix it.
+
+set -uo pipefail
+
+# nf-fa-video_camera, the glyph the capture menu uses for the webcam, escaped so
+# this file reads without a Nerd Font.
+readonly CAMERA_GLYPH=$'\uf03d'
+
+# Starting a stream is a burst of opens and closes, and Chromium enumerates by
+# opening every node in turn; let it settle before reading who holds what.
+readonly settle_seconds=${OMARCHY_CAMERA_WATCH_SETTLE_SECONDS:-1}
+
+# A call app keeps its pid across calls, so tracking holders alone would
+# announce it at the start of every call. Announce a program at most once a
+# window.
+readonly dedupe_seconds=${OMARCHY_CAMERA_WATCH_DEDUPE_SECONDS:-300}
+
+# Extended regex of process names never worth announcing.
+readonly ignore_pattern=${OMARCHY_CAMERA_WATCH_IGNORE:-}
+
+declare -A holding last_notified
+
+camera_name() {
+  local node=${1#/dev/} name=""
+
+  [[ -r /sys/class/video4linux/$node/name ]] && name=$(</sys/class/video4linux/"$node"/name)
+  echo "${name:-$1}"
+}
+
+announce() {
+  local comm=$1 device=$2 name
+
+  name=$(camera_name "$device")
+
+  omarchy-notification-wait || return 1
+
+  omarchy-notification-send \
+    --urgency critical \
+    --glyph "$CAMERA_GLYPH" \
+    "Camera locked by $comm" \
+    "$comm took $name over V4L2, so every other app gets no camera, or a black one, until it lets go. Chromium and Electron apps can share a camera through PipeWire instead: start them with --enable-features=WebRtcPipeWireCamera."
+}
+
+# Who is streaming from a camera right now, one "pid device comm" per line.
+#
+# A process with the node open but not mapped is only looking (enumerating,
+# probing formats); mapped buffers mean a running stream, and that is what
+# locks the device. PipeWire's own node is the shared path, never the problem.
+# Only this user's processes are readable under /proc, and only this user's
+# apps are the ones the toast can ask to close.
+exclusive_holders() {
+  local fd_dir link pid device comm
+  local -A seen=()
+
+  while read -r fd_dir link; do
+    pid=${fd_dir#/proc/}
+    pid=${pid%%/*}
+    device=$link
+
+    [[ -n ${seen[$pid $device]+x} ]] && continue
+    seen[$pid $device]=1
+
+    [[ -r /proc/$pid/comm ]] || continue
+    comm=$(<"/proc/$pid/comm")
+    [[ -n $comm && $comm != "pipewire" ]] || continue
+
+    grep -qF "$device" "/proc/$pid/maps" 2>/dev/null || continue
+
+    printf '%s %s %s\n' "$pid" "$device" "$comm"
+  done < <(find /proc/[0-9]*/fd -maxdepth 1 -lname '/dev/video[0-9]*' -printf '%h %l\n' 2>/dev/null)
+}
+
+scan() {
+  local pid device comm key now
+  local -A current=()
+
+  while read -r pid device comm; do
+    key="$pid $device"
+    current[$key]=$comm
+
+    [[ -n ${holding[$key]+x} ]] && continue
+    holding[$key]=$comm
+
+    [[ -n $ignore_pattern && $comm =~ $ignore_pattern ]] && continue
+
+    now=$EPOCHSECONDS
+    (((now - ${last_notified[$comm]:-0}) < dedupe_seconds)) && continue
+
+    # Only a delivered toast starts the dedupe window; a failed send that
+    # counted would silence the next lock for five minutes.
+    announce "$comm" "$device" && last_notified[$comm]=$now
+  done < <(exclusive_holders)
+
+  # A holder that let go can be announced again when it takes the camera back.
+  for key in "${!holding[@]}"; do
+    [[ -n ${current[$key]+x} ]] || unset "holding[$key]"
+  done
+}
+
+# Whoever already holds a camera when this starts locked it before anyone was
+# watching, and is just as much the reason the next call sees no camera.
+scan
+
+# Watch /dev itself rather than the nodes, so a camera plugged in later is
+# covered without a restart; --include keeps the rest of /dev's traffic (every
+# open of /dev/null) from ever reaching the loop.
+while IFS= read -r _; do
+  while IFS= read -r -t "$settle_seconds" _; do :; done
+  scan
+done < <(inotifywait -m -q -e open,close,create,delete --include '/dev/video[0-9]+$' --format '%w%f' /dev)

--- a/config/chromium-flags.conf
+++ b/config/chromium-flags.conf
@@ -1,5 +1,5 @@
 --ozone-platform=wayland
 --ozone-platform-hint=wayland
 --password-store=gnome-libsecret
---enable-features=TouchpadOverscrollHistoryNavigation
+--enable-features=TouchpadOverscrollHistoryNavigation,WebRtcPipeWireCamera
 --load-extension=/usr/share/omarchy/default/chromium/extensions/copy-url,/usr/share/omarchy/default/chromium/extensions/yt-dlp,/usr/share/omarchy/default/chromium/extensions/whatsapp-slim

--- a/default/systemd/user/omarchy-camera-watch.service
+++ b/default/systemd/user/omarchy-camera-watch.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Warn when an app takes a camera over V4L2 and locks everyone else out
+# Needs the session bus to notify, which is up only after graphical-session.target.
+After=graphical-session.target
+PartOf=graphical-session.target
+ConditionEnvironment=WAYLAND_DISPLAY
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/omarchy-camera-watch
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=graphical-session.target

--- a/docs/file-layout.md
+++ b/docs/file-layout.md
@@ -277,7 +277,7 @@ and/or a working user systemd instance:
   `systemctl --user enable --now` the shipped user units (`bt-agent`,
   `omarchy-sleep-lock`, `omarchy-recover-internal-monitor`,
   `omarchy-migrate-notify.service`, `omarchy-fcitx5.service`,
-  `omarchy-crash-watch.service`) so they run in the first session too.
+  `omarchy-crash-watch.service`, `omarchy-camera-watch.service`) so they run in the first session too.
   Done here, not at finalize, because
   the user manager isn't reachable from the ISO chroot; `ConditionPath*`
   in the unit files keeps services inert when they don't apply.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -173,6 +173,13 @@ Everything goes through the same sender contract, so the pieces are small:
   hostile process name stays a discrete argument). It waits for the
   server first: a shell crash takes the notification server down with it, and
   that crash is the one most worth reporting.
+- **Camera locked** — `omarchy-camera-watch` watches `/dev` for camera opens and,
+  once the burst settles, reads `/proc` for any process of this user with a
+  `/dev/video*` node mapped — a running V4L2 stream, which locks every other
+  app out of that camera. PipeWire's own node is skipped as the shared path.
+  It announces the holder (deduped per program for five minutes) as a critical
+  toast that names the camera and the `WebRtcPipeWireCamera` flag that lets
+  Chromium and Electron apps share it instead.
 - **Pending migrations** — `omarchy-migrate-notify` (from its user service
   after `graphical-session.target`) waits for the server, then sends a
   critical toast whose click opens a terminal running `omarchy-migrate`,

--- a/install/user/first-run/enable-user-units.sh
+++ b/install/user/first-run/enable-user-units.sh
@@ -18,4 +18,5 @@ systemctl --user enable --now \
   omarchy-sleep-lock.service \
   omarchy-migrate-notify.service \
   omarchy-fcitx5.service \
-  omarchy-crash-watch.service
+  omarchy-crash-watch.service \
+  omarchy-camera-watch.service

--- a/migrations/1788983308.sh
+++ b/migrations/1788983308.sh
@@ -1,0 +1,41 @@
+echo "Share cameras between apps through PipeWire and warn when one is locked over V4L2"
+
+# A V4L2 camera streams to one process at a time, so a call in Slack leaves
+# Chrome reporting no camera at all, with nothing to say why. Chromium-based
+# browsers can take cameras through PipeWire instead, where any number of apps
+# share one stream. The shipped flags file now asks for that; every browser
+# flags file already copied from it gets the same feature, on its existing
+# --enable-features line because Chromium keeps only the last one it is given.
+
+feature="WebRtcPipeWireCamera"
+
+flag_files=(
+  "$HOME/.config/chromium-flags.conf"
+  "$HOME/.config/chrome-flags.conf"
+  "$HOME/.config/google-chrome-flags.conf"
+  "$HOME/.config/google-chrome-stable-flags.conf"
+  "$HOME/.config/brave-flags.conf"
+  "$HOME/.config/brave-browser-flags.conf"
+  "$HOME/.config/brave-origin-flags.conf"
+  "$HOME/.config/brave-origin-beta-flags.conf"
+  "$HOME/.config/microsoft-edge-flags.conf"
+  "$HOME/.config/microsoft-edge-stable-flags.conf"
+  "$HOME/.config/opera-flags.conf"
+  "$HOME/.config/vivaldi-flags.conf"
+  "$HOME/.config/helium-flags.conf"
+)
+
+for file in "${flag_files[@]}"; do
+  [[ -f $file ]] || continue
+  grep -qF "$feature" "$file" && continue
+
+  if grep -q '^--enable-features=' "$file"; then
+    sed -i -E \
+      -e "s/^--enable-features=(.*[^,])$/--enable-features=\1,$feature/" \
+      -e "s/^--enable-features=,?$/--enable-features=$feature/" \
+      "$file"
+  else
+    [[ -z $(tail -c1 "$file") ]] || echo >> "$file"
+    echo "--enable-features=$feature" >> "$file"
+  fi
+done

--- a/migrations/1788983400.sh
+++ b/migrations/1788983400.sh
@@ -1,0 +1,23 @@
+echo "Warn when an app takes a camera over V4L2 and locks everyone else out"
+
+# A V4L2 camera streams to one process at a time, and the app that lost out
+# only says "no camera". The watcher names whoever holds it, so that stops
+# looking like broken hardware. Fresh installs enable the unit from
+# install/user/first-run, which is skipped after the first login, so existing
+# installs need it done here.
+
+systemctl --user daemon-reload >/dev/null 2>&1 || true
+
+# `systemctl enable` needs a live user manager, which an update from a TTY does
+# not have, so fall back to writing the symlink it would have written.
+if ! systemctl --user enable omarchy-camera-watch.service >/dev/null 2>&1; then
+  wants_dir="$HOME/.config/systemd/user/graphical-session.target.wants"
+  mkdir -p "$wants_dir"
+  ln -sfn /usr/lib/systemd/user/omarchy-camera-watch.service \
+    "$wants_dir/omarchy-camera-watch.service"
+fi
+
+# Nothing to start into over SSH; the next graphical login handles it.
+if systemctl --user is-active --quiet graphical-session.target; then
+  systemctl --user start omarchy-camera-watch.service >/dev/null 2>&1 || true
+fi

--- a/test/shell.d/config-test.sh
+++ b/test/shell.d/config-test.sh
@@ -150,6 +150,7 @@ package_defaults = [
   ("default/systemd/user/omarchy-tailscale-receive.service", "/usr/lib/systemd/user/omarchy-tailscale-receive.service", "systemd/user/omarchy-tailscale-receive.service"),
   ("default/systemd/user/omarchy-fcitx5.service", "/usr/lib/systemd/user/omarchy-fcitx5.service", "systemd/user/omarchy-fcitx5.service"),
   ("default/systemd/user/omarchy-crash-watch.service", "/usr/lib/systemd/user/omarchy-crash-watch.service", "systemd/user/omarchy-crash-watch.service"),
+  ("default/systemd/user/omarchy-camera-watch.service", "/usr/lib/systemd/user/omarchy-camera-watch.service", "systemd/user/omarchy-camera-watch.service"),
   ("default/systemd/zram-generator.conf.d/90-omarchy.conf", "/usr/lib/systemd/zram-generator.conf.d/90-omarchy.conf", "systemd/zram-generator.conf.d/90-omarchy.conf"),
   ("default/systemd/system/plocate-updatedb.service.d/10-omarchy.conf", "/usr/lib/systemd/system/plocate-updatedb.service.d/10-omarchy.conf", "systemd/system/plocate-updatedb.service.d/10-omarchy.conf"),
   ("default/fonts/omarchy/omarchy.ttf", "/usr/share/fonts/omarchy/omarchy.ttf", "omarchy.ttf"),


### PR DESCRIPTION
A V4L2 camera streams to one process at a time. Start a call in Slack, then open a meeting in Chrome, and Chrome reports it has no camera, with nothing to say why. It reads like broken hardware, so people reboot instead of closing the app that holds it.

Chromium can take cameras through the `org.freedesktop.portal.Camera` portal instead, where PipeWire opens the device once and fans the frames out to every client. This enables `WebRtcPipeWireCamera` (`chrome://flags/#enable-webrtc-pipewire-camera`) in the shipped Chromium flags file, and a migration adds it to every browser flags file already copied from it, on the existing `--enable-features` line since Chromium keeps only the last one it is given.

Whatever still takes a camera over V4L2 locks the rest of the desktop out, so a new user service says so. `omarchy-camera-watch` follows camera opens on `/dev` and names any process of this user with a `/dev/video*` node mapped, as a critical toast: "Camera locked by slack — slack took Elgato Facecam 4K over V4L2, so every other app gets no camera, or a black one, until it lets go. Chromium and Electron apps can share a camera through PipeWire instead: start them with --enable-features=WebRtcPipeWireCamera." A node that is merely open (enumeration, format probing) is ignored; only mapped buffers mean a running stream, and PipeWire's own node is skipped as the shared path. One toast per program every five minutes, and `OMARCHY_CAMERA_WATCH_IGNORE` mutes one by regex. Electron apps such as Slack bundle their own Chromium and never read the flags files, which is why the toast names the flag rather than Omarchy setting it for them.

The unit is enabled at first run and by migration, and installed to `/usr/lib/systemd/user` by omacom/omarchy-pkgs#371, which belongs right behind this: `omarchy-settings-dev` builds the quattro tip, so that line needs the unit here first, and first-run enables every shipped unit in one call, so a unit missing from that path fails the whole call the way it did for the crash watcher (omacom/omarchy-pkgs#140). `config-test.sh` asserts the install.

Validation, on a desktop with an Elgato Facecam 4K, pipewire 1.6.8, wireplumber 0.5.17 and xdg-desktop-portal 1.22.1 with the gtk backend serving Access. Two Chromium 152 instances with the flag, in separate profiles, asked for the camera at the same time: both got a live "Elgato Facecam 4K (V4L2)" track at 640x480, PipeWire showed two stream links out of the one camera node, and `/dev/video0` was held by `pipewire` alone. The portal's `AccessCamera` resolved as allowed for a host app, logging the parent-window warning from #8843 without it blocking, and answered in under a second on every later call. With the flag off, Chromium held the device itself, and an instance with the flag started afterwards got a track that rendered 0 frames in 4 seconds against 121 for the holder, which is the failure the toast is for; the watcher announced "Camera locked by chromium" as that stream started and forgot it on release. The migration ran against a temporary `$HOME` with flags files in every shape (existing line, none, empty value, already present, no trailing newline) and is idempotent. `./test/all` passes except the tests that need an omarchy-iso checkout or a single-screen shell, which fail the same way on quattro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
