### PR TITLE
Run declared plugin cleanup before removal

### DIFF
--- a/bin/omarchy-plugin-pre-remove
+++ b/bin/omarchy-plugin-pre-remove
@@ -1,0 +1,134 @@
+#!/bin/bash
+
+# omarchy:summary=Validate or run a plugin's pre-remove hook
+# omarchy:group=plugin
+# omarchy:hidden=true
+# omarchy:args=<plugin-folder> <mode> [snapshot]
+
+set -euo pipefail
+
+fail() {
+  echo "omarchy-plugin-pre-remove: $*" >&2
+  exit 1
+}
+
+(( $# >= 2 && $# <= 3 )) || fail "usage: omarchy-plugin-pre-remove <plugin-folder> --check|--snapshot|--expect <snapshot>"
+plugin_dir="$1"
+mode="$2"
+expected_snapshot=""
+case "$mode" in
+--check | --snapshot) (( $# == 2 )) || fail "unexpected argument: $3" ;;
+--expect)
+  (( $# == 3 )) || fail "--expect requires the original snapshot"
+  expected_snapshot="$3"
+  ;;
+*) fail "unknown option: $mode" ;;
+esac
+[[ -e $plugin_dir || -L $plugin_dir ]] || fail "plugin folder not found: $plugin_dir"
+
+root_state="directory"
+hook=""
+manifest=""
+
+# A dangling installed-root symlink is still safe to unlink during recovery.
+if [[ -L $plugin_dir && ! -e $plugin_dir ]]; then
+  root_state="dangling"
+  IFS= read -r -d '' root < <(/usr/bin/realpath -msz -- "$plugin_dir") \
+    || fail "cannot resolve plugin folder: $plugin_dir"
+else
+  [[ -d $plugin_dir ]] || fail "plugin folder not found: $plugin_dir"
+  IFS= read -r -d '' root < <(/usr/bin/realpath -ez -- "$plugin_dir") \
+    || fail "cannot resolve plugin folder: $plugin_dir"
+  manifest="$root/manifest.json"
+  # An absent manifest must not prevent recovery of an old or broken installation.
+  if [[ -e $manifest || -L $manifest ]]; then
+    [[ -f $manifest ]] || fail "manifest.json is not a readable file: $manifest"
+    # Keep the path JSON-encoded until every character has been checked: Bash
+    # cannot represent NUL, and command substitution strips trailing newlines.
+    # Slurping rejects empty manifests and multiple JSON documents.
+    hook_json=$(/usr/bin/jq -ce -s '
+      if length != 1 or (.[0] | type) != "object" then
+        error("manifest must contain one JSON object")
+      else .[0] end
+      | if has("hooks") then
+          if (.hooks | type) != "object" then error("hooks must be an object")
+          elif (.hooks | has("preRemove")) then
+            .hooks.preRemove
+            | if type != "string" then error("hooks.preRemove must be a string")
+              elif length == 0 or startswith("/") or contains("..") then
+                error("hooks.preRemove must be a nonempty safe relative path without ..")
+              elif (explode | all(. >= 32 and (. < 127 or . > 159)) | not) then
+                error("hooks.preRemove may not contain control characters")
+              else . end
+          else "" end
+        else "" end
+    ' "$manifest") || fail "invalid pre-remove declaration or manifest in $manifest"
+    hook=$(/usr/bin/jq -r '.' <<<"$hook_json")
+  fi
+fi
+
+if [[ -n $hook ]]; then
+  # Resolve only the installed root; refuse every symlink within the hook path.
+  # All validation uses absolute paths without entering the checkout.
+  remaining="$hook"
+  candidate="$root"
+  while :; do
+    component="${remaining%%/*}"
+    candidate="$candidate/$component"
+    [[ ! -L $candidate ]] || fail "pre-remove hook path contains a symlink: $hook"
+    [[ $remaining == */* ]] || break
+    remaining="${remaining#*/}"
+  done
+  [[ -f $root/$hook && -x $root/$hook ]] || fail "pre-remove hook must be an executable file: $hook"
+fi
+
+if [[ $mode == "--check" ]]; then
+  [[ -z $hook ]] || printf '%s\n' "$hook"
+  exit 0
+fi
+
+# These host tools are installed by Omarchy. Absolute paths avoid resolving a
+# plugin-supplied executable through a relative entry in the caller's PATH.
+root_identity=$(/usr/bin/stat -c '%d:%i:%f' -- "$root") || fail "cannot identify plugin folder: $root"
+root_target=""
+manifest_digest="absent"
+hook_identity=""
+hook_digest=""
+if [[ $root_state == "dangling" ]]; then
+  IFS= read -r -d '' root_target < <(/usr/bin/readlink -z -- "$root") \
+    || fail "cannot read dangling plugin symlink: $root"
+elif [[ -e $manifest || -L $manifest ]]; then
+  manifest_digest=$(/usr/bin/sha256sum <"$manifest") || fail "cannot fingerprint manifest: $manifest"
+  manifest_digest="${manifest_digest%% *}"
+fi
+if [[ -n $hook ]]; then
+  hook_identity=$(/usr/bin/stat -c '%d:%i:%f' -- "$root/$hook") || fail "cannot identify pre-remove hook: $hook"
+  hook_digest=$(/usr/bin/sha256sum <"$root/$hook") || fail "cannot fingerprint pre-remove hook: $hook"
+  hook_digest="${hook_digest%% *}"
+fi
+# NUL separators keep paths and states unambiguous. This detects changes between
+# confirmation and revalidation; it is not an atomic defense against hostile edits.
+fingerprint=$(printf '%s\0' 'pre-remove-v1' "$root_state" "$root" "$root_identity" "$root_target" \
+  "$manifest_digest" "$hook" "$hook_identity" "$hook_digest" | /usr/bin/sha256sum) \
+  || fail "cannot fingerprint pre-remove state"
+fingerprint="${fingerprint%% *}"
+snapshot=$(/usr/bin/jq -cn --arg hook "$hook" --arg fingerprint "$fingerprint" '{hook: $hook, fingerprint: $fingerprint}')
+if [[ $mode == "--snapshot" ]]; then
+  printf '%s\n' "$snapshot"
+  exit 0
+fi
+[[ $snapshot == "$expected_snapshot" ]] || fail "pre-remove state changed after confirmation; retry removal and confirm the current hook"
+[[ -n $hook ]] || exit 0
+
+caller_env=()
+mapfile -d '' -t caller_env < <(/usr/bin/env -0)
+
+# Hooks are trusted user code, not sandboxed. A transient user service waits for
+# the whole inherited cgroup, even after its leader exits, and kills that cgroup
+# on timeout. Execute the exact relative hook with the caller's environment and
+# stdin at EOF; --collect also unloads failed units after --wait reports status.
+/usr/bin/systemd-run --user --wait --pipe --collect --quiet --service-type=exec --expand-environment=no \
+  --property=ExitType=cgroup --property=KillMode=control-group \
+  --property=RuntimeMaxSec=60s --property=TimeoutStopSec=5s \
+  --working-directory="$root" -- /usr/bin/env -i "${caller_env[@]}" "./$hook" </dev/null \
+  || fail "pre-remove hook '$hook' failed (status $?); inspect cleanup effects and fix the hook before retrying removal"

--- a/bin/omarchy-plugin-remove
+++ b/bin/omarchy-plugin-remove
@@ -2,13 +2,15 @@
 
 # omarchy:summary=Remove an installed shell plugin
 # omarchy:group=plugin
-# omarchy:args=[id] [--yes]
+# omarchy:args=[id] [--yes] [--run-pre-remove]
 # omarchy:alias=omarchy plugin rm
+# omarchy:examples=omarchy plugin remove <plugin-id> --yes # Skip removal confirmation, not cleanup authorization | omarchy plugin remove <plugin-id> --yes --run-pre-remove # Authorize required cleanup too; neither flag bypasses it
 
 set -euo pipefail
 
 PLUGINS_DIR="$HOME/.config/omarchy/plugins"
 ASSUME_YES=0
+RUN_PRE_REMOVE=0
 
 fail() {
   echo "omarchy-plugin-remove: $*" >&2
@@ -41,8 +43,23 @@ while (( $# > 0 )); do
     ASSUME_YES=1
     shift
     ;;
+  --run-pre-remove)
+    RUN_PRE_REMOVE=1
+    shift
+    ;;
   -h | --help)
-    echo "Usage: omarchy plugin remove [id] [--yes]"
+    cat <<USAGE
+Usage: omarchy plugin remove [id] [--yes] [--run-pre-remove]
+
+  --yes, -y         Skip the removal confirmation, not cleanup authorization.
+  --run-pre-remove  Authorize execution of the plugin's declared cleanup hook.
+
+A declared cleanup hook must succeed before removal; neither flag bypasses it.
+Without --run-pre-remove, execution requires separate confirmation in a terminal.
+
+For unattended removal of a plugin with cleanup:
+  omarchy plugin remove <plugin-id> --yes --run-pre-remove
+USAGE
     exit 0
     ;;
   -*)
@@ -71,6 +88,10 @@ valid_plugin_id "$id" || fail "invalid plugin id '$id'"
 target="$PLUGINS_DIR/$id"
 [[ -e $target || -L $target ]] || fail "plugin '$id' is not installed"
 
+pre_remove="$(dirname -- "${BASH_SOURCE[0]}")/omarchy-plugin-pre-remove"
+snapshot=$("$pre_remove" "$target" --snapshot) || fail "pre-remove validation failed; fix the declaration before retrying removal"
+hook=$(jq -r '.hook' <<<"$snapshot")
+
 was_enabled=""
 shell_plugins=$(omarchy-shell shell listPlugins)
 if [[ -n $shell_plugins ]]; then
@@ -84,6 +105,14 @@ if [[ -f $target/manifest.json ]]; then
   cloned_from=$(jq -r '.omarchy.clonedFrom // empty' "$target/manifest.json")
 fi
 
+if [[ -n $hook ]]; then
+  printf "Pre-remove hook '%s' runs unsandboxed as your user before removal (60-second timeout).\n" "$hook"
+  if (( ! RUN_PRE_REMOVE )); then
+    interactive || fail "cleanup requires explicit authorization; review '$target/$hook' and pass --run-pre-remove, or retain the checkout for manual recovery"
+    gum confirm "Run '$hook' as your user to clean up '$id'?" || fail "cleanup declined; checkout retained for inspection and manual recovery"
+  fi
+fi
+
 if [[ -L $target ]]; then
   confirm "Unlink '$id' (symlink -> $(readlink "$target"))?" || fail "aborted"
 elif [[ -d $target/.git ]]; then
@@ -91,6 +120,8 @@ elif [[ -d $target/.git ]]; then
 else
   confirm "Remove '$id'? The folder will be backed up." || fail "aborted"
 fi
+
+"$pre_remove" "$target" --expect "$snapshot" || fail "pre-remove check or cleanup failed; removal aborted before disabling or removing '$id'. Inspect cleanup effects, fix the cause, and retry."
 
 if [[ $was_enabled == "true" ]]; then
   omarchy-shell shell setPluginEnabled "$id" false >/dev/null

--- a/bin/omarchy-plugin-validate
+++ b/bin/omarchy-plugin-validate
@@ -5,9 +5,9 @@
 # omarchy:args=<plugin-folder>
 # omarchy:examples=omarchy plugin validate ./my-plugin
 
-# Mirrors the checks in shell/services/PluginRegistry.qml so the CLI refuses to
-# install anything the running shell would silently reject (or worse, load
-# unsafely). The shell never trusts manifests blindly; neither do we.
+# Mirrors runtime checks in shell/services/PluginRegistry.qml and validates CLI
+# lifecycle hooks before installation. The shell never trusts manifests blindly;
+# neither do we.
 
 set -o pipefail
 
@@ -23,6 +23,7 @@ Usage: omarchy plugin validate <plugin-folder>
 Checks a plugin folder's manifest.json against the schema the shell enforces:
 schemaVersion, required fields, safe relative entry points that exist, an entry
 point for each kind that needs one, no symlinks, and an id that is not reserved.
+Also validates optional CLI pre-remove hooks without executing plugin code.
 Exits 0 if valid — handy for plugin authors before publishing.
 USAGE
   exit 0
@@ -34,6 +35,9 @@ PLUGIN_DIR="${1:-}"
 MANIFEST="$PLUGIN_DIR/manifest.json"
 [[ -f $MANIFEST ]] || fail "missing manifest.json in $PLUGIN_DIR"
 jq -e . "$MANIFEST" >/dev/null 2>&1 || fail "manifest.json is not valid JSON: $MANIFEST"
+
+pre_remove="$(dirname -- "${BASH_SOURCE[0]}")/omarchy-plugin-pre-remove"
+"$pre_remove" "$PLUGIN_DIR" --check >/dev/null || fail "invalid pre-remove hook declaration"
 
 # schemaVersion must be exactly the JSON number 1 (the only version the registry
 # understands). jq's == is type-aware, so the string "1" is correctly rejected
@@ -112,7 +116,7 @@ done
 # copied plugin back at arbitrary files on disk after it lands in the trusted
 # plugins directory. The .git dir is skipped: installed plugins are git
 # checkouts, and git's internals are never loaded by the shell.
-link=$(find "$PLUGIN_DIR" -name .git -prune -o -type l -print -quit 2>/dev/null)
+link=$(find "$PLUGIN_DIR/" -name .git -prune -o -type l -print -quit 2>/dev/null)
 [[ -z $link ]] || fail "symlinks are not allowed inside a plugin folder: $link"
 
 exit 0

--- a/docs/omarchy-shell.md
+++ b/docs/omarchy-shell.md
@@ -43,7 +43,8 @@ Entry points are QML `Item`s. Panel, overlay, and menu entry points expose `open
 
 A third-party replacement bar can render registered widget components, but widgets it hosts receive a service-less entry facade. Allowing the bar to manufacture an own-service facade for an arbitrary widget would also let it retrieve that plugin's live service object. Service-backed third-party widgets therefore retain their full integration only under the trusted built-in bar; a replacement bar may still provide their target-scoped lifecycle and settings operations.
 
-Full schema: [`shell/services/PluginRegistry.qml`](../shell/services/PluginRegistry.qml).
+Shell-loading schema: [`shell/services/PluginRegistry.qml`](../shell/services/PluginRegistry.qml).
+The CLI also validates optional [pre-removal cleanup metadata](../shell/README.md#pre-removal-cleanup).
 
 ## Installing a third-party plugin
 
@@ -78,7 +79,9 @@ one replaces the active bar, and it is therefore never offered under Disable.
 Bar widgets may set `barWidget.defaultSection` to `left`, `center`, or `right`;
 widgets that omit it default to `center`.
 
-Plugins run as **unsandboxed code** inside `omarchy-shell`. Adding warns you before cloning, plugins land disabled so you can review the code before `omarchy plugin enable`, and updates show a diff before touching anything. Commands confirm in a terminal even when given arguments; without one they refuse rather than guess. Add `--yes` to skip every prompt (the path for scripts and agents). The scoped interfaces remove direct access to authentication services and avoid handing generic cross-plugin service factories to replacement bars, but visual plugins can still traverse ordinary objects in their shared QML scene. Plugin code also has the same user-level file and process access as the shell.
+Plugins run as **unsandboxed code** inside `omarchy-shell`. Adding warns you before cloning, plugins land disabled so you can review the code before `omarchy plugin enable`, and updates show a diff before touching anything. Commands confirm in a terminal even when given arguments; without one they refuse rather than guess. Add `--yes` to skip ordinary confirmation prompts; removal hooks need separate execution authorization (see below). The scoped interfaces remove direct access to authentication services and avoid handing generic cross-plugin service factories to replacement bars, but visual plugins can still traverse ordinary objects in their shared QML scene. Plugin code also has the same user-level file and process access as the shell.
+
+Plugins may declare `hooks.preRemove` to clean up owned state outside their checkout. Removal asks separately for permission to run the current executable, then runs it before disabling the plugin or deleting, unlinking, or backing up the checkout. Scripts must explicitly pass `--yes --run-pre-remove`; `--yes` alone does not authorize plugin code, including for never-enabled plugins. Changes to the resolved checkout identity, manifest contents, or hook identity or contents abort removal. Cleanup runs in a transient systemd user service with a 60-second deadline and 5-second stop grace period. Failure or timeout retains the checkout for recovery. See the [pre-removal contract](../shell/README.md#pre-removal-cleanup) for execution limits and retry responsibilities.
 
 You can still install by hand: drop a plugin into
 `~/.config/omarchy/plugins/<id>/`, run `omarchy-shell shell rescanPlugins`, then

--- a/manual/32-shell-plugins.md
+++ b/manual/32-shell-plugins.md
@@ -58,6 +58,8 @@ omarchy plugin remove acme.weather
 
 Removal disables the plugin first, then deletes it if it's a git checkout (the repo is still upstream) or unlinks it if it's a symlink. A hand-made plugin folder with no git repo gets moved to a timestamped backup inside the plugins directory instead of being deleted outright.
 
+If a plugin declares a pre-remove cleanup hook, removal asks separately for permission to run it before disabling or removing anything. Declining, a changed hook, or failed cleanup leaves the checkout in place. For scripts, `--yes` alone does not authorize plugin code: review the hook, then pass `--yes --run-pre-remove`. Plugins without a hook keep the normal removal behavior.
+
 ## Cloning a built-in to modify it
 
 This is my favorite part. If you want to change how a built-in widget behaves, don't edit the files under `$OMARCHY_PATH` — those belong to the package and the next update will overwrite them. Clone it instead:

--- a/shell/README.md
+++ b/shell/README.md
@@ -97,7 +97,8 @@ Entry points may declare `omarchyPath`, `shell`, `manifest`, `pluginRegistry`, a
 
 Widgets rendered by a third-party replacement bar receive a service-less entry facade with target-scoped lifecycle and settings operations. Their live service objects are available only when the trusted built-in bar hosts them; otherwise the replacement bar could request and retain any configured widget's service.
 
-The full schema lives in `services/PluginRegistry.qml`.
+The shell-loading schema lives in `services/PluginRegistry.qml`. The CLI also
+validates optional [pre-removal cleanup](#pre-removal-cleanup) metadata.
 
 ## Installing a third-party plugin
 
@@ -114,10 +115,7 @@ omarchy plugin remove acme.weather
 
 > ⚠️ **Plugins run as unsandboxed code inside `omarchy-shell`.** Adding warns you before cloning, plugins land disabled so you can review the code before enabling, and updates show a diff of the changes before touching anything. The scoped QML interfaces remove direct authentication-service and generic replacement-bar service lookups, but visual plugins still share and can traverse the ordinary host scene. Only add repos whose code you are willing to run.
 
-Each command is **interactive** when run bare in a terminal (gum pickers,
-confirmation, a diff to review) and fully **non-interactive** when given
-arguments. Pass `--yes` to skip every prompt — this is the path for scripts and
-AI agents:
+Commands use terminal pickers and confirmations when needed. Pass `--yes` to skip ordinary confirmation prompts in scripts and AI agents. Removal hooks require separate execution authorization, described below:
 
 ```bash
 omarchy plugin add https://github.com/acme/omarchy-weather.git --enable --yes
@@ -128,6 +126,34 @@ The installer never runs plugin code, install hooks, or sudo — it only clones
 files, validates the manifest, and toggles enabled state over shell IPC. Since
 an installed plugin is a plain git checkout, anything beyond add/update
 (pinning a ref, switching branches) is ordinary git in the plugin directory.
+
+### Pre-removal cleanup
+
+A plugin that owns registrations or other state outside its checkout can declare one optional executable in `manifest.json`:
+
+```json
+{
+  "hooks": {
+    "preRemove": "bin/cleanup"
+  }
+}
+```
+
+The path must name an executable regular file within the checkout. Absolute paths, `..`, control characters, and symlinks in the hook path are rejected. The installed plugin directory itself may be a symlink to a development checkout. `omarchy plugin validate <folder>` checks the declaration and file without executing plugin code. Removal records the checkout identity, manifest contents, and hook identity and contents before prompting, then checks them again before execution. A change aborts removal, including an added or removed hook.
+
+After confirmation, `omarchy plugin remove` runs the hook **before disabling the plugin or deleting, unlinking, or moving its checkout**. It also runs for disabled plugins, including plugins that have never been enabled. The terminal asks separately for permission to execute cleanup code. `--yes` skips the ordinary removal confirmation, but does not authorize code execution. After reviewing the current hook, scripts can authorize both steps explicitly:
+
+```bash
+omarchy plugin remove <plugin-id> --yes --run-pre-remove
+```
+
+Declining either confirmation leaves the checkout in place without running cleanup. With no declaration, removal behaves as before and needs no execution authorization or systemd user manager.
+
+The executable runs directly, respecting its shebang, with the physical checkout as its working directory, no arguments, the caller's environment and privileges, and standard input connected to `/dev/null`. Omarchy does not invoke `sudo`. Cleanup must be noninteractive. A transient systemd user service supervises the hook and its inherited cgroup, waiting for remaining processes even if the hook leader exits. After 60 seconds, it sends TERM to the group, followed by KILL after a 5-second stop grace period. Running a hook requires a reachable systemd user manager; validation does not.
+
+An invalid declaration, changed snapshot, failure to start, nonzero exit, or timeout aborts removal before the CLI disables the plugin or removes the checkout. Inspect any partial cleanup effects, correct the cause, and retry. Cleanup must be safely retryable: failure does not roll back completed effects. An entirely absent manifest remains removable for recovery of old or broken installations; a present but malformed manifest blocks removal.
+
+Hooks run as **unsandboxed plugin code**, even if the plugin was never enabled. Review the current executable before authorizing it. Path and snapshot checks detect intervening changes, but are not atomic protection against hostile concurrent edits. Process supervision is not a sandbox: hooks must not move cleanup into other services or otherwise escape the supervised cgroup. Hooks must clean up only state they own, wait for their cleanup work to finish, and return zero only when cleanup is complete. If a hook cannot be trusted or repaired, retain the checkout and recover manually; moving it can break external registrations that still point into it.
 
 ### Installing by hand
 

--- a/test/shell.d/plugin-pre-remove-test.sh
+++ b/test/shell.d/plugin-pre-remove-test.sh
@@ -1,0 +1,504 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+# Supervision cases require a real systemd user manager and take about 65 seconds
+# concurrently. GNU timeout is only an outer safety net, never the supervisor.
+for command in jq python3 git timeout realpath; do
+  require_command "$command"
+done
+
+TMPDIR=$(mktemp -d)
+cleanup() {
+  # Check both process identity and scratch-directory ownership before killing
+  # a stranded fixture. Hooks execute by relative path, not absolute argv.
+  python3 - "$TMPDIR" <<'PY'
+import os
+from pathlib import Path
+import signal
+import sys
+root = Path(sys.argv[1])
+for record in root.glob("**/fixture-pids"):
+    for value in record.read_text().splitlines():
+        pid, started = value.split()
+        pid = int(pid)
+        try:
+            stat = Path(f"/proc/{pid}/stat").read_text().rsplit(")", 1)[1].split()
+            cwd = Path(f"/proc/{pid}/cwd").resolve()
+            if stat[19] == started and cwd.is_relative_to(root):
+                os.kill(pid, signal.SIGKILL)
+        except (FileNotFoundError, ProcessLookupError):
+            pass
+PY
+  rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+stub_dir="$TMPDIR/stubs"
+mkdir -p "$stub_dir"
+cat >"$stub_dir/omarchy-shell" <<'STUB'
+#!/bin/bash
+set -euo pipefail
+case "$*" in
+  'shell listPlugins')
+    if [[ -e $HOME/enabled ]]; then
+      printf '[{"id":"acme.cleanup","enabled":true}]\n'
+    else
+      printf '[{"id":"acme.cleanup","enabled":false}]\n'
+    fi
+    ;;
+  'shell setPluginEnabled acme.cleanup false')
+    touch "$HOME/disabled"
+    rm -f "$HOME/enabled"
+    ;;
+  'shell rescanPlugins') touch "$HOME/rescanned" ;;
+  *) exit 99 ;;
+esac
+STUB
+chmod +x "$stub_dir/omarchy-shell"
+export PATH="$stub_dir:$ROOT/bin:$PATH"
+export OMARCHY_PATH="$ROOT"
+export EXPECTED_UID
+EXPECTED_UID=$(id -u)
+export PRE_REMOVE_INHERITED='ordinary inherited environment: $HOME ${MISSING} %n %i %%'
+
+new_plugin() {
+  export HOME="$TMPDIR/$1"
+  plugins="$HOME/.config/omarchy/plugins"
+  target="$plugins/acme.cleanup"
+  mkdir -p "$target/bin" "$HOME/external-registry"
+  touch "$target/checkout-present" "$HOME/enabled"
+  printf '{"plugin":"acme.cleanup","checkout":"installed"}\n' >"$HOME/external-registry/plugin.json"
+  cat >"$target/manifest.json" <<'JSON'
+{"schemaVersion":1,"id":"acme.cleanup","name":"Cleanup fixture","version":"1.0.0","kinds":["service"],"entryPoints":{"service":"Service.qml"},"hooks":{"preRemove":"bin/cleanup"}}
+JSON
+  touch "$target/Service.qml"
+  cat >"$target/bin/cleanup" <<'PY'
+#!/usr/bin/env python3
+import json
+import os
+from pathlib import Path
+import sys
+home = Path.home()
+checkout = Path(__file__).resolve().parent.parent
+assert Path.cwd() == checkout
+assert (checkout / "checkout-present").is_file()
+assert os.getuid() == int(os.environ["EXPECTED_UID"])
+assert os.environ["PRE_REMOVE_INHERITED"] == "ordinary inherited environment: $HOME ${MISSING} %n %i %%"
+assert sys.stdin.read() == ""
+assert not (home / "disabled").exists()
+with (home / "attempts").open("a") as attempts:
+    attempts.write("cleanup\n")
+(home / "external-registry/plugin.json").unlink(missing_ok=True)
+if (home / "block-cleanup").exists():
+    sys.exit(23)
+(home / "receipt.json").write_text(json.dumps({"cwd": str(Path.cwd()), "enabled": (home / "enabled").exists()}))
+assert len(sys.argv) == 1
+PY
+  chmod +x "$target/bin/cleanup"
+}
+
+remove_plugin() {
+  "$ROOT/bin/omarchy-plugin-remove" acme.cleanup "$@" </dev/null 2>&1
+}
+
+assert_retained() {
+  [[ -f $target/checkout-present && ! -e $HOME/disabled && ! -e $HOME/rescanned ]] \
+    || fail "failed removal retains checkout without disabling or rescanning" "${output:-}"
+}
+
+assert_removed() {
+  [[ ! -e $target && ! -L $target && -e $HOME/rescanned ]] \
+    || fail "successful removal removes installed path and rescans" "${output:-}"
+}
+
+new_plugin unconfirmed
+output=$(remove_plugin) && fail "noninteractive removal requires confirmation" "$output"
+assert_retained
+[[ ! -e $HOME/attempts && -e $HOME/external-registry/plugin.json ]] \
+  || fail "refusal without confirmation never executes cleanup"
+pass "unconfirmed removal never executes plugin code"
+
+new_plugin never-enabled
+rm "$HOME/enabled"
+output=$(remove_plugin --yes) && fail "--yes alone cannot authorize plugin code" "$output"
+assert_retained
+[[ ! -e $HOME/attempts && ! -e $HOME/receipt.json && -e $HOME/external-registry/plugin.json ]] \
+  || fail "noninteractive consent refusal leaves never-enabled plugin untouched"
+pass "--yes alone retains never-enabled checkout without running code"
+
+new_plugin caller-path
+cat >"$target/jq" <<'HOOK'
+#!/bin/bash
+printf 'executed\n' >"$HOME/plugin-jq-ran"
+exit 99
+HOOK
+chmod +x "$target/jq"
+output=$(cd "$HOME" && PATH=".:$PATH" "$ROOT/bin/omarchy-plugin-pre-remove" "$target" --check 2>&1) \
+  || fail "--check safely accepts caller PATH containing dot" "$output"
+[[ $output == "bin/cleanup" && ! -e $HOME/plugin-jq-ran && ! -e $HOME/attempts ]] \
+  || fail "--check does not resolve host utilities inside plugin checkout" "$output"
+pass "--check never executes plugin-owned jq through caller PATH"
+
+# The approval describes one checkout state, not permission for whatever hook
+# happens to be declared later. Every mutation remains otherwise valid.
+for mutation in added added-empty added-missing dropped dropped-manifest replaced bytes manifest identity mode root; do
+  new_plugin "snapshot-$mutation"
+  case "$mutation" in
+  added) jq 'del(.hooks)' "$target/manifest.json" >"$HOME/manifest" ;;
+  added-empty) jq '.hooks = {}' "$target/manifest.json" >"$HOME/manifest" ;;
+  added-missing) rm "$target/manifest.json" ;;
+  mode) chmod 755 "$target/bin/cleanup" ;;
+  esac
+  [[ ! -f $HOME/manifest ]] || mv "$HOME/manifest" "$target/manifest.json"
+  snapshot=$("$ROOT/bin/omarchy-plugin-pre-remove" "$target" --snapshot 2>&1) \
+    || fail "capture valid checkout before mutation: $mutation" "$snapshot"
+  [[ ! -e $HOME/attempts && -e $HOME/external-registry/plugin.json ]] \
+    || fail "snapshot never runs plugin code"
+  case "$mutation" in
+  added | added-empty)
+    jq '.hooks = {"preRemove":"bin/cleanup"}' "$target/manifest.json" >"$HOME/manifest"
+    ;;
+  added-missing)
+    printf '{"hooks":{"preRemove":"bin/cleanup"}}\n' >"$HOME/manifest"
+    ;;
+  dropped) jq 'del(.hooks)' "$target/manifest.json" >"$HOME/manifest" ;;
+  dropped-manifest) rm "$target/manifest.json" ;;
+  replaced)
+    cp "$target/bin/cleanup" "$target/bin/replacement"
+    jq '.hooks.preRemove = "bin/replacement"' "$target/manifest.json" >"$HOME/manifest"
+    ;;
+  bytes) printf '\n# Changed after approval.\n' >>"$target/bin/cleanup" ;;
+  manifest) printf '\n' >>"$target/manifest.json" ;;
+  identity)
+    cp -p "$target/bin/cleanup" "$target/bin/replacement"
+    mv "$target/bin/replacement" "$target/bin/cleanup"
+    ;;
+  mode) chmod 700 "$target/bin/cleanup" ;;
+  root)
+    cp -a "$target" "$HOME/replacement-checkout"
+    mv "$target" "$HOME/original-checkout"
+    mv "$HOME/replacement-checkout" "$target"
+    ;;
+  esac
+  [[ ! -f $HOME/manifest ]] || mv "$HOME/manifest" "$target/manifest.json"
+  output=$("$ROOT/bin/omarchy-plugin-pre-remove" "$target" --expect "$snapshot" 2>&1) \
+    && fail "stale snapshot refuses changed checkout: $mutation" "$output"
+  assert_retained
+  [[ ! -e $HOME/attempts && ! -e $HOME/receipt.json && -e $HOME/external-registry/plugin.json && -e $HOME/enabled ]] \
+    || fail "stale snapshot never runs code or changes plugin state: $mutation"
+done
+pass "stale approval rejects declaration, executable, manifest, and root changes"
+
+for declaration in absent empty missing-manifest; do
+  new_plugin "no-hook-$declaration"
+  git -C "$target" init -q
+  case "$declaration" in
+  absent) jq 'del(.hooks)' "$target/manifest.json" >"$HOME/manifest" ;;
+  empty) jq '.hooks = {}' "$target/manifest.json" >"$HOME/manifest" ;;
+  missing-manifest) rm "$target/manifest.json" ;;
+  esac
+  [[ ! -f $HOME/manifest ]] || mv "$HOME/manifest" "$target/manifest.json"
+  output=$(remove_plugin --yes) || fail "no-hook recovery works: $declaration" "$output"
+  assert_removed
+  [[ ! -e $HOME/attempts && -e $HOME/external-registry/plugin.json && -e $HOME/disabled ]] \
+    || fail "no-hook removal does not infer cleanup from executable presence: $declaration"
+done
+pass "absent hooks, empty hooks, and absent manifests retain no-hook removal behavior"
+
+new_plugin dangling-root
+rm -rf "$target"
+ln -s "$HOME/missing-checkout" "$target"
+snapshot=$("$ROOT/bin/omarchy-plugin-pre-remove" "$target" --snapshot)
+rm "$target"
+ln -s "$HOME/different-missing-checkout" "$target"
+output=$("$ROOT/bin/omarchy-plugin-pre-remove" "$target" --expect "$snapshot" 2>&1) \
+  && fail "retargeted dangling root rejects stale approval" "$output"
+[[ -L $target && ! -e $HOME/disabled && ! -e $HOME/rescanned ]] \
+  || fail "retargeted dangling root remains untouched"
+output=$(remove_plugin --yes) || fail "dangling installed root remains removable" "$output"
+assert_removed
+pass "dangling-root recovery revalidates the link before unlinking"
+
+# Every malformed declaration must fail both --check and destructive removal.
+# NUL must be rejected before shell command substitution can discard it.
+while IFS= read -r hooks; do
+  new_plugin invalid-declaration
+  # Existing control-character filenames distinguish unsafe-path rejection
+  # from merely reporting a missing executable.
+  for suffix in $'\n' $'\t' $'\177'; do
+    cp "$target/bin/cleanup" "$target/bin/cleanup$suffix"
+  done
+  jq --argjson hooks "$hooks" '.hooks = $hooks' "$target/manifest.json" >"$HOME/manifest"
+  mv "$HOME/manifest" "$target/manifest.json"
+  output=$("$ROOT/bin/omarchy-plugin-pre-remove" "$target" --check 2>&1) \
+    && fail "helper refuses unsafe declaration: $hooks" "$output"
+  output=$(remove_plugin --yes --run-pre-remove) && fail "removal refuses unsafe declaration: $hooks" "$output"
+  assert_retained
+  [[ ! -e $HOME/attempts && -e $HOME/external-registry/plugin.json ]] \
+    || fail "invalid declaration never executes code: $hooks"
+  rm -rf "$HOME"
+done <<'JSON'
+null
+[]
+"bin/cleanup"
+{"preRemove":null}
+{"preRemove":7}
+{"preRemove":false}
+{"preRemove":[]}
+{"preRemove":{}}
+{"preRemove":""}
+{"preRemove":"/bin/true"}
+{"preRemove":"../bin/cleanup"}
+{"preRemove":"bin/../bin/cleanup"}
+{"preRemove":"bin/clean\u0000up"}
+{"preRemove":"bin/cleanup\n"}
+{"preRemove":"bin/cleanup\t"}
+{"preRemove":"bin/cleanup\u007f"}
+JSON
+pass "invalid hook types and unsafe paths fail before cleanup or destructive actions"
+
+for manifest in malformed null directory; do
+  new_plugin "bad-manifest-$manifest"
+  case "$manifest" in
+  malformed) printf '{"hooks":' >"$target/manifest.json" ;;
+  null) printf 'null\n' >"$target/manifest.json" ;;
+  directory)
+    rm "$target/manifest.json"
+    mkdir "$target/manifest.json"
+    ;;
+  esac
+  output=$(remove_plugin --yes --run-pre-remove) && fail "present invalid manifest cannot bypass cleanup: $manifest" "$output"
+  assert_retained
+  [[ ! -e $HOME/attempts && -e $HOME/external-registry/plugin.json ]] \
+    || fail "present invalid manifest leaves external registration untouched"
+done
+pass "malformed and non-file present manifests cannot silently bypass cleanup"
+
+# Validation is not authorization to execute later: rerun path checks after
+# replacing a previously valid executable with each unsafe filesystem state.
+for mutation in missing nonexecutable directory symlink-file symlink-parent internal-symlink-file internal-symlink-parent; do
+  new_plugin "tampered-$mutation"
+  output=$("$ROOT/bin/omarchy-plugin-pre-remove" "$target" --check 2>&1) \
+    || fail "helper accepts valid hook before tampering" "$output"
+  output=$("$ROOT/bin/omarchy-plugin-validate" "$target" 2>&1) \
+    || fail "validator accepts valid hook before tampering" "$output"
+  [[ ! -e $HOME/attempts && -e $HOME/external-registry/plugin.json ]] \
+    || fail "validation never executes hook"
+  case "$mutation" in
+  missing) rm "$target/bin/cleanup" ;;
+  nonexecutable) chmod -x "$target/bin/cleanup" ;;
+  directory)
+    rm "$target/bin/cleanup"
+    mkdir "$target/bin/cleanup"
+    ;;
+  symlink-file)
+    mv "$target/bin/cleanup" "$HOME/outside-cleanup"
+    ln -s "$HOME/outside-cleanup" "$target/bin/cleanup"
+    ;;
+  symlink-parent)
+    mv "$target/bin" "$HOME/outside-bin"
+    ln -s "$HOME/outside-bin" "$target/bin"
+    ;;
+  internal-symlink-file)
+    mv "$target/bin/cleanup" "$target/bin/real-cleanup"
+    ln -s real-cleanup "$target/bin/cleanup"
+    ;;
+  internal-symlink-parent)
+    mv "$target/bin" "$target/real-bin"
+    ln -s real-bin "$target/bin"
+    ;;
+  esac
+  output=$(remove_plugin --yes --run-pre-remove) && fail "runtime rejects tampered hook: $mutation" "$output"
+  assert_retained
+  [[ ! -e $HOME/attempts && -e $HOME/external-registry/plugin.json ]] \
+    || fail "tampered hook is not executed: $mutation"
+done
+pass "runtime rechecks missing, nonexecutable, non-file, and symlink hooks after validation"
+
+if ! command -v systemd-run >/dev/null || ! systemctl --user show-environment >/dev/null 2>&1; then
+  pass "no systemd user manager; skipping supervised hook execution"
+  exit 0
+fi
+
+# A real non-shell executable removes an external registration while its
+# checkout and enabled state still exist; the CLI then deletes the git checkout.
+new_plugin enabled-git
+git -C "$target" init -q
+expected_checkout=$(realpath "$target")
+output=$(remove_plugin --yes --run-pre-remove) || fail "enabled plugin cleanup succeeds" "$output"
+assert_removed
+[[ ! -e $HOME/external-registry/plugin.json && -e $HOME/disabled ]] \
+  || fail "enabled cleanup removes registration and then disables plugin"
+jq -e --arg cwd "$expected_checkout" '.cwd == $cwd and .enabled == true' "$HOME/receipt.json" >/dev/null \
+  || fail "hook runs in checkout before disable"
+pass "enabled git plugin cleans external registration before disable and checkout deletion"
+
+# Root install symlinks are supported, even though internal symlinks are not.
+new_plugin disabled-symlink
+rm "$HOME/enabled"
+checkout="$HOME/developer checkout"
+mv "$target" "$checkout"
+ln -s "$checkout" "$target"
+output=$(remove_plugin --yes --run-pre-remove) || fail "disabled linked plugin cleanup succeeds" "$output"
+assert_removed
+[[ -f $checkout/checkout-present && ! -e $HOME/external-registry/plugin.json && ! -e $HOME/disabled ]] \
+  || fail "disabled plugin hook runs while only installed symlink is removed"
+jq -e --arg cwd "$(realpath "$checkout")" '.cwd == $cwd and .enabled == false' "$HOME/receipt.json" >/dev/null \
+  || fail "linked hook uses canonical checkout"
+pass "authorized disabled removal cleans up, unlinks install, and retains canonical checkout"
+
+new_plugin plain-backup
+output=$(remove_plugin --yes --run-pre-remove) || fail "plain directory cleanup succeeds" "$output"
+assert_removed
+backups=("$plugins"/.acme.cleanup.bak.*)
+(( ${#backups[@]} == 1 )) && [[ -f ${backups[0]}/checkout-present && ! -e $HOME/external-registry/plugin.json ]] \
+  || fail "plain directory moves intact to one backup after cleanup"
+pass "plain plugin directory is backed up only after cleanup"
+
+# Cleanup may have partial external effects. Failure must retain the checkout
+# and enabled state, allowing the user to correct the cause and retry.
+new_plugin retry
+git -C "$target" init -q
+touch "$HOME/block-cleanup"
+output=$(remove_plugin --yes --run-pre-remove) && fail "cleanup failure aborts removal" "$output"
+assert_retained
+[[ -e $HOME/enabled && ! -e $HOME/external-registry/plugin.json && ! -e $HOME/receipt.json ]] \
+  || fail "failed cleanup preserves plugin state without undoing external effects"
+rm "$HOME/block-cleanup"
+output=$(remove_plugin --yes --run-pre-remove) || fail "corrected cleanup can be retried" "$output"
+assert_removed
+(( $(wc -l <"$HOME/attempts") == 2 )) && [[ -e $HOME/receipt.json && -e $HOME/disabled ]] \
+  || fail "retry reruns cleanup and completes removal"
+pass "partial cleanup failure retains enabled checkout and supports correction and retry"
+
+# Supply actual input so this checks the helper's EOF boundary, not the caller's.
+new_plugin stdin-eof
+snapshot=$("$ROOT/bin/omarchy-plugin-pre-remove" "$target" --snapshot)
+output=$("$ROOT/bin/omarchy-plugin-pre-remove" "$target" --expect "$snapshot" \
+  <<<"caller input must not reach cleanup" 2>&1) || fail "hook receives EOF rather than caller input" "$output"
+[[ -e $HOME/receipt.json && ! -e $HOME/external-registry/plugin.json ]] \
+  || fail "cleanup completes with stdin isolated from caller input"
+pass "hook stdin is EOF even when the caller supplies input"
+
+# A successful leader must not let removal race a still-running child. The child
+# checks the checkout and enabled state after its parent has exited.
+new_plugin leader-exit
+git -C "$target" init -q
+cat >"$target/bin/cleanup" <<'PY'
+#!/usr/bin/env python3
+import os
+from pathlib import Path
+import subprocess
+import sys
+import time
+home = Path.home()
+if len(sys.argv) > 1:
+    (home / "child-ready").touch()
+    while not (home / "leader-exiting").exists():
+        time.sleep(0.01)
+    time.sleep(2)
+    assert Path("checkout-present").is_file()
+    assert (home / "enabled").exists()
+    assert not (home / "disabled").exists()
+    (home / "child-completed").touch()
+    sys.exit(0)
+child = subprocess.Popen([sys.executable, str(Path(__file__).resolve()), "child"])
+with (home / "fixture-pids").open("w") as record:
+    for pid in (os.getpid(), child.pid):
+        started = Path(f"/proc/{pid}/stat").read_text().rsplit(")", 1)[1].split()[19]
+        record.write(f"{pid} {started}\n")
+while not (home / "child-ready").exists():
+    time.sleep(0.01)
+(home / "leader-exiting").touch()
+PY
+chmod +x "$target/bin/cleanup"
+output=$(timeout --kill-after=5s 15s "$ROOT/bin/omarchy-plugin-remove" acme.cleanup --yes --run-pre-remove </dev/null 2>&1) \
+  || fail "successful leader waits for its child before removal" "$output"
+assert_removed
+[[ -e $HOME/child-completed && -e $HOME/disabled ]] \
+  || fail "child finishes while checkout is still installed and enabled"
+pass "successful leader exit waits for remaining child before disable and deletion"
+
+# The default-TERM parent exposes the process-group timeout escape: after the
+# parent dies, its TERM-resistant child must still be killed. Also retain the
+# both-resistant case. Isolated homes let the real 60s deadlines overlap.
+run_timeout_case() (
+  trap - EXIT
+  new_plugin "timeout-$1"
+  export RESISTANT_PARENT="$1"
+  git -C "$target" init -q
+  cat >"$target/bin/cleanup" <<'PY'
+#!/usr/bin/env python3
+import os
+from pathlib import Path
+import signal
+import subprocess
+import sys
+import time
+home = Path.home()
+if len(sys.argv) > 1:
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+    (home / "child-ready").touch()
+    while True:
+        time.sleep(0.1)
+if os.environ["RESISTANT_PARENT"] == "yes":
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+child = subprocess.Popen([sys.executable, str(Path(__file__).resolve()), "child"])
+assert os.getpgid(child.pid) == os.getpgrp()
+with (home / "fixture-pids").open("w") as record:
+    for pid in (os.getpid(), child.pid):
+        started = Path(f"/proc/{pid}/stat").read_text().rsplit(")", 1)[1].split()[19]
+        record.write(f"{pid} {started}\n")
+while not (home / "child-ready").exists():
+    time.sleep(0.01)
+(home / "timeout-started").touch()
+child.wait()
+PY
+  chmod +x "$target/bin/cleanup"
+  started=$SECONDS
+  # A separate outer timeout remains only a safety net for a broken supervisor.
+  status=0
+  timeout --kill-after=5s 90s "$ROOT/bin/omarchy-plugin-remove" acme.cleanup --yes --run-pre-remove \
+    </dev/null >"$HOME/timeout-output" 2>&1 || status=$?
+  elapsed=$((SECONDS - started))
+  output=$(cat "$HOME/timeout-output")
+  (( status != 0 && elapsed >= 64 && elapsed < 85 )) \
+    || fail "real deadline kills resistant child with resistant-parent=$1" "status=$status elapsed=${elapsed}s $output"
+  assert_retained
+  [[ -e $HOME/enabled && -e $HOME/timeout-started && -e $HOME/external-registry/plugin.json ]] \
+    || fail "timeout retains enabled checkout and external registration"
+  python3 - "$HOME/fixture-pids" <<'PY' || fail "timeout terminates both hook and descendant"
+from pathlib import Path
+import sys
+import time
+pids = [line.split() for line in Path(sys.argv[1]).read_text().splitlines()]
+for _ in range(100):
+    live = []
+    for pid, started in pids:
+        try:
+            # Ignore PID reuse and terminated zombies awaiting init reaping.
+            stat = Path(f"/proc/{pid}/stat").read_text().rsplit(")", 1)[1].split()
+            if stat[19] == started and stat[0] != "Z":
+                live.append(pid)
+        except FileNotFoundError:
+            pass
+    if not live:
+        break
+    time.sleep(0.01)
+else:
+    sys.exit(f"fixture processes survived timeout: {live}")
+PY
+  pass "real supervision kills resistant child with resistant-parent=$1 and aborts removal"
+)
+
+run_timeout_case no &
+default_parent_case=$!
+run_timeout_case yes &
+resistant_parent_case=$!
+timeout_failures=0
+wait "$default_parent_case" || timeout_failures=$((timeout_failures + 1))
+wait "$resistant_parent_case" || timeout_failures=$((timeout_failures + 1))
+(( timeout_failures == 0 )) || fail "all supervised timeout cases succeed"

--- a/test/shell.d/plugin-validate-test.sh
+++ b/test/shell.d/plugin-validate-test.sh
@@ -115,3 +115,95 @@ output=$(validate "$dir") && fail "validate refuses an entry point file that is 
 grep -qF "entry point file not found" <<<"$output" \
   || fail "validate reports a missing file as a missing file" "$output"
 pass "validate refuses an entry point file that is not there"
+
+# Pre-remove metadata is checked by the CLI without executing trusted plugin
+# code. Use a real executable whose only effect would be an external marker.
+hook_dir=$(write_plugin "cleanup-hook" '["service"]' '{"service": "Service.qml"}')
+mkdir -p "$hook_dir/bin"
+cat >"$hook_dir/bin/cleanup" <<'HOOK'
+#!/bin/bash
+touch "$HOME/cleanup-ran"
+HOOK
+chmod +x "$hook_dir/bin/cleanup"
+hook_home="$TMPDIR/hook-home"
+mkdir -p "$hook_home"
+
+set_hooks() {
+  jq --argjson hooks "$1" '.hooks = $hooks' "$hook_dir/manifest.json" >"$TMPDIR/hook-manifest"
+  mv "$TMPDIR/hook-manifest" "$hook_dir/manifest.json"
+}
+
+validate_hook() {
+  HOME="$hook_home" validate "$hook_dir"
+}
+
+set_hooks '{"preRemove":"bin/cleanup"}'
+output=$(validate_hook) || fail "validate accepts executable pre-remove hook" "$output"
+[[ ! -e $hook_home/cleanup-ran ]] || fail "validate must not execute pre-remove hook"
+pass "validate accepts executable pre-remove metadata without executing code"
+
+# A caller may have dot in PATH. Validating another directory must not turn its
+# jq into a host utility just because the hook checker inspects that checkout.
+cat >"$hook_dir/jq" <<'HOOK'
+#!/bin/bash
+printf 'executed\n' >"$HOME/plugin-jq-ran"
+exit 99
+HOOK
+chmod +x "$hook_dir/jq"
+output=$(cd "$hook_home" && PATH=".:$PATH" validate_hook) \
+  || fail "validate safely accepts caller PATH containing dot" "$output"
+[[ ! -e $hook_home/plugin-jq-ran && ! -e $hook_home/cleanup-ran ]] \
+  || fail "validate never executes plugin-owned jq or cleanup"
+pass "validate does not resolve host utilities inside the plugin checkout"
+
+set_hooks '{}'
+output=$(validate_hook) || fail "validate accepts empty hook declarations" "$output"
+pass "validate accepts empty hooks"
+
+# These files really exist, so rejection must not depend on a missing file.
+for suffix in $'\n' $'\t' $'\177'; do
+  cp "$hook_dir/bin/cleanup" "$hook_dir/bin/cleanup$suffix"
+done
+
+while IFS= read -r hooks; do
+  set_hooks "$hooks"
+  output=$(validate_hook) && fail "validate rejects invalid hook declaration: $hooks" "$output"
+  [[ ! -e $hook_home/cleanup-ran ]] || fail "invalid hook validation must not execute code"
+done <<'JSON'
+null
+[]
+"bin/cleanup"
+{"preRemove":null}
+{"preRemove":7}
+{"preRemove":false}
+{"preRemove":[]}
+{"preRemove":{}}
+{"preRemove":""}
+{"preRemove":"/bin/true"}
+{"preRemove":"../bin/cleanup"}
+{"preRemove":"bin/../bin/cleanup"}
+{"preRemove":"bin/clean\u0000up"}
+{"preRemove":"bin/cleanup\n"}
+{"preRemove":"bin/cleanup\t"}
+{"preRemove":"bin/cleanup\u007f"}
+JSON
+pass "validate rejects invalid hook types, traversal, absolute paths, NUL, and control characters"
+
+set_hooks '{"preRemove":"bin/missing"}'
+output=$(validate_hook) && fail "validate rejects missing hook executable" "$output"
+set_hooks '{"preRemove":"bin/cleanup"}'
+chmod -x "$hook_dir/bin/cleanup"
+output=$(validate_hook) && fail "validate rejects nonexecutable hook" "$output"
+chmod +x "$hook_dir/bin/cleanup"
+pass "validate rejects hooks that are missing or nonexecutable"
+
+mv "$hook_dir/bin/cleanup" "$TMPDIR/outside-cleanup"
+ln -s "$TMPDIR/outside-cleanup" "$hook_dir/bin/cleanup"
+output=$(validate_hook) && fail "validate rejects symlink hook executable" "$output"
+rm "$hook_dir/bin/cleanup"
+mv "$TMPDIR/outside-cleanup" "$hook_dir/bin/cleanup"
+mv "$hook_dir/bin" "$TMPDIR/outside-bin"
+ln -s "$TMPDIR/outside-bin" "$hook_dir/bin"
+output=$(validate_hook) && fail "validate rejects symlink parent escape" "$output"
+[[ ! -e $hook_home/cleanup-ran ]] || fail "filesystem hook validation must not execute code"
+pass "validate rejects symlink executables and symlink parent escapes without executing code"


### PR DESCRIPTION
## Why

Plugins can own registrations or other state outside their checkout. Removing the checkout first leaves that state behind and can remove the executable needed to clean it up.

Add one optional manifest declaration, `hooks.preRemove`, so a plugin can finish its own cleanup before Omarchy removes it. Once declared, successful cleanup is required for removal; there is no bypass flag.

## Usage

```json
{
  "hooks": {
    "preRemove": "bin/cleanup"
  }
}
```

Interactive removal asks separately for permission to run cleanup and confirmation to remove the plugin. `--yes` skips ordinary removal confirmation, not authorization to execute the hook. After reviewing the current executable, scripts can authorize both explicitly:

```bash
omarchy plugin remove <plugin-id> --yes --run-pre-remove
```

`omarchy plugin validate <folder>` validates the declaration without executing plugin code.

## Behavior

- Run cleanup before the CLI disables the plugin or deletes, unlinks, or moves its checkout, including disabled and never-enabled plugins.
- Require an executable regular file inside the checkout. Reject absolute paths, `..`, control characters, and symlinks in the hook path; the installed plugin directory may itself link to a development checkout.
- Snapshot the checkout identity, manifest contents, and hook identity and contents before prompting, then revalidate before execution. Changes, including adding or removing a declaration, abort removal.
- Abort before CLI disable/removal on declined consent, invalid metadata, changed snapshots, failure to start, nonzero exit, or timeout. Completed cleanup effects are not rolled back; hooks must be safely retryable.
- Preserve the existing removal path when no hook is declared, without requiring execution authorization or a systemd user manager. An absent manifest remains removable for recovery; a present but malformed manifest blocks removal.

## Execution

The hook runs directly as an executable, respecting its shebang rather than being sourced or forced through Bash. It receives no arguments, uses the physical checkout as its working directory, inherits the caller's environment and privileges, and reads standard input from `/dev/null`. Omarchy does not invoke `sudo`.

A transient systemd user service supervises the hook and its inherited cgroup, including remaining children after the hook leader exits. The runtime limit is 60 seconds, followed by a 5-second stop grace period. Execution requires a reachable systemd user manager; validation does not.

This is unsandboxed plugin code. Snapshot checks are not atomic protection against hostile concurrent edits, and process supervision is not a sandbox. Hooks must clean up only their own state, wait for their work, and return zero only when cleanup is complete.

## Scope

One pre-removal hook, shared validation/execution helper, CLI integration, documentation, and regression coverage. No install/update hooks, activation ledger, package-management framework, or changes to individual plugins.

## Verification

- `./test/all` passed on Omarchy: CLI suite and all 237 shell test files, with desktop-dependent checks skipped in the headless test session. The run used real `omarchy-pkgs` and `omarchy-iso` companion checkouts and `PYTHONDONTWRITEBYTECODE=1` to keep generated bytecode out of source scans.
- Focused validation/removal tests exercised consent refusal, changed declarations and executable contents, invalid paths, development symlinks, missing manifests, dangling roots, disabled/never-enabled plugins, backups, failure/retry, stdin EOF, child completion, and both real timeout cases.
- A separate headless run confirmed static checks still execute without a systemd user manager and supervised execution cases skip cleanly.
- Actual terminal confirmation flows and caller-environment preservation were exercised.
- A controlled live Aperture exercise verified cleanup of owned registrations and worker state, failure preservation, and successful retry. Its original checkout, manifest, and configuration were restored afterward; this PR does not change Aperture or add a hook to its published manifest.

## Context

- https://github.com/omacom/omarchy-plugin-marketplace/issues/5361#issuecomment-5588792134
- https://github.com/omacom/omarchy/pull/10974