### PR TITLE
Point six installer keymaps at ones systemd can map

### DIFF
--- a/install/provisioning/setup-form.sh
+++ b/install/provisioning/setup-form.sh
@@ -36,9 +36,9 @@ English (US, Colemak)|colemak
 Azerbaijani|azerty
 Belarusian|by
 Belgian|be-latin1
-Bulgarian|bg-cp1251
+Bulgarian|bg_bds-utf8
 Croatian|croat
-Czech|cz
+Czech|cz-lat2
 Danish|dk-latin1
 Dutch|nl
 Estonian|et
@@ -48,7 +48,7 @@ French (Canada)|cf
 French (Switzerland)|fr_CH
 Georgian|ge
 German|de
-German (Switzerland)|de_CH-latin1
+German (Switzerland)|sg-latin1
 Greek|gr
 Hebrew|il
 Hungarian|hu
@@ -62,8 +62,8 @@ Lao|la-latin1
 Latvian|lv
 Lithuanian|lt
 Macedonian|mk-utf
-Norwegian|no-latin1
-Polish|pl
+Norwegian|no
+Polish|pl2
 Portuguese|pt-latin1
 Portuguese (Brazil)|br-abnt2
 Romanian|ro
@@ -76,7 +76,7 @@ Spanish (Latin American)|la-latin1
 Swedish|sv-latin1
 Tajik|tj_alt-UTF8
 Turkish|trq
-Ukrainian|ua'
+Ukrainian|ua-utf'
 
 OMARCHY_USERNAME_PATTERN='^[a-z_][a-z0-9_-]*[$]?$'
 OMARCHY_RESERVED_USERNAMES='^(root|bin|daemon|mail|ftp|http|nobody|dbus|systemd-coredump|systemd-network|systemd-oom|systemd-journal-remote|systemd-resolve|systemd-timesync|tss|uuidd|alpm|git|avahi|cups|cups-browsed|lp|_talkd|polkitd|rtkit|qemu|brltty|gluster|rpc|libvirt-qemu|pcscd|nvidia-persistenced|sddm)$'

--- a/install/provisioning/setup-form.sh
+++ b/install/provisioning/setup-form.sh
@@ -58,7 +58,6 @@ Italian|it
 Japanese|jp106
 Kazakh|kazakh
 Kyrgyz|kyrgyz
-Lao|la-latin1
 Latvian|lv
 Lithuanian|lt
 Macedonian|mk-utf


### PR DESCRIPTION
Fixes six of the nine installer keyboard layouts reported in #11004, and drops one duplicate row.

`systemd-firstboot` derives `XKBLAYOUT` from `kbd-model-map`. A console keymap with no row there leaves `XKBLAYOUT` unset, and `default/hypr/input.lua` line 31 — `local kb_layout = vconsole.XKBLAYOUT or "us"` — falls back to `us`. Nine of the 48 offered layouts have no such row, so those users get a US desktop layout whatever they picked.

Six of the nine have an equivalent keymap that *is* mapped, so the fix is data only:

| Label | was | now | resulting `XKBLAYOUT` |
| --- | --- | --- | --- |
| Bulgarian | `bg-cp1251` | `bg_bds-utf8` | `bg,us` |
| Czech | `cz` | `cz-lat2` | `cz` |
| German (Switzerland) | `de_CH-latin1` | `sg-latin1` | `ch` |
| Norwegian | `no-latin1` | `no` | `no` |
| Polish | `pl` | `pl2` | `pl` |
| Ukrainian | `ua` | `ua-utf` | `ua,us` |

Bulgarian and Ukrainian are the sharp end: those users landed on a US layout with **no way to type Cyrillic at all**. `input.lua`'s `non_latin_layouts` guard exists for exactly that case but never fired, because `XKBLAYOUT` was empty. The mapped keymaps also bring `grp:shifts_toggle` and `grp_led:scroll`, so switching between the Cyrillic and Latin layouts works.

Credit to @aholbreich, who widened this from the two rows I originally reported to all nine and worked out which were fixable this way.

## Evidence

On Omarchy, systemd 261, kbd 2.10.0. `--root` writes to a throwaway directory, so nothing on the host changes:

```
$ systemd-firstboot --root=$T --keymap=bg-cp1251 --force
$ cat $T/etc/vconsole.conf
KEYMAP=bg-cp1251
                                    <- no XKBLAYOUT

$ systemd-firstboot --root=$T3 --keymap=bg_bds-utf8 --force
$ cat $T3/etc/vconsole.conf
KEYMAP=bg_bds-utf8
XKBLAYOUT=bg,us
XKBMODEL=pc105
XKBOPTIONS=terminate:ctrl_alt_bksp,grp:shifts_toggle,grp_led:scroll
```

Running that over every row in `OMARCHY_KEYBOARD_LAYOUTS` takes the number with no `XKBLAYOUT` from **nine to three**, and every keymap in the list is one `kbd` actually ships.

One trap worth recording: `cz-qwerty` resolves to `cz,us` but `kbd` does not ship it, so it would pass a `kbd-model-map` check and fail at runtime. `cz-lat2` is the safe pick.

## What this does not fix

Colemak, Azerbaijani and Kyrgyz have no mapped equivalent — there is no keymap to point them at. They still need the fallback table proposed in #8685, which is complementary to this: that change derives XKB from `KEYMAP` at runtime and so also helps machines already installed with the current values, while this one stops new installs writing a bad value in the first place.

Azerbaijani is separately mislabelled — `azerty` is the French console keymap and `kbd` has no Azerbaijani one — which is the other half of #11004 and not addressed here.

## Lao

Second commit, split so it can be dropped on its own. `la-latin1` is the Latin American Spanish keymap and is already offered under that name three rows down, so picking Lao gave a Spanish keyboard. `kbd` ships no Lao keymap, so there is nothing to point the row at. `xkeyboard-config` does have a `lo` layout, so Lao could return if the list ever carries an explicit XKB field.

## Testing

- `test/shell.d/setup-form-test.sh`, `keyboard-layout-test.sh` and `hyprland-keyboard-layout-test.sh` pass
- Full `test/shell` reports the same 38 pre-existing failures before and after this change — none introduced. Those are environment-dependent (missing package fixtures, no external access) and fail identically on a clean checkout.

Worth flagging: nothing in this repo's suite validates the layout rows themselves. `setup-form-test.sh` only asserts the first row is `English (US)|us`; the check that every keymap is known to `localectl` lives in `omarchy-iso`'s `test/unit/test_keyboard.py`. So these six swaps are not covered by an automated test here, before or after. I verified them by hand as above and am happy to add coverage if you want it in this repo.

Not tested from a built ISO.
