### PR TITLE
Stop bar plugins from freezing the keyboard when you close them

### DIFF
--- a/shell/Ui/KeyboardPanel.qml
+++ b/shell/Ui/KeyboardPanel.qml
@@ -67,8 +67,15 @@ PanelWindow {
   readonly property string barPos: bar ? bar.position : "top"
 
   function close() {
-    if (owner && "close" in owner) owner.close()
-    else root.open = false
+    try {
+      if (owner && "close" in owner) owner.close()
+      else root.open = false
+    } catch (err) {
+      // owner.close() can throw (readonly bar facade writes, plugin bugs).
+      // Forcing open false releases Exclusive/OnDemand; do not assign on
+      // the success path or a bound `open: owner.opened` is permanently broken.
+      root.open = false
+    }
   }
 
   function beginFocusPrime() {

--- a/shell/Ui/PluginBarApi.qml
+++ b/shell/Ui/PluginBarApi.qml
@@ -23,7 +23,19 @@ QtObject {
   property bool foregroundAnimationEnabled: true
   property bool centerSectionRevealHeld: false
   property bool _centerHoverRevealSuppressed: false
-  readonly property bool centerHoverRevealSuppressed: _centerHoverRevealSuppressed
+  // Writable on purpose. 4.0.3 made this readonly and third-party close()
+  // still assigned it; the TypeError aborted hide() and KeyboardPanel kept
+  // Exclusive focus, locking the session. Forward the write to the setter
+  // so Bar's binding on the backing store stays intact. Bar.qml mirrors
+  // host changes back onto this property.
+  property bool centerHoverRevealSuppressed: false
+
+  onCenterHoverRevealSuppressedChanged: {
+    if (centerHoverRevealSuppressed === _centerHoverRevealSuppressed)
+      return
+    setCenterHoverRevealSuppressed(centerHoverRevealSuppressed)
+  }
+
   property var activePopout: null
   property var clickTargets: []
   property var layoutConfig: ({})

--- a/shell/plugins/bar/Bar.qml
+++ b/shell/plugins/bar/Bar.qml
@@ -110,6 +110,14 @@ Item {
   property var clickTargets: []
   property var moduleSlots: []
   property var pluginBarApis: ({})
+
+  onCenterHoverRevealSuppressedChanged: {
+    for (var id in pluginBarApis) {
+      var api = pluginBarApis[id]
+      if (api && api.centerHoverRevealSuppressed !== root.centerHoverRevealSuppressed)
+        api.centerHoverRevealSuppressed = root.centerHoverRevealSuppressed
+    }
+  }
   property var pluginObjectOwners: []
 
   Component {
@@ -135,6 +143,7 @@ Item {
     api.foregroundAnimationEnabled = Qt.binding(function() { return root.foregroundAnimationEnabled })
     api.centerSectionRevealHeld = Qt.binding(function() { return root.centerSectionRevealHeld })
     api._centerHoverRevealSuppressed = Qt.binding(function() { return root.centerHoverRevealSuppressed })
+    api.centerHoverRevealSuppressed = root.centerHoverRevealSuppressed
     root.syncPluginBarApiObjects(api)
   }
 


### PR DESCRIPTION
## Summary
- After 4.0.3, opening some bar plugins (printer, CPU, and others) could freeze the whole desktop. Closing the popup failed, so an invisible overlay kept the keyboard and mouse.
- This lets those popups close the way they used to.
- If a plugin still hits an error while closing, the overlay now lets go of the keyboard instead of trapping you until a shell restart.

Fixes https://github.com/omacom/omarchy/issues/10999 and https://github.com/omacom/omarchy/issues/10979.

## Test plan
- [x] Ran this branch on a live 4.0.3 desktop
- [x] Opened the printer and CPU plugins, then closed them with Escape, a click outside, and the bar icon — keyboard came back each time
- [ ] Reviewer: open any third-party bar plugin popup, close it those same three ways, and confirm the rest of the desktop still accepts keys
- [ ] Reviewer: confirm the built-in clock and weather popups still behave as before


Made with [Cursor](https://cursor.com)