### PR TITLE
Move setCenterHoverRevealSuppressed into Panel base to protect cloned plugins

### DIFF
--- a/migrations/1788986100.sh
+++ b/migrations/1788986100.sh
@@ -1,0 +1,67 @@
+echo "Patch cloned panel plugins that wrote centerHoverRevealSuppressed directly"
+
+# When PluginBarApi made centerHoverRevealSuppressed readonly (4.0.3), any
+# panel plugin cloned before that change kept the old pattern:
+#
+#   if (root.bar && "centerHoverRevealSuppressed" in root.bar)
+#     root.bar.centerHoverRevealSuppressed = value
+#
+# which now fires a TypeError on every open/close, spamming the Quickshell log
+# and stalling the event loop.  Panel.qml base now owns the correct
+# setCenterHoverRevealSuppressed() implementation, so clones that still carry a
+# local copy of the broken pattern just need it stripped out to inherit from base.
+#
+# We only touch files that have the broken assignment and belong to a plugin
+# cloned from omarchy.clock or omarchy.weather (the only first-party panels
+# that use this call).  Any plugin that already has the right form, or that has
+# a genuinely different local override, is left alone.
+
+PLUGINS_DIR="$HOME/.config/omarchy/plugins"
+
+[[ -d $PLUGINS_DIR ]] || exit 0
+
+broken_pattern='(root\.)?bar\.centerHoverRevealSuppressed[[:space:]]*='
+patched=0
+
+while IFS= read -r -d '' manifest; do
+  plugin_dir="$(dirname "$manifest")"
+
+  # Only process clones of clock or weather panels
+  cloned_from="$(jq -r '.omarchy.clonedFrom // empty' "$manifest" 2>/dev/null)"
+  [[ $cloned_from == "omarchy.clock" || $cloned_from == "omarchy.weather" ]] || continue
+
+  # Find QML files that still contain the broken assignment
+  while IFS= read -r -d '' qml_file; do
+    # Confirm the file has the old pattern but NOT the new function-check form
+    if grep -qE "$broken_pattern" "$qml_file" && \
+       ! grep -q 'typeof root\.bar\.setCenterHoverRevealSuppressed' "$qml_file" && \
+       ! grep -q 'typeof bar\.setCenterHoverRevealSuppressed' "$qml_file"; then
+
+      backup=$(mktemp "${qml_file}.bak.XXXXXX")
+      cp -p "$qml_file" "$backup"
+
+      # Remove the local function block and any directly preceding comment lines
+      # using recursive balanced braces to safely handle nested blocks.
+      perl -0777 -i -pe '
+        s{(?:\n[ \t]*//[^\n]*)*\n[ \t]*function\s+setCenterHoverRevealSuppressed\s*\([^)]*\)\s*(\{ (?: [^{}]+ | (?1) )* \})}{}gx;
+      ' "$qml_file"
+
+      # Sanity check: confirm the broken assignment was eliminated
+      if grep -qE "$broken_pattern" "$qml_file"; then
+        echo "  Warning: could not cleanly remove local override from $qml_file; restoring backup." >&2
+        cp -p "$backup" "$qml_file"
+      else
+        echo "  Patched: $qml_file (backup: $backup)"
+        (( patched++ )) || true
+      fi
+    fi
+  done < <(find "$plugin_dir" -name "*.qml" -print0)
+
+done < <(find "$PLUGINS_DIR" -maxdepth 2 -name "manifest.json" -print0)
+
+if (( patched > 0 )); then
+  echo "  Patched $patched file(s)."
+else
+  echo "  No cloned panel plugins needed patching."
+fi
+

--- a/shell/Ui/Panel.qml
+++ b/shell/Ui/Panel.qml
@@ -41,6 +41,17 @@ Item {
     return value === undefined || value === null ? fallback : value
   }
 
+  // Suppress or restore the center-section hover reveal while this panel is
+  // open. Delegates through the PluginBarApi function so the call works on
+  // any bar build; if the function is absent (pre-4.0.3 builds still in
+  // use by a cloned plugin) it falls back to a direct property write.
+  function setCenterHoverRevealSuppressed(value) {
+    if (bar && typeof bar.setCenterHoverRevealSuppressed === "function")
+      bar.setCenterHoverRevealSuppressed(value)
+    else if (bar && "centerHoverRevealSuppressed" in bar)
+      bar.centerHoverRevealSuppressed = value
+  }
+
   PanelController {
     id: panelController
   }

--- a/shell/plugins/panels/clock/Panel.qml
+++ b/shell/plugins/panels/clock/Panel.qml
@@ -116,14 +116,6 @@ Panel {
     return false
   }
 
-  // Summoning by hotkey moves no pointer, so a hover the bar was still
-  // holding must not keep the center indicators revealed behind the panel.
-  function setCenterHoverRevealSuppressed(value) {
-    if (root.bar && typeof root.bar.setCenterHoverRevealSuppressed === "function")
-      root.bar.setCenterHoverRevealSuppressed(value)
-    else if (root.bar && "centerHoverRevealSuppressed" in root.bar)
-      root.bar.centerHoverRevealSuppressed = value
-  }
 
   function refresh() {
     root.today = new Date()

--- a/shell/plugins/panels/weather/Panel.qml
+++ b/shell/plugins/panels/weather/Panel.qml
@@ -62,13 +62,6 @@ Panel {
     return false
   }
 
-  function setCenterHoverRevealSuppressed(value) {
-    if (root.bar && typeof root.bar.setCenterHoverRevealSuppressed === "function")
-      root.bar.setCenterHoverRevealSuppressed(value)
-    else if (root.bar && "centerHoverRevealSuppressed" in root.bar)
-      root.bar.centerHoverRevealSuppressed = value
-  }
-
   // Parsed wttr.in j1 response. Kept on failure so stale data stays visible.
   property var report: null
   property var dailyForecastReport: null


### PR DESCRIPTION
## Problem

When `PluginBarApi` made `centerHoverRevealSuppressed` **readonly** in 4.0.3 (commit 094c913), the clock and weather panels were updated to call the new `setCenterHoverRevealSuppressed()` function. However, any user-cloned copy of those panels (created with `omarchy plugin clone omarchy.clock` or `omarchy plugin clone omarchy.weather`) kept the old direct-write pattern on disk:

```qml
// old broken pattern — fires TypeError in a loop after 4.0.3:
if (root.bar && "centerHoverRevealSuppressed" in root.bar)
  root.bar.centerHoverRevealSuppressed = value
```

Because `clone` takes a static copy of the source files at clone time, those plugins are never updated by package upgrades. The TypeError fires on every panel open and close, spamming the Quickshell log and stalling the event loop — causing the entire desktop to freeze while the calendar (or weather panel) is open.

## Solution

**Move `setCenterHoverRevealSuppressed()` into the `Panel` base** (`shell/Ui/Panel.qml`).

The base is always from the running build. Because cloned plugins inherit from `Panel` through `qs.Ui`, they get the correct implementation automatically — without any file in the clone needing to be edited. The function is backward-compatible: it calls the `PluginBarApi` function when available (4.0.3+) and falls back to the direct property write for older builds.

The local overrides in the clock and weather panels become redundant and are removed.

**Add a migration** (`migrations/1788986100.sh`) that detects cloned clock/weather panels still carrying the broken local override, safely strips it with backup and nested-block awareness, and leaves the shell restart to `omarchy update` per migration guidelines.

## Changes

| File | Change |
|------|--------|
| `shell/Ui/Panel.qml` | Add `setCenterHoverRevealSuppressed()` — backward-compatible, delegates to `PluginBarApi` function |
| `shell/plugins/panels/clock/Panel.qml` | Remove redundant local override (now inherited) |
| `shell/plugins/panels/weather/Panel.qml` | Remove redundant local override (now inherited) |
| `migrations/1788986100.sh` | Safely strip broken pattern from existing cloned plugins with backups and validation |

## Why Panel base, not just a migration

A migration alone fixes currently-installed clones, but the next user who clones `omarchy.clock` gets a fresh static copy of whichever `Panel.qml` exists at clone time. If that copy ever lacks the function, they hit the same bug again. Putting the implementation in the **base** makes it invariant: the base always tracks the running build, so the correct behavior follows the shell version, not the clone timestamp.