### PR TITLE
Keep plugin shell facades alive and intact for live consumers

### DIFF
--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -198,8 +198,7 @@ ShellRoot {
 
   function isBarOptionManifest(manifest) {
     return manifest
-      && Array.isArray(manifest.kinds)
-      && manifest.kinds.indexOf("bar") !== -1
+      && shell.manifestHasKind(manifest, "bar")
       && manifest.entryPoints
       && manifest.entryPoints.bar
   }
@@ -346,9 +345,26 @@ ShellRoot {
     return snapshot
   }
 
+  // A manifest that traveled through a `property var` boundary (an injected
+  // facade, an Instantiator model) can arrive with its kinds list as a
+  // QVariant sequence view: it stringifies as an array but fails
+  // Array.isArray, which silently zeroed capability profiles computed from
+  // it. Rehydrate non-native views through JSON, which always yields a real
+  // array. Cheap: kinds lists are a handful of strings.
+  function manifestKinds(manifest) {
+    var kinds = manifest ? manifest.kinds : undefined
+    if (Array.isArray(kinds)) return kinds
+    if (kinds === undefined || kinds === null) return []
+    try {
+      var parsed = JSON.parse(JSON.stringify(kinds))
+      return Array.isArray(parsed) ? parsed : []
+    } catch (e) {
+      return []
+    }
+  }
+
   function manifestHasKind(manifest, kind) {
-    return !!manifest && Array.isArray(manifest.kinds)
-      && manifest.kinds.indexOf(kind) !== -1
+    return shell.manifestKinds(manifest).indexOf(kind) !== -1
   }
 
   function pluginHasBarCapabilities(manifest) {
@@ -414,18 +430,31 @@ ShellRoot {
     return true
   }
 
+  // createObject() initial properties push every value through a QVariant
+  // conversion that flattens nested arrays into key-maps: a delivered
+  // barConfig loses its layout arrays and a delivered manifest loses its
+  // kinds list. Scalars survive either way, so create with only the
+  // required scalars and assign the payload — assignment keeps values whole.
+  function createPluginApi(component, scalars, payload) {
+    var api = component.createObject(null, scalars)
+    if (!api) return null
+    for (var key in payload) api[key] = payload[key]
+    return api
+  }
+
   function pluginAppLibraryFor(cacheKey, pluginId) {
     if (_pluginAppLibraryApis[cacheKey]) return _pluginAppLibraryApis[cacheKey]
-    var api = pluginAppLibraryApiComponent.createObject(null, {
-      ownerPluginId: pluginId,
-      _entryName: function(entry) { return shell.appLibrary.entryName(entry) },
-      _entrySubtext: function(entry) { return shell.appLibrary.entrySubtext(entry) },
-      _sortedEntries: function(query) { return shell.appLibrary.sortedEntries(query) },
-      _iconSource: function(icon) { return shell.appLibrary.iconSource(icon) },
-      _refreshIcons: function() { shell.appLibrary.refreshIcons() },
-      _launch: function(desktopId, name) { shell.appLibrary.launch(desktopId, name) },
-      _remove: function(desktopId, name) { shell.appLibrary.remove(desktopId, name) }
-    })
+    var api = shell.createPluginApi(pluginAppLibraryApiComponent,
+      { ownerPluginId: pluginId },
+      {
+        _entryName: function(entry) { return shell.appLibrary.entryName(entry) },
+        _entrySubtext: function(entry) { return shell.appLibrary.entrySubtext(entry) },
+        _sortedEntries: function(query) { return shell.appLibrary.sortedEntries(query) },
+        _iconSource: function(icon) { return shell.appLibrary.iconSource(icon) },
+        _refreshIcons: function() { shell.appLibrary.refreshIcons() },
+        _launch: function(desktopId, name) { shell.appLibrary.launch(desktopId, name) },
+        _remove: function(desktopId, name) { shell.appLibrary.remove(desktopId, name) }
+      })
     if (!api) return null
     var next = ({})
     for (var id in _pluginAppLibraryApis) next[id] = _pluginAppLibraryApis[id]
@@ -459,34 +488,34 @@ ShellRoot {
     function service() {
       return shell.serviceFor(shell.pluginRegistry.resolveEnabledId(id))
     }
-    var api = pluginFirstPartyServiceApiComponent.createObject(null, {
-      ownerPluginId: pluginId,
-      serviceId: id,
-      _setIdleEnabled: function(value) {
-        var target = service()
-        if (target && typeof target.setIdleEnabled === "function") target.setIdleEnabled(value)
-      },
-      _setNightlight: function(value) {
-        var target = service()
-        if (target && typeof target.setNightlight === "function") target.setNightlight(value)
-      },
-      _setDoNotDisturb: function(value) {
-        var target = service()
-        if (target && typeof target.setDoNotDisturb === "function") target.setDoNotDisturb(value)
-      },
-      _runAction: function(action, showFeedback, targetKey) {
-        var target = service()
-        if (target && typeof target.runAction === "function") target.runAction(action, showFeedback, targetKey)
-      },
-      _playerKey: function(player) {
-        var target = service()
-        return target && typeof target.playerKey === "function" ? target.playerKey(player) : ""
-      },
-      _selectPlayer: function(playerKey) {
-        var target = service()
-        if (target && typeof target.selectPlayer === "function") target.selectPlayer(playerKey)
-      }
-    })
+    var api = shell.createPluginApi(pluginFirstPartyServiceApiComponent,
+      { ownerPluginId: pluginId, serviceId: id },
+      {
+        _setIdleEnabled: function(value) {
+          var target = service()
+          if (target && typeof target.setIdleEnabled === "function") target.setIdleEnabled(value)
+        },
+        _setNightlight: function(value) {
+          var target = service()
+          if (target && typeof target.setNightlight === "function") target.setNightlight(value)
+        },
+        _setDoNotDisturb: function(value) {
+          var target = service()
+          if (target && typeof target.setDoNotDisturb === "function") target.setDoNotDisturb(value)
+        },
+        _runAction: function(action, showFeedback, targetKey) {
+          var target = service()
+          if (target && typeof target.runAction === "function") target.runAction(action, showFeedback, targetKey)
+        },
+        _playerKey: function(player) {
+          var target = service()
+          return target && typeof target.playerKey === "function" ? target.playerKey(player) : ""
+        },
+        _selectPlayer: function(playerKey) {
+          var target = service()
+          if (target && typeof target.selectPlayer === "function") target.selectPlayer(playerKey)
+        }
+      })
     if (!api) return null
     api.stayAwake = Qt.binding(function() {
       var target = service()
@@ -523,15 +552,16 @@ ShellRoot {
     ].join("|")
   }
 
-  function cacheWithoutKey(cache, key, destroyValue) {
+  // Cache entries are dropped by replacement, never by destroy(): every
+  // facade is handed to live plugins that keep holding the reference. A
+  // destroyed QObject reads back as null and takes the plugin's state with
+  // it, while a replaced-but-alive facade still answers capability checks
+  // against the current manifest (call-time checks, below). JavaScript
+  // ownership reclaims the object once the last reference drops.
+  function cacheWithoutKey(cache, key) {
     var next = ({})
     for (var existing in cache) {
-      if (existing === key) {
-        var value = cache[existing]
-        if (destroyValue && value && typeof value.destroy === "function") value.destroy()
-      } else {
-        next[existing] = cache[existing]
-      }
+      if (existing !== key) next[existing] = cache[existing]
     }
     return next
   }
@@ -539,12 +569,7 @@ ShellRoot {
   function cacheWithoutPrefix(cache, prefix) {
     var next = ({})
     for (var existing in cache) {
-      if (existing.indexOf(prefix) === 0) {
-        var value = cache[existing]
-        if (value && typeof value.destroy === "function") value.destroy()
-      } else {
-        next[existing] = cache[existing]
-      }
+      if (existing.indexOf(prefix) !== 0) next[existing] = cache[existing]
     }
     return next
   }
@@ -552,11 +577,11 @@ ShellRoot {
   function revokePluginShellApi(cacheKey) {
     var key = String(cacheKey || "")
     if (!key) return
-    _pluginAppLibraryApis = shell.cacheWithoutKey(_pluginAppLibraryApis, key, true)
+    _pluginAppLibraryApis = shell.cacheWithoutKey(_pluginAppLibraryApis, key)
     _pluginFirstPartyServiceApis = shell.cacheWithoutPrefix(_pluginFirstPartyServiceApis, key + "::")
     _pluginBarEntryShellApis = shell.cacheWithoutPrefix(_pluginBarEntryShellApis, key + ":")
-    _pluginShellApis = shell.cacheWithoutKey(_pluginShellApis, key, true)
-    _pluginShellApiDescriptors = shell.cacheWithoutKey(_pluginShellApiDescriptors, key, false)
+    _pluginShellApis = shell.cacheWithoutKey(_pluginShellApis, key)
+    _pluginShellApiDescriptors = shell.cacheWithoutKey(_pluginShellApiDescriptors, key)
   }
 
   function createScopedPluginShell(manifest, cacheKey, allowOwnService, barCapabilities) {
@@ -590,56 +615,57 @@ ShellRoot {
       }
     }
 
-    var api = pluginShellApiComponent.createObject(null, {
-      pluginId: key,
-      appLibrary: shell.manifestHasKind(manifest, "menu")
-        ? shell.pluginAppLibraryFor(cacheKey, key) : null,
-      bar: shell.pluginBarStateFor(cacheKey, key),
-      barConfig: shell.publicBarConfig(),
-      idleConfig: shell.publicIdleConfigFor(manifest),
-      _serviceLookup: function(requestedId) {
-        return allowOwnService ? shell.pluginServiceFor(key, requestedId) : null
-      },
-      _firstPartyServiceLookup: function(requestedId) {
-        if (allowOwnService && shell.pluginOwnsTarget(key, requestedId))
-          return shell.pluginServiceFor(key, requestedId)
-        return hasCurrentBarCapabilities() ? (firstPartyServices[requestedId] || null) : null
-      },
-      _barEntryShellLookup: function(ownerId, moduleName) {
-        return hasCurrentBarCapabilities()
-          ? shell.pluginShellForBarEntry(cacheKey + ":" + ownerId, moduleName) : null
-      },
-      _summon: function(requestedId, payloadJson) {
-        if (!shell.pluginOwnsTarget(key, requestedId)
-            && !shell.barPluginMayControl(currentManifest(), requestedId)
-            && !shell.pluginCloneMaySummon(currentManifest(), requestedId)) return false
-        return shell.summon(shell.pluginRegistry.resolveEnabledId(requestedId), payloadJson)
-      },
-      _hide: function(requestedId) {
-        if (!shell.pluginOwnsTarget(key, requestedId)
-            && !shell.barPluginMayControl(currentManifest(), requestedId)) return false
-        return shell.hide(shell.pluginRegistry.resolveEnabledId(requestedId))
-      },
-      _toggle: function(requestedId, payloadJson) {
-        if (!shell.pluginOwnsTarget(key, requestedId)
-            && !shell.barPluginMayControl(currentManifest(), requestedId)) return false
-        return shell.toggle(shell.pluginRegistry.resolveEnabledId(requestedId), payloadJson)
-      },
-      _isOpen: function(requestedId) {
-        if (!shell.pluginOwnsTarget(key, requestedId)
-            && !shell.barPluginMayControl(currentManifest(), requestedId)) return false
-        return shell.isPluginOpen(shell.pluginRegistry.resolveEnabledId(requestedId))
-      },
-      _updateSettings: function(requestedId, settings) {
-        if (shell.pluginOwnsTarget(key, requestedId)) return shell.updateEntryInline(key, settings)
-        if (hasCurrentBarCapabilities() && shell.barEntryConfigured(requestedId))
-          return shell.updateEntryInline(requestedId, settings)
-        return false
-      },
-      _mutateBarConfig: function(mutator) {
-        return hasCurrentBarCapabilities() ? shell.mutatePluginBarConfig(mutator) : false
-      }
-    })
+    var api = shell.createPluginApi(pluginShellApiComponent,
+      { pluginId: key },
+      {
+        appLibrary: shell.manifestHasKind(manifest, "menu")
+          ? shell.pluginAppLibraryFor(cacheKey, key) : null,
+        bar: shell.pluginBarStateFor(cacheKey, key),
+        barConfig: shell.publicBarConfig(),
+        idleConfig: shell.publicIdleConfigFor(manifest),
+        _serviceLookup: function(requestedId) {
+          return allowOwnService ? shell.pluginServiceFor(key, requestedId) : null
+        },
+        _firstPartyServiceLookup: function(requestedId) {
+          if (allowOwnService && shell.pluginOwnsTarget(key, requestedId))
+            return shell.pluginServiceFor(key, requestedId)
+          return hasCurrentBarCapabilities() ? (firstPartyServices[requestedId] || null) : null
+        },
+        _barEntryShellLookup: function(ownerId, moduleName) {
+          return hasCurrentBarCapabilities()
+            ? shell.pluginShellForBarEntry(cacheKey + ":" + ownerId, moduleName) : null
+        },
+        _summon: function(requestedId, payloadJson) {
+          if (!shell.pluginOwnsTarget(key, requestedId)
+              && !shell.barPluginMayControl(currentManifest(), requestedId)
+              && !shell.pluginCloneMaySummon(currentManifest(), requestedId)) return false
+          return shell.summon(shell.pluginRegistry.resolveEnabledId(requestedId), payloadJson)
+        },
+        _hide: function(requestedId) {
+          if (!shell.pluginOwnsTarget(key, requestedId)
+              && !shell.barPluginMayControl(currentManifest(), requestedId)) return false
+          return shell.hide(shell.pluginRegistry.resolveEnabledId(requestedId))
+        },
+        _toggle: function(requestedId, payloadJson) {
+          if (!shell.pluginOwnsTarget(key, requestedId)
+              && !shell.barPluginMayControl(currentManifest(), requestedId)) return false
+          return shell.toggle(shell.pluginRegistry.resolveEnabledId(requestedId), payloadJson)
+        },
+        _isOpen: function(requestedId) {
+          if (!shell.pluginOwnsTarget(key, requestedId)
+              && !shell.barPluginMayControl(currentManifest(), requestedId)) return false
+          return shell.isPluginOpen(shell.pluginRegistry.resolveEnabledId(requestedId))
+        },
+        _updateSettings: function(requestedId, settings) {
+          if (shell.pluginOwnsTarget(key, requestedId)) return shell.updateEntryInline(key, settings)
+          if (hasCurrentBarCapabilities() && shell.barEntryConfigured(requestedId))
+            return shell.updateEntryInline(requestedId, settings)
+          return false
+        },
+        _mutateBarConfig: function(mutator) {
+          return hasCurrentBarCapabilities() ? shell.mutatePluginBarConfig(mutator) : false
+        }
+      })
     if (!api) return null
 
     var next = ({})
@@ -688,31 +714,32 @@ ShellRoot {
       return shell.pluginRegistry.installedPlugins[id] || null
     }
 
-    var api = pluginShellApiComponent.createObject(null, {
-      pluginId: target,
-      barConfig: shell.publicBarConfig(),
-      _summon: function(requestedId, payloadJson) {
-        if (!owns(requestedId)
-            && !shell.pluginCloneMaySummon(currentManifest(), requestedId)) return false
-        return shell.summon(shell.pluginRegistry.resolveEnabledId(requestedId), payloadJson)
-      },
-      _hide: function(requestedId) {
-        return owns(requestedId)
-          ? shell.hide(shell.pluginRegistry.resolveEnabledId(target)) : false
-      },
-      _toggle: function(requestedId, payloadJson) {
-        return owns(requestedId)
-          ? shell.toggle(shell.pluginRegistry.resolveEnabledId(target), payloadJson) : false
-      },
-      _isOpen: function(requestedId) {
-        return owns(requestedId)
-          ? shell.isPluginOpen(shell.pluginRegistry.resolveEnabledId(target)) : false
-      },
-      _updateSettings: function(requestedId, settings) {
-        return String(requestedId || "") === target
-          ? shell.updateEntryInline(target, settings) : false
-      }
-    })
+    var api = shell.createPluginApi(pluginShellApiComponent,
+      { pluginId: target },
+      {
+        barConfig: shell.publicBarConfig(),
+        _summon: function(requestedId, payloadJson) {
+          if (!owns(requestedId)
+              && !shell.pluginCloneMaySummon(currentManifest(), requestedId)) return false
+          return shell.summon(shell.pluginRegistry.resolveEnabledId(requestedId), payloadJson)
+        },
+        _hide: function(requestedId) {
+          return owns(requestedId)
+            ? shell.hide(shell.pluginRegistry.resolveEnabledId(target)) : false
+        },
+        _toggle: function(requestedId, payloadJson) {
+          return owns(requestedId)
+            ? shell.toggle(shell.pluginRegistry.resolveEnabledId(target), payloadJson) : false
+        },
+        _isOpen: function(requestedId) {
+          return owns(requestedId)
+            ? shell.isPluginOpen(shell.pluginRegistry.resolveEnabledId(target)) : false
+        },
+        _updateSettings: function(requestedId, settings) {
+          return String(requestedId || "") === target
+            ? shell.updateEntryInline(target, settings) : false
+        }
+      })
     if (!api) return null
     var next = ({})
     for (var id in _pluginBarEntryShellApis) next[id] = _pluginBarEntryShellApis[id]
@@ -734,15 +761,16 @@ ShellRoot {
     if (!key) return null
     if (_pluginRegistryApis[key]) return _pluginRegistryApis[key]
 
-    var api = pluginRegistryApiComponent.createObject(null, {
-      pluginId: key,
-      manifest: shell.publicPluginManifest(manifest),
-      enabled: shell.pluginRegistry.isEnabled(key),
-      _entryPointUrl: function(kind) {
-        var current = shell.pluginRegistry.installedPlugins[key]
-        return current ? shell.pluginRegistry.entryPointUrl(current, kind) : ""
-      }
-    })
+    var api = shell.createPluginApi(pluginRegistryApiComponent,
+      { pluginId: key },
+      {
+        manifest: shell.publicPluginManifest(manifest),
+        enabled: shell.pluginRegistry.isEnabled(key),
+        _entryPointUrl: function(kind) {
+          var current = shell.pluginRegistry.installedPlugins[key]
+          return current ? shell.pluginRegistry.entryPointUrl(current, kind) : ""
+        }
+      })
     if (!api) return null
 
     var next = ({})
@@ -758,10 +786,12 @@ ShellRoot {
     if (!key) return null
     if (_pluginBarWidgetRegistryApis[key]) return _pluginBarWidgetRegistryApis[key]
 
-    var api = pluginBarWidgetRegistryApiComponent.createObject(null, {
-      widgets: shell.publicBarWidgetSnapshot(),
-      revision: shell.barWidgetRegistry.revision
-    })
+    var api = shell.createPluginApi(pluginBarWidgetRegistryApiComponent,
+      {},
+      {
+        widgets: shell.publicBarWidgetSnapshot(),
+        revision: shell.barWidgetRegistry.revision
+      })
     if (!api) return null
 
     var next = ({})
@@ -785,11 +815,15 @@ ShellRoot {
       var shellApi = _pluginShellApis[shellKey]
       var descriptor = _pluginShellApiDescriptors[shellKey]
       var manifest = descriptor ? plugins[descriptor.pluginId] : null
-      var barCapabilities = descriptor && descriptor.allowOwnService
+      // A missing manifest usually means the registry is mid-rebuild, not
+      // that the plugin vanished: judging capabilities against the hole
+      // revoked healthy facades under live plugins. Leave the entry alone;
+      // the pass after the scan settles judges it for real.
+      if (!manifest) continue
+      var barCapabilities = descriptor.allowOwnService
         && shell.pluginHasBarCapabilities(manifest)
-      var expectedProfile = descriptor
-        ? shell.pluginShellCapabilityProfile(manifest, descriptor.allowOwnService, barCapabilities) : ""
-      var active = descriptor && manifest && shell.pluginRegistry.isEnabled(descriptor.pluginId)
+      var expectedProfile = shell.pluginShellCapabilityProfile(manifest, descriptor.allowOwnService, barCapabilities)
+      var active = shell.pluginRegistry.isEnabled(descriptor.pluginId)
       if (!active || descriptor.profile !== expectedProfile)
         shell.revokePluginShellApi(shellKey)
     }
@@ -798,7 +832,6 @@ ShellRoot {
     for (var registryKey in _pluginRegistryApis) {
       var registryApi = _pluginRegistryApis[registryKey]
       if (shell.pluginApiActive(registryApi, plugins)) registryNext[registryKey] = registryApi
-      else if (registryApi && typeof registryApi.destroy === "function") registryApi.destroy()
     }
     _pluginRegistryApis = registryNext
 
@@ -806,7 +839,6 @@ ShellRoot {
     for (var widgetKey in _pluginBarWidgetRegistryApis) {
       var widgetApi = _pluginBarWidgetRegistryApis[widgetKey]
       if (plugins[widgetKey] && shell.pluginRegistry.isEnabled(widgetKey)) widgetNext[widgetKey] = widgetApi
-      else if (widgetApi && typeof widgetApi.destroy === "function") widgetApi.destroy()
     }
     _pluginBarWidgetRegistryApis = widgetNext
 
@@ -814,7 +846,6 @@ ShellRoot {
     for (var appKey in _pluginAppLibraryApis) {
       var appApi = _pluginAppLibraryApis[appKey]
       if (shell.pluginApiActive(appApi, plugins)) appNext[appKey] = appApi
-      else if (appApi && typeof appApi.destroy === "function") appApi.destroy()
     }
     _pluginAppLibraryApis = appNext
 
@@ -822,7 +853,6 @@ ShellRoot {
     for (var barStateKey in _pluginBarStateApis) {
       var barStateApi = _pluginBarStateApis[barStateKey]
       if (shell.pluginApiActive(barStateApi, plugins)) barStateNext[barStateKey] = barStateApi
-      else if (barStateApi && typeof barStateApi.destroy === "function") barStateApi.destroy()
     }
     _pluginBarStateApis = barStateNext
 
@@ -830,7 +860,6 @@ ShellRoot {
     for (var serviceKey in _pluginFirstPartyServiceApis) {
       var serviceApi = _pluginFirstPartyServiceApis[serviceKey]
       if (shell.pluginApiActive(serviceApi, plugins)) serviceNext[serviceKey] = serviceApi
-      else if (serviceApi && typeof serviceApi.destroy === "function") serviceApi.destroy()
     }
     _pluginFirstPartyServiceApis = serviceNext
 
@@ -838,7 +867,6 @@ ShellRoot {
     for (var entryKey in _pluginBarEntryShellApis) {
       var entryApi = _pluginBarEntryShellApis[entryKey]
       if (entryApi && shell.barEntryConfigured(entryApi.pluginId)) entryNext[entryKey] = entryApi
-      else if (entryApi && typeof entryApi.destroy === "function") entryApi.destroy()
     }
     _pluginBarEntryShellApis = entryNext
   }
@@ -866,6 +894,26 @@ ShellRoot {
     }
     for (var entryKey in _pluginBarEntryShellApis)
       _pluginBarEntryShellApis[entryKey].barConfig = shell.publicBarConfig()
+    shell.refreshPluginShellApis()
+  }
+
+  // A facade swap (capability change, cache replacement) leaves already-loaded
+  // panels and the active bar holding the previous object forever. Plugins
+  // re-request on their own reload, but a live panel never does, so the host
+  // re-injects after every sync: whatever each consumer now holds is current.
+  function refreshPluginShellApis() {
+    var plugins = shell.pluginRegistry.installedPlugins
+    for (var pluginId in panelLoaders) {
+      var loader = panelLoaders[pluginId]
+      var item = loader && loader.item ? loader.item : null
+      if (!item || !plugins[pluginId]) continue
+      var fresh = shell.pluginShellFor(plugins[pluginId])
+      if (fresh && item.shell !== fresh && "shell" in item) item.shell = fresh
+    }
+    if (shell.bar && "shell" in shell.bar && shell.activeBarManifest) {
+      var barFresh = shell.pluginShellFor(shell.activeBarManifest)
+      if (barFresh && shell.bar.shell !== barFresh) shell.bar.shell = barFresh
+    }
   }
 
   // Reassigned as each service registers, so a binding that reads this before
@@ -893,7 +941,7 @@ ShellRoot {
     var manifest = pluginRegistry && pluginRegistry.installedPlugins
       ? pluginRegistry.installedPlugins[key] : null
     if (!manifest) return null
-    if (!Array.isArray(manifest.kinds) || manifest.kinds.indexOf("service") === -1) return null
+    if (!shell.manifestHasKind(manifest, "service")) return null
     if (!manifest.entryPoints || !manifest.entryPoints.service) return null
     var url = pluginRegistry.entryPointUrl(manifest, "service")
     if (!url) return null

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -815,11 +815,14 @@ ShellRoot {
       var shellApi = _pluginShellApis[shellKey]
       var descriptor = _pluginShellApiDescriptors[shellKey]
       var manifest = descriptor ? plugins[descriptor.pluginId] : null
-      // A missing manifest usually means the registry is mid-rebuild, not
-      // that the plugin vanished: judging capabilities against the hole
-      // revoked healthy facades under live plugins. Leave the entry alone;
-      // the pass after the scan settles judges it for real.
-      if (!manifest) continue
+      if (!manifest) {
+        // Mid-scan the registry can be between states; judge nothing until
+        // it settles. Outside a scan, a missing manifest means the plugin is
+        // gone, and its cache entry should go with it.
+        if (shell.pluginRegistry.scanning) continue
+        shell.revokePluginShellApi(shellKey)
+        continue
+      }
       var barCapabilities = descriptor.allowOwnService
         && shell.pluginHasBarCapabilities(manifest)
       var expectedProfile = shell.pluginShellCapabilityProfile(manifest, descriptor.allowOwnService, barCapabilities)

--- a/test/shell.d/plugin-shell-lifecycle-test.sh
+++ b/test/shell.d/plugin-shell-lifecycle-test.sh
@@ -1,0 +1,248 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+TMPDIR=""
+QS_PID=""
+
+cleanup() {
+  if [[ -n $QS_PID ]] && kill -0 "$QS_PID" 2>/dev/null; then
+    kill "$QS_PID" 2>/dev/null || true
+    wait "$QS_PID" 2>/dev/null || true
+  fi
+  [[ -n $TMPDIR && -d $TMPDIR ]] && rm -rf "$TMPDIR"
+  return 0
+}
+trap cleanup EXIT
+
+require_compositor "plugin shell lifecycle test"
+
+if ! command -v quickshell >/dev/null 2>&1; then
+  pass "quickshell not installed; skipping plugin shell lifecycle test"
+  exit 0
+fi
+
+require_command jq
+
+shell_ipc() {
+  OMARCHY_PATH="$test_root" "$ROOT/bin/omarchy-shell" "$@"
+}
+
+shell_ipc_quiet() {
+  OMARCHY_PATH="$test_root" "$ROOT/bin/omarchy-shell" -q "$@"
+}
+
+fail_with_log() {
+  local description=$1
+  sed -n '1,240p' "$log" >&2
+  fail "$description"
+}
+
+TMPDIR=$(mktemp -d)
+test_root="$TMPDIR/omarchy"
+test_home="$TMPDIR/home"
+log="$TMPDIR/quickshell.log"
+mkdir -p "$test_root" "$test_home"
+cp -a "$ROOT/shell" "$test_root/shell"
+ln -s "$ROOT/config" "$test_root/config"
+ln -s "$ROOT/bin" "$test_root/bin"
+
+probe_id="acme.probe-bar"
+probe_dir="$test_home/.config/omarchy/plugins/$probe_id"
+mkdir -p "$probe_dir"
+cat >"$probe_dir/manifest.json" <<JSON
+{
+  "schemaVersion": 1,
+  "id": "$probe_id",
+  "name": "Probe Bar",
+  "version": "1.0.0",
+  "kinds": ["bar", "panel"],
+  "keepLoaded": true,
+  "entryPoints": {"bar": "Bar.qml", "panel": "Panel.qml"}
+}
+JSON
+
+# Reports, separately, what survives each hop a real third-party plugin uses:
+# the bar property injection (barConfig), the scoped shell API's barConfig
+# snapshot, mutation, and persistence to shell.json on disk.
+cat >"$probe_dir/Bar.qml" <<'QML'
+import QtQuick
+import Quickshell.Io
+
+Item {
+  id: root
+
+  property var shell: null
+  property var barConfig: null
+  property var manifest: null
+
+  function layoutArrays(value) {
+    return value && value.layout !== undefined
+      && Array.isArray(value.layout.left)
+      && Array.isArray(value.layout.center)
+      && Array.isArray(value.layout.right)
+  }
+
+  IpcHandler {
+    target: "acme-probe-bar"
+
+    function state(): string {
+      var apiConfig = root.shell && root.shell.barConfig !== undefined
+        ? root.shell.barConfig : null
+      return JSON.stringify({
+        shellAlive: root.shell !== null && root.shell !== undefined,
+        propLayoutArrays: root.layoutArrays(root.barConfig),
+        apiLayoutArrays: root.layoutArrays(apiConfig),
+        manifestKinds: root.manifest && Array.isArray(root.manifest.kinds)
+      })
+    }
+
+    function mutate(mark: string): string {
+      if (!root.shell || typeof root.shell.mutateShellConfig !== "function")
+        return "no-api"
+      return root.shell.mutateShellConfig(function(config) {
+        if (!config.bar) config.bar = {}
+        config.bar.probeMark = mark
+      }) ? "ok" : "refused"
+    }
+  }
+}
+QML
+
+# A keepLoaded panel: receives the same injections and must keep a working
+# shell reference across plugin rescans, since it is never re-created.
+cat >"$probe_dir/Panel.qml" <<'QML'
+import QtQuick
+import Quickshell.Io
+
+Item {
+  id: root
+
+  property var shell: null
+  property var manifest: null
+
+  function layoutArrays(value) {
+    return value && value.layout !== undefined
+      && Array.isArray(value.layout.left)
+      && Array.isArray(value.layout.center)
+      && Array.isArray(value.layout.right)
+  }
+
+  function open(payloadJson) {}
+  function close() {}
+
+  IpcHandler {
+    target: "acme-probe-panel"
+
+    function state(): string {
+      var apiConfig = root.shell && root.shell.barConfig !== undefined
+        ? root.shell.barConfig : null
+      return JSON.stringify({
+        shellAlive: root.shell !== null && root.shell !== undefined,
+        apiLayoutArrays: root.layoutArrays(apiConfig),
+        manifestKinds: root.manifest && Array.isArray(root.manifest.kinds)
+      })
+    }
+
+    function mutate(mark: string): string {
+      if (!root.shell || typeof root.shell.mutateShellConfig !== "function")
+        return "no-api"
+      return root.shell.mutateShellConfig(function(config) {
+        if (!config.bar) config.bar = {}
+        config.bar.probeMark = mark
+      }) ? "ok" : "refused"
+    }
+  }
+}
+QML
+
+cat >"$test_home/.config/omarchy/shell.json" <<JSON
+{
+  "version": 1,
+  "bar": {
+    "id": "$probe_id",
+    "layout": {"left": [], "center": [], "right": []}
+  },
+  "plugins": []
+}
+JSON
+
+OMARCHY_PATH="$test_root" \
+HOME="$test_home" \
+XDG_CONFIG_HOME="$test_home/.config" \
+XDG_CACHE_HOME="$test_home/.cache" \
+XDG_STATE_HOME="$test_home/.local/state" \
+PATH="$ROOT/bin:$PATH" \
+  quickshell -p "$test_root/shell" --no-color >"$log" 2>&1 &
+QS_PID=$!
+
+for _ in {1..80}; do
+  if shell_ipc_quiet shell ping >/dev/null 2>&1; then
+    break
+  fi
+  if ! kill -0 "$QS_PID" 2>/dev/null; then
+    fail_with_log "test shell exited before IPC became available"
+  fi
+  sleep 0.1
+done
+
+wait_for() {
+  local description=$1
+  local probe_target=$2
+  local filter=$3
+  local outcome=""
+  for _ in {1..80}; do
+    outcome=$(shell_ipc "$probe_target" state 2>/dev/null || true)
+    if jq -e "$filter" <<<"$outcome" >/dev/null 2>&1; then
+      printf '%s' "$outcome"
+      return 0
+    fi
+    if ! kill -0 "$QS_PID" 2>/dev/null; then
+      fail_with_log "test shell exited while waiting for: $description"
+    fi
+    sleep 0.1
+  done
+  printf 'Probe output: %s\n' "$outcome" >&2
+  fail_with_log "$description"
+}
+
+bar_state=$(wait_for "replacement bar probe responded" acme-probe-bar '.shellAlive == true')
+jq -e '.propLayoutArrays == true' <<<"$bar_state" >/dev/null ||
+  fail_with_log "bar receives its barConfig property with layout arrays intact"
+jq -e '.apiLayoutArrays == true' <<<"$bar_state" >/dev/null ||
+  fail_with_log "bar's scoped shell API keeps layout arrays in its barConfig snapshot"
+jq -e '.manifestKinds == true' <<<"$bar_state" >/dev/null ||
+  fail_with_log "bar manifest injection keeps kinds an array"
+pass "bar injections keep arrays and manifest shape"
+
+panel_state=$(wait_for "keepLoaded panel probe responded" acme-probe-panel '.shellAlive == true')
+jq -e '.apiLayoutArrays == true' <<<"$panel_state" >/dev/null ||
+  fail_with_log "panel's scoped shell API keeps layout arrays in its barConfig snapshot"
+jq -e '.manifestKinds == true' <<<"$panel_state" >/dev/null ||
+  fail_with_log "panel manifest injection keeps kinds an array"
+pass "panel injections keep arrays and manifest shape"
+
+[[ $(shell_ipc acme-probe-bar mutate "bar-round-1") == "ok" ]] ||
+  fail_with_log "bar's scoped shell API accepts a bar-config mutation"
+[[ $(shell_ipc acme-probe-panel mutate "panel-round-1") == "ok" ]] ||
+  fail_with_log "panel's scoped shell API accepts a bar-config mutation"
+grep -q '"probeMark": "panel-round-1"' "$test_home/.config/omarchy/shell.json" ||
+  fail_with_log "accepted mutations persist to shell.json on disk"
+pass "scoped API mutations apply and persist"
+
+# A plugin rescan with an unchanged manifest must not kill the panel's
+# injected shell reference: the panel is keepLoaded, so nothing recreates it.
+shell_ipc_quiet shell rescanPlugins >/dev/null
+sleep 1
+panel_state_after=$(wait_for "keepLoaded panel still responds after rescan" acme-probe-panel '.shellAlive == true')
+jq -e '.apiLayoutArrays == true' <<<"$panel_state_after" >/dev/null ||
+  fail_with_log "panel's shell API keeps layout arrays after a plugin rescan"
+[[ $(shell_ipc acme-probe-panel mutate "panel-round-2") == "ok" ]] ||
+  fail_with_log "panel's shell API still accepts mutations after a plugin rescan"
+grep -q '"probeMark": "panel-round-2"' "$test_home/.config/omarchy/shell.json" ||
+  fail_with_log "post-rescan mutation persists to shell.json on disk"
+pass "keepLoaded panel keeps a working shell API across plugin rescans"
+
+pass "plugin shell lifecycle contracts hold"


### PR DESCRIPTION
I ship a third-party replacement bar (skal.bar, in the marketplace queue) with a settings panel. On 4.0.3 the panel kept going brain-dead: it opened fine but showed none of the current config, every control silently no-op'd, and nothing short of a shell restart brought it back. Chasing that led here.

## How I found it

I instrumented the panel to log every injection. On a clean boot the log showed the host handing it a perfectly healthy shell facade, and then, seconds later, the same reference reading back as null. So the injection worked and something killed it right after.

So I built a probe plugin (a third-party bar plus a keepLoaded panel) and a test that runs the real shell against it, and the failure sequence showed up in the log every single run:

```
createScopedPluginShell acme.probe-bar profile = own-service|no-bar|no-menu kinds = NOT-ARRAY:["bar","panel"]
panel onLoaded acme.probe-bar api = obj
createScopedPluginShell acme.probe-bar profile = own-service|bar|no-menu kinds = bar+panel
profile mismatch revoke acme.probe-bar cached = no-bar caller = bar
```

The first facade got created from a manifest whose `kinds` stringifies as an array but fails `Array.isArray`. That's a QVariant sequence view: it shows up when a manifest travels through a `property var` boundary, like the `activeBarManifest` binding. Two problems fall out of that, plus two more I found on the way:

1. **Poisoned capability profiles.** `pluginHasBarCapabilities` on the degraded view returns false, so the facade is cached with `no-bar`. The next consumer holding a faithful view computes a different profile, the cache treats that as a capability change, and the swap destroys the object while live plugins still hold it. A destroyed QObject in a `property var` reads as null, which is exactly my dead settings panel. My panel died on every boot; the bar got its facade killed by the panel's own injection, which is why right-click toggles went dead too.
2. **Revocation against mid-rebuild state.** `prunePluginApis` judges cached facades against `installedPlugins`, which is momentarily missing entries during a rescan. Judging against the hole revoked healthy facades for plugins that never changed.
3. **No re-injection.** A keepLoaded panel never re-requests its facade, so after any swap it holds the old object forever. The bar survives because the loader rebuilds it; panels had no such luck.
4. **Lossy snapshots.** `createObject()` initial properties run every value through a QVariant conversion that flattens nested arrays into key maps. `barConfig` arrived with `layout.left/center/right` no longer arrays, so anything rendering from the facade's snapshot came up empty.

## What this changes

- `manifestKinds()` rehydrates non-native views through JSON (tiny lists, cheap), and every kind check goes through it. Profiles now agree no matter which path a manifest took.
- Facades are replaced in the caches, never `destroy()`ed. Capability revocation still works because the checks run at call time against the current manifest: the existing runtime-smoke assertions (current and retained references both losing capabilities after a real manifest change) pass unchanged. A replaced facade just loses its powers instead of taking the plugin's state down with it.
- `prunePluginApis` skips entries whose manifest is absent mid-rebuild; the pass after the scan settles judges them for real.
- `syncPluginApis` re-injects the current facade into registered panel loaders and the active bar, so a live consumer always converges no matter what order things happened in.
- Facades are created with their required scalars only, then composite payloads are assigned, which keeps arrays whole.
- New `plugin-shell-lifecycle-test.sh` runs a third-party bar plus keepLoaded panel against the real shell and holds every hop: snapshots keep arrays, mutations apply and persist to shell.json on disk, and the panel keeps a working facade across a plugin rescan.

## Testing

`./test/all` on my machine: same 4 pre-existing failures as clean quattro (config, locate, snapper, unowned-system-paths), nothing new. The new lifecycle test and the full runtime smoke suite, including the deliberate capability-revocation cases, pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)