### PR TITLE
Disable broken eDP Panel Replay on Dell XPS Panther Lake

### DIFF
--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -21,6 +21,7 @@ run_logged "$OMARCHY_INSTALL/hardware/intel/thermald.sh"
 run_logged "$OMARCHY_INSTALL/hardware/intel/ptl-kernel.sh"
 run_logged "$OMARCHY_INSTALL/hardware/intel/ipu7-camera.sh"
 run_logged "$OMARCHY_INSTALL/hardware/intel/fred.sh"
+run_logged "$OMARCHY_INSTALL/hardware/intel/fix-dell-xps-ptl-panel-replay.sh"
 run_logged "$OMARCHY_INSTALL/hardware/intel/fix-wifi7-eht.sh"
 run_logged "$OMARCHY_INSTALL/hardware/intel/sof-firmware.sh"
 

--- a/install/hardware/intel/fix-dell-xps-ptl-panel-replay.sh
+++ b/install/hardware/intel/fix-dell-xps-ptl-panel-replay.sh
@@ -1,0 +1,18 @@
+# Display/power fix for Dell XPS Panther Lake (XPS 14, PTL-H).
+#
+# Panel Replay is Xe3-new, default-on in the xe driver, and negotiates
+# selective-update + early transport + DSC on this eDP panel but never
+# completes a cycle: the sink reports a Link CRC error, and every frame
+# update costs ~50 GPU interrupts (~6000/s at 120Hz), pinning the GT at
+# its 900MHz policy floor and blocking package C-states. Idle draw sits
+# near 13W instead of ~7.5W, roughly halving battery life. Classic PSR2
+# works fine once Panel Replay is off, so only that gets disabled —
+# unlike the Wildcat Lake XPS 13, which also needs xe.enable_psr=0.
+
+if omarchy-hw-match "XPS" && omarchy-hw-intel-ptl; then
+  mkdir -p /etc/limine-entry-tool.d
+  cat > /etc/limine-entry-tool.d/dell-xps-ptl-panel-replay.conf <<'EOF'
+# Dell XPS Panther Lake eDP Panel Replay workaround
+KERNEL_CMDLINE[default]+=" xe.enable_panel_replay=0"
+EOF
+fi

--- a/migrations/1789006054.sh
+++ b/migrations/1789006054.sh
@@ -1,0 +1,19 @@
+echo "Disable broken eDP Panel Replay on Dell XPS Panther Lake systems"
+
+DROP_IN="/etc/limine-entry-tool.d/dell-xps-ptl-panel-replay.conf"
+
+# New installs get this from install/hardware/intel/fix-dell-xps-ptl-panel-replay.sh.
+# Systems that predate that hook live with the Panel Replay interrupt storm
+# (~6000 xe IRQs/s, GT pinned awake, roughly half the battery life they should
+# get), so retrofit the drop-in here. Second and later users no-op on the file
+# check.
+if omarchy-hw-match "XPS" && omarchy-hw-intel-ptl; then
+  if [[ ! -f $DROP_IN ]]; then
+    sudo mkdir -p /etc/limine-entry-tool.d
+    cat <<'EOF' | sudo tee "$DROP_IN" >/dev/null
+# Dell XPS Panther Lake eDP Panel Replay workaround
+KERNEL_CMDLINE[default]+=" xe.enable_panel_replay=0"
+EOF
+    sudo limine-update
+  fi
+fi


### PR DESCRIPTION
## Summary

My new XPS 14 (Ultra X7 358H, PTL-H, linux-ptl 7.2.3) was getting 3-4 hours of battery instead of the 6-8 it should manage. Chased it down and it's the eDP Panel Replay handshake.

The panel negotiates Panel Replay selective-update + early transport + DSC, but it never actually works: the sink reports a Link CRC error, the driver's PR performance counter never leaves zero, and selective fetch fails at boot ("Selective fetch area calculation failed in pipe A"). Meanwhile every frame update costs ~50 GPU interrupts — about 6,000 xe IRQs per second at 120Hz — which pins the render tile awake at its 900MHz policy floor, keeps the package out of every C-state, and leaves a ~13W idle floor instead of ~7.5W. A power-saving feature that costs 5 watts.

Turning Panel Replay off falls the driver back to PSR2, which works fine on this panel:

| | Panel Replay (broken) | PSR2 |
|---|---|---|
| xe interrupts @ 120Hz | ~6,000/s | ~220/s |
| GPU render tile | 95% awake @ 900MHz floor | 100% parked in C6 |
| Battery draw | ~13.3W | ~7.5W |

Roughly double the battery, everything still smooth at 120Hz, DSC untouched.

This is the same knob and the same Xe3 pathology as the ASUS B9406 fix (#5423), just failing differently — that one locks the panel up, this one quietly torches the battery and adds lag. #11016 is the same machine and the same kernel window: 7.1.8-ptl was fine with Panel Replay, 7.2.3-ptl broke it, and their debugfs testing independently lands on "Panel Replay off = smooth". It's also the same class of thing the old broad PTL display knobs covered before they were retired in favor of kernel patches (a70b05e8) — the patches fixed the PSR stalls, but not this.

Scope notes:

- Only `enable_panel_replay` goes off. PSR2 engages cleanly afterwards (SU_STANDBY, GT parked), so unlike the Wildcat Lake XPS 13 (#6849) there's no need to disable PSR too.
- Gated on `omarchy-hw-match "XPS" && omarchy-hw-intel-ptl`, the same guard `ptl-kernel.sh` and the old 1777909712 cleanup migration used.
- I included a migration even though the B9406 PR dropped its own (that machine's audience was basically nobody without nomodeset). XPS 14 PTL installs are ordinary working installs that just live with half the battery and some lag — #11016 is exactly that reporter, and they're not going to reinstall to pick up an install hook. The migration is idempotent and no-ops once the drop-in exists.

Fixes #11016

🤖 Generated with [Claude Code](https://claude.com/claude-code)