### PR TITLE
Add pre-T2 MacBook Cirrus CS8409 speaker fix

### DIFF
--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -41,6 +41,7 @@ run_logged "$OMARCHY_INSTALL/hardware/framework/qmk-hid.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-spi-keyboard.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-suspend-nvme.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-t2.sh"
+run_logged "$OMARCHY_INSTALL/hardware/apple/fix-cirrus-speakers.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-brcmfmac-supplicant.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/lenovo/fix-yoga-pro7-bass-speakers.sh"

--- a/install/hardware/apple/fix-cirrus-speakers.sh
+++ b/install/hardware/apple/fix-cirrus-speakers.sh
@@ -1,0 +1,18 @@
+# Restore speaker output on pre-T2 "Touch Bar" MacBooks (Cirrus CS8409 audio).
+#
+# These models pair a Cirrus CS8409 HDA bridge with a MAX98706 speaker amp. The
+# in-tree snd_hda_codec_cs8409 driver never initialises the amp, so the card
+# comes up with speaker_outs=0 and only headphones work. fix-t2.sh does not
+# cover them: it gates on the T2 PCI ID (106b:180[12]), which these Macs predate.
+#
+# davidjo/snd_hda_macbookpro ships the out-of-tree codec patch; the DKMS package
+# rebuilds it against every installed kernel, so the fix survives kernel updates.
+# Affected: MacBookPro13,2 MacBookPro13,3 MacBookPro14,2 MacBookPro14,3.
+
+product_name="${OMARCHY_DMI_PRODUCT_NAME:-$(cat /sys/class/dmi/id/product_name 2>/dev/null)}"
+pci="$(lspci -nn)"
+if [[ $product_name =~ ^MacBookPro1[34],[23]$ ]] &&
+  [[ $pci != *"106b:1801"* && $pci != *"106b:1802"* ]]; then
+  echo "Detected pre-T2 MacBook with Cirrus CS8409 speakers"
+  omarchy-pkg-add snd-hda-macbookpro-dkms-git
+fi

--- a/migrations/1788959623.sh
+++ b/migrations/1788959623.sh
@@ -1,0 +1,21 @@
+echo "Install the Cirrus CS8409 speaker codec fix on pre-T2 Touch Bar MacBooks"
+
+# Pre-T2 MacBookPro13,2/13,3/14,2/14,3 pair a Cirrus CS8409 HDA bridge with a
+# MAX98706 speaker amp the in-tree driver never initialises, so speakers stay
+# silent. install/hardware/apple/fix-cirrus-speakers.sh now installs the
+# davidjo/snd_hda_macbookpro DKMS codec patch on fresh setups; this backfills it
+# on existing installs. DKMS then rebuilds it on every future kernel bump, so no
+# manual re-apply is needed after an omarchy update.
+
+product_name="${OMARCHY_DMI_PRODUCT_NAME:-$(cat /sys/class/dmi/id/product_name 2>/dev/null)}"
+[[ $product_name =~ ^MacBookPro1[34],[23]$ ]] || exit 0
+
+# Read lspci into a variable before matching: piping straight into `grep -q`
+# lets grep close the pipe on the first match, and the SIGPIPE that lands on
+# lspci trips `set -o pipefail` into reporting "no T2 hardware" (#6608).
+pci="$(lspci -nn)"
+[[ $pci == *"106b:1801"* || $pci == *"106b:1802"* ]] && exit 0
+
+omarchy-pkg-present snd-hda-macbookpro-dkms-git && exit 0
+
+omarchy-pkg-add snd-hda-macbookpro-dkms-git

--- a/test/shell.d/cirrus-speakers-test.sh
+++ b/test/shell.d/cirrus-speakers-test.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+fix="$ROOT/install/hardware/apple/fix-cirrus-speakers.sh"
+migration="$ROOT/migrations/1788959623.sh"
+
+grep -Fq 'snd-hda-macbookpro-dkms-git' "$fix" ||
+  fail "Cirrus setup installs the out-of-tree codec DKMS package"
+grep -Fq 'run_logged "$OMARCHY_INSTALL/hardware/apple/fix-cirrus-speakers.sh"' "$ROOT/install/hardware/all.sh" ||
+  fail "Cirrus setup is dispatched from install/hardware/all.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+calls="$test_tmp/calls.log"
+mkdir -p "$stub_bin"
+
+cat >"$stub_bin/lspci" <<'SH'
+#!/bin/bash
+if (( ${T2_HARDWARE:-0} == 1 )); then
+  echo '01:00.0 Bridge [0680]: Apple Inc. T2 Security Chip [106b:1801]'
+fi
+for _ in {1..4096}; do
+  echo '02:00.0 Host bridge [0600]: Filler Device [ffff:0000]'
+done
+SH
+
+cat >"$stub_bin/omarchy-pkg-present" <<'SH'
+#!/bin/bash
+(( ${DKMS_INSTALLED:-0} == 1 ))
+SH
+
+cat >"$stub_bin/omarchy-pkg-add" <<'SH'
+#!/bin/bash
+printf 'omarchy-pkg-add\t%s\n' "$*" >>"$TEST_LOG"
+SH
+
+chmod +x "$stub_bin"/*
+
+run_migration() {
+  : >"$calls"
+  PATH="$stub_bin:$PATH" TEST_LOG="$calls" \
+    OMARCHY_DMI_PRODUCT_NAME="$1" T2_HARDWARE="${2:-0}" DKMS_INSTALLED="${3:-0}" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+for model in MacBookPro13,2 MacBookPro13,3 MacBookPro14,2 MacBookPro14,3; do
+  run_migration "$model"
+  grep -Fq $'omarchy-pkg-add\tsnd-hda-macbookpro-dkms-git' "$calls" ||
+    fail "Cirrus migration installs the codec fix on $model"
+done
+
+for model in MacBookPro13,1 MacBookPro14,1 MacBookPro15,2 "MacBookAir8,1" "Precision 5540"; do
+  run_migration "$model"
+  [[ ! -s $calls ]] || fail "Cirrus migration ignores $model" "$(cat "$calls")"
+done
+
+run_migration MacBookPro14,3 1
+[[ ! -s $calls ]] || fail "Cirrus migration defers to fix-t2.sh on T2 hardware" "$(cat "$calls")"
+
+run_migration MacBookPro14,3 0 1
+[[ ! -s $calls ]] || fail "Cirrus migration is idempotent once the package is installed" "$(cat "$calls")"
+
+pass "Cirrus CS8409 speaker fix targets only pre-T2 Touch Bar MacBooks"


### PR DESCRIPTION
## Problem

Pre-T2 "Touch Bar" MacBooks (`MacBookPro13,2`, `MacBookPro13,3`, `MacBookPro14,2`, `MacBookPro14,3`) pair a **Cirrus CS8409** HDA bridge with a **MAX98706** speaker amp. The in-tree `snd_hda_codec_cs8409` driver never initialises the amp, so the card comes up with `speaker_outs=0` and only headphone output works.

`install/hardware/apple/fix-t2.sh` does not help here — it gates on the T2 PCI ID (`106b:180[12]`), which these models predate. So today there is no path in Omarchy that restores speaker output on these Macs, and users have to re-apply an out-of-tree patch by hand after every update.

Write-up of the underlying issue and manual fix: https://medium.com/@chris.xg.wang/installing-omarchy-linux-on-your-old-mac-heres-the-fix-for-your-sound-1a0c289377f4

## Change

- **`install/hardware/apple/fix-cirrus-speakers.sh`** (new) — detects the affected models via `/sys/class/dmi/id/product_name`, excludes real T2 hardware, and installs `snd-hda-macbookpro-dkms-git` ([davidjo/snd_hda_macbookpro](https://github.com/davidjo/snd_hda_macbookpro)). DKMS rebuilds the codec patch on every kernel bump, so the fix survives updates — no manual re-apply.
- **`install/hardware/all.sh`** — dispatches the new leaf next to the other `apple/` lines, right after `fix-t2.sh`.
- **`migrations/1788959623.sh`** (new) — same detection, idempotent (`omarchy-pkg-present` guard), backfills the package on installs set up before the leaf existed.
- **`test/shell.d/cirrus-speakers-test.sh`** (new) — static checks plus stubbed migration runs across the four target models, rejected models, T2 hardware, and the already-installed case.

Both scripts read `lspci` into a variable before matching to avoid the `grep -q` SIGPIPE / `pipefail` misfire (#6608).

## Verification

- `./test/shell` — new test passes; the only failing files (`config`, `locate`, `snapper`, `unowned-system-paths`) fail identically on a clean `quattro` here (they need a local `omarchy-pkgs` checkout).
- On a `MacBookPro13,2`: after the DKMS build + reboot, `dmesg | grep -i cs8409` shows the patched codec, `wpctl status` lists the speaker sink, and `speaker-test -D hw:0,0 -c 2 -t sine -f 440` produces output from both speakers.

## Open questions for maintainers

- **`-git` AUR dependency.** `snd-hda-macbookpro-dkms-git` has no pinned release. Happy to switch to a versioned/vendored package or move it into the Omarchy package repo if you'd prefer.
- **Model list.** Confirming `13,2 / 13,3 / 14,2 / 14,3` is the complete CS8409 + MAX98706 set (non-Touch Bar `13,1 / 14,1` are deliberately excluded — different codec). Happy to narrow or widen.
- Whether newer `linux-t2` / `apple-t2-audio-config` now covers any of these, shrinking the target.