### PR TITLE
Make lock display blanking configurable

### DIFF
--- a/config/omarchy/shell.json
+++ b/config/omarchy/shell.json
@@ -2,7 +2,8 @@
   "version": 1,
   "idle": {
     "screensaver": 150,
-    "lock": 300
+    "lock": 300,
+    "blankDisplay": true
   },
   "bar": {
     "position": "top",

--- a/default/agents/skills/omarchy/plugins.md
+++ b/default/agents/skills/omarchy/plugins.md
@@ -49,4 +49,5 @@ automatically. If a change somehow fails to apply, force a reload with
 
 Set `idle.screensaver` and `idle.lock` in `~/.config/omarchy/shell.json`,
 in seconds since user idle began. Example: "lock after ten minutes" means
-setting `idle.lock` to `600`.
+setting `idle.lock` to `600`. Set `idle.blankDisplay` to `false` when a monitor
+or dock cannot recover after the lock screen turns the displays off.

--- a/manual/13-toggles-idle-screensaver.md
+++ b/manual/13-toggles-idle-screensaver.md
@@ -71,12 +71,15 @@ The Omarchy shell owns idle behavior, and the timings are a top-level `idle` blo
   "version": 1,
   "idle": {
     "screensaver": 150,
-    "lock": 300
+    "lock": 300,
+    "blankDisplay": true
   }
 }
 ```
 
 Both numbers are seconds counted from the moment you went idle — not from each other. So with the defaults, the screensaver comes up after two and a half minutes and the lock screen takes over at five minutes, whether or not the screensaver ran. Save the file and the shell picks up the new timings right away.
+
+The lock screen blanks the displays after five seconds by default. Set `idle.blankDisplay` to `false` if DPMS display blanking causes an external monitor or dock to disconnect instead of waking cleanly. Locking and authentication still work normally; only automatic display power-off is skipped.
 
 If you dismiss the screensaver before the lock deadline, that counts as activity and the pending lock is cancelled. You don't get locked out for glancing at your machine.
 

--- a/shell/README.md
+++ b/shell/README.md
@@ -237,7 +237,8 @@ becomes the authoritative file — we do **not** deep-merge defaults back in.
   "version": 1,
   "idle": {
     "screensaver": 150,
-    "lock": 300
+    "lock": 300,
+    "blankDisplay": true
   },
   "bar": {
     "id": "omarchy.bar",
@@ -279,9 +280,10 @@ becomes the authoritative file — we do **not** deep-merge defaults back in.
    `allowMultiple: true`. Each instance is independent — e.g. two clock
    widgets in different timezones are just two `{"id":"omarchy.clock", "timezone": ...}`
    entries with their own values.
-7. **Idle timings are top-level.** `idle.screensaver` and `idle.lock`
+7. **Idle settings are top-level.** `idle.screensaver` and `idle.lock`
    are seconds since user idle began, so the default lock fires at 300s
-   even if the 150s screensaver starts first.
+   even if the 150s screensaver starts first. `idle.blankDisplay` controls
+   whether the lock screen powers displays off after five seconds.
 8. **`version: 1` is required** at the top level. The shell will fall back
    to defaults rather than load an unknown version.
 

--- a/shell/plugins/lock/LockModel.js
+++ b/shell/plugins/lock/LockModel.js
@@ -1,0 +1,14 @@
+function blankDisplayEnabled(idleConfig) {
+  return !idleConfig || idleConfig.blankDisplay !== false
+}
+
+function shouldBlankDisplay(enabled, lockRequested, authenticatingPassword) {
+  return Boolean(enabled && lockRequested && !authenticatingPassword)
+}
+
+if (typeof module !== "undefined") {
+  module.exports = {
+    blankDisplayEnabled: blankDisplayEnabled,
+    shouldBlankDisplay: shouldBlankDisplay
+  }
+}

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -4,6 +4,7 @@ import Quickshell.Io
 import Quickshell.Services.Pam
 import Quickshell.Wayland
 import qs.Commons
+import "LockModel.js" as LockModel
 
 Item {
   id: root
@@ -15,6 +16,8 @@ Item {
   readonly property string stateHome: home + "/.local/state"
   readonly property string userName: Quickshell.env("USER") || Quickshell.env("LOGNAME")
   readonly property string currentBackgroundLink: stateHome + "/omarchy/current/background"
+  readonly property var idleConfig: shell && shell.shellConfig && shell.shellConfig.idle ? shell.shellConfig.idle : ({})
+  readonly property bool blankDisplayEnabled: LockModel.blankDisplayEnabled(idleConfig)
 
   property bool lockRequested: false
   property bool pendingSessionLock: false
@@ -46,6 +49,13 @@ Item {
   readonly property bool authenticating: authenticatingPassword || fingerprintAuthenticating
   readonly property var batteryService: shell && shell.services ? shell.firstPartyServiceFor("omarchy.battery") : null
   readonly property bool powerSaverActive: batteryService ? batteryService.powerSaverOnBattery : false
+
+  onBlankDisplayEnabledChanged: {
+    if (!blankDisplayEnabled) {
+      idleBlankTimer.stop()
+      if (displaysBlank) runWake()
+    } else if (lockRequested && !authenticatingPassword) armBlankTimer()
+  }
 
   function realScreenCount() {
     var screens = Quickshell.screens || []
@@ -170,6 +180,11 @@ Item {
   }
 
   function armBlankTimer() {
+    if (!blankDisplayEnabled) {
+      idleBlankTimer.stop()
+      return
+    }
+
     idleBlankTimer.armedAt = Date.now()
     idleBlankTimer.restart()
   }
@@ -493,7 +508,7 @@ Item {
       // Only a password check in flight should hold the display up. The
       // fingerprint PAM stays armed for the whole lock, so gating on
       // `authenticating` here would keep the panel lit until unlock.
-      if (root.lockRequested && !root.authenticatingPassword) root.runBlank()
+      if (LockModel.shouldBlankDisplay(root.blankDisplayEnabled, root.lockRequested, root.authenticatingPassword)) root.runBlank()
     }
   }
 

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -38,7 +38,8 @@ ShellRoot {
     version: 1,
     idle: {
       screensaver: 150,
-      lock: 300
+      lock: 300,
+      blankDisplay: true
     },
     bar: {
       position: "top",

--- a/test/shell.d/lock-blank-fingerprint-test.sh
+++ b/test/shell.d/lock-blank-fingerprint-test.sh
@@ -6,16 +6,43 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
 run_node_test <<'JS'
 const fs = require('fs')
+const lock = requireFromRoot('shell/plugins/lock/LockModel.js')
 const serviceQml = fs.readFileSync(path.join(root, 'shell/plugins/lock/Service.qml'), 'utf8')
+const shellQml = fs.readFileSync(path.join(root, 'shell/shell.qml'), 'utf8')
+const defaultConfig = JSON.parse(fs.readFileSync(path.join(root, 'config/omarchy/shell.json'), 'utf8'))
+
+assertEqual(defaultConfig.idle.blankDisplay, true, 'lock display blanking defaults to enabled')
+assertEqual(lock.blankDisplayEnabled({}), true, 'missing display blank setting preserves the default')
+assertEqual(lock.blankDisplayEnabled({ blankDisplay: true }), true, 'display blanking accepts an explicit enable')
+assertEqual(lock.blankDisplayEnabled({ blankDisplay: false }), false, 'display blanking accepts an explicit disable')
+assertEqual(lock.shouldBlankDisplay(true, true, false), true, 'an idle locked display can blank')
+assertEqual(lock.shouldBlankDisplay(false, true, false), false, 'disabled display blanking blocks DPMS-off')
+assertEqual(lock.shouldBlankDisplay(true, false, false), false, 'an unlocked display never blanks')
+assertEqual(lock.shouldBlankDisplay(true, true, true), false, 'password authentication holds the display awake')
+assert(
+  /idle: \{\s*screensaver: 150,\s*lock: 300,\s*blankDisplay: true\s*\}/.test(shellQml),
+  'the bundled fallback also enables lock display blanking'
+)
+assert(
+  /readonly property bool blankDisplayEnabled: LockModel\.blankDisplayEnabled\(idleConfig\)/.test(serviceQml),
+  'lock display blanking reads the idle config through the tested model'
+)
+assert(
+  /function armBlankTimer\(\) \{\s*if \(!blankDisplayEnabled\) \{\s*idleBlankTimer\.stop\(\)\s*return\s*\}/.test(serviceQml),
+  'disabled display blanking never arms the blank timer'
+)
+assert(
+  /if \(LockModel\.shouldBlankDisplay\(root\.blankDisplayEnabled, root\.lockRequested, root\.authenticatingPassword\)\) root\.runBlank\(\)/.test(serviceQml),
+  'a running timer uses the tested decision before switching off the display'
+)
+assert(
+  /onBlankDisplayEnabledChanged: \{[\s\S]*?idleBlankTimer\.stop\(\)[\s\S]*?if \(displaysBlank\) runWake\(\)[\s\S]*?else if \(lockRequested && !authenticatingPassword\) armBlankTimer\(\)/.test(serviceQml),
+  'live config changes stop or re-arm blanking and wake an already blank display'
+)
 
 // The fingerprint PAM stays armed for the whole lock waiting for a finger, so
 // `authenticating` is true from lock until unlock on every machine with a
 // reader enrolled. Gating the blank on it leaves the panel lit all night.
-assert(
-  /if \(root\.lockRequested && !root\.authenticatingPassword\) root\.runBlank\(\)/.test(serviceQml),
-  'only a password check in flight stops the blank timer from blanking'
-)
-
 assert(
   !/idleBlankTimer[\s\S]*?!root\.authenticating\)/.test(serviceQml),
   'the blank timer never gates on the combined authenticating state'


### PR DESCRIPTION
## Status: rework required, not a standby/wake fix

Local testing showed that this implementation avoids the failing DPMS transition by leaving the monitor powered on. That is not the required outcome. This PR must preserve Omarchy's existing idle, secure-lock, physical display-power-down, and wake behavior. A permanently visible lock screen or a black software surface with the backlight still on is not an equivalent fix.

Do not merge this implementation as the resolution of #11066. It remains a draft while the failure and a behavior-preserving fix are investigated.

## Aquamarine progress: local dpmsfix3, not hardware-approved

See the [detailed investigation and verification update](https://github.com/omacom/omarchy/issues/11066#issuecomment-5619287755) on #11066.

- Built from the exact Aquamarine v0.15.0 baseline. The candidate permits narrowly guarded synchronous disconnected-output teardown rather than changing Omarchy power policy.
- Current build and offline `drmDisconnect`, `attachments`, `output` and `commitThread` tests pass. The actual packaged library also passes the regression in a sandbox without real DRM devices or desktop sockets. SONAME remains `libaquamarine.so.14`.
- Independent review confirms an unresolved failure path: a failed KMS detach can still allow premature CRTC reuse. Nested synchronous callbacks and actively submitting async/disconnect races remain test gaps; consumer teardown integration also needs verification.
- dpmsfix3 is not installed. No physical standby/wake or suspend/resume acceptance is claimed. The current read-only baseline has a nonzero 3840x2160@60 mode and the stock shell running, but complete idle/helper routing remains to be checked.
- Next gates: close review/test gaps; validate rollback and GUI-independent recovery; coordinate any package/session transition; then test real automatic idle, public manual lock, physical standby, protected wake, re-blanking, authentication, repeated cycles and separately approved suspend/resume.

This PR's code is unchanged and remains the original opt-out. Keep it in draft/rework status; do not treat the Aquamarine offline results as validation of this PR or resolution of #11066.

## Required behavior

Based on the unmodified Omarchy baseline `8ea51516390320f8e768808b230098e67bdaa82c`:

- Preserve the configured idle timings. Defaults are `idle.screensaver: 150` and `idle.lock: 300`, both measured from the start of user inactivity.
- Preserve screensaver toggles, stay-awake/inhibitor behavior, and cancellation of a pending idle lock when the user dismisses the screensaver before the lock deadline.
- At the lock deadline or on manual lock, acquire the secure session lock and preserve normal lock-command side effects: stop the screensaver, reset the keyboard layout, and lock 1Password when applicable.
- Preserve the normal five-second lock blanking timer, including password-authentication and resume safeguards. The normal blanking action turns off keyboard lighting and sends display DPMS-off. The monitor must actually enter its standby/display-off state, not simply draw black.
- Keyboard/mouse activity wakes the display to a usable lock screen. The desktop remains inaccessible until authentication succeeds. If the user does not unlock, normal re-blanking remains in effect.
- Preserve the separate system-suspend path: secure the session before suspend and return to a usable secure lock on resume. Monitor standby is not the same as system suspend.

References:
- [Idle/screensaver/lock manual](https://github.com/omacom/omarchy/blob/8ea51516390320f8e768808b230098e67bdaa82c/manual/13-toggles-idle-screensaver.md)
- [Lock command](https://github.com/omacom/omarchy/blob/8ea51516390320f8e768808b230098e67bdaa82c/bin/omarchy-system-lock)
- [Lock service and timer](https://github.com/omacom/omarchy/blob/8ea51516390320f8e768808b230098e67bdaa82c/shell/plugins/lock/Service.qml)
- [Hardware display-power helper](https://github.com/omacom/omarchy/blob/8ea51516390320f8e768808b230098e67bdaa82c/bin/omarchy-brightness-display)
- [Input wake defaults](https://github.com/omacom/omarchy/blob/8ea51516390320f8e768808b230098e67bdaa82c/default/hypr/input.lua)
- [Pre-suspend secure-lock helper](https://github.com/omacom/omarchy/blob/8ea51516390320f8e768808b230098e67bdaa82c/bin/omarchy-system-sleep-lock)

## Current implementation, retained for review history

- Adds `idle.blankDisplay`, defaulting to `true`.
- Setting it to `false` stops the blank timer and skips the DPMS-off transition.
- Adds a testable policy module and documentation.

This is an opt-out workaround, not a repair of the MST/atomic-modeset wake failure. A separate local Aquamarine candidate now has offline regression coverage, but it is not part of this PR and has not been installed or validated on the affected hardware.

## Verification limits and acceptance gates

Previous focused/full-suite and QML lint results validate the opt-out implementation only. They do not prove the intended standby/wake cycle.

Local manual tests observed a mapped screensaver, a secure lock, a monitor that stayed powered on, and one user-confirmed successful authentication. The repeated test did not receive an unlock confirmation. These are not successful physical-standby/wake tests.

A further read-only audit found a split local test environment: Quickshell ran from the PR checkout, while the automatic idle service's `bash -lc` children reset `OMARCHY_PATH` through `/etc/omarchy.conf` to the packaged path. A probe in the running shell's environment returned `omarchy-shell is not running` for that child path. Manual checkout IPC bypassed this problem. The local environment must be made consistent before another end-to-end test; this is a test-deployment flaw, not evidence of an upstream idle regression.

Required before claiming resolution:
- [ ] Reproduce and isolate the original DPMS-off/wake failure with consistent session, helper, IPC, and sleep-service paths.
- [ ] Implement a fix that retains actual monitor standby and secure authentication; do not substitute a DPMS opt-out or software-black overlay.
- [ ] Test the real automatic idle path as well as the public manual-lock command, not just direct lock IPC.
- [ ] Observe physical standby and successful keyboard/mouse wake on the affected hardware; correlate with DRM/Hyprland state and logs.
- [ ] Verify wake without authentication does not expose the desktop and that idle re-blanking still works.
- [ ] Repeat complete standby/wake/unlock cycles and verify the display mode is usable, without requiring reboot, cable reconnection, or compositor restart.
- [ ] Test the separately coordinated suspend/resume path without weakening pre-suspend locking.
- [ ] Add regression coverage for the identified cause and rerun the relevant/full test suites.

Related: #11066
