### PR TITLE
Let reminders use clock times and manage queued ones

### DIFF
--- a/bin/omarchy-reminder
+++ b/bin/omarchy-reminder
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # omarchy:summary=Set and show lightweight desktop notification reminders
-# omarchy:args=[-i|--interactive] | <minutes> [message] | show [-j|--json] | clear
-# omarchy:examples=omarchy reminder -i | omarchy reminder 5 | omarchy reminder 30 "Check the oven" | omarchy reminder show | omarchy reminder show --json | omarchy reminder clear
+# omarchy:args=[-i|--interactive] | <minutes|HH:MM> [message] | show [-j|--json] | cancel [--quiet] <unit> | clear
+# omarchy:examples=omarchy reminder -i | omarchy reminder 5 | omarchy reminder 17:00 "Check the oven" | omarchy reminder show | omarchy reminder show --json | omarchy reminder cancel omarchy-reminder-15m-1710000000 | omarchy reminder clear
 
 set -euo pipefail
 
@@ -42,11 +42,56 @@ open_interactive() {
   omarchy-shell shell summon omarchy.reminders "{}"
 }
 
+open_manager() {
+  local output
+  output=$(omarchy-shell shell summon omarchy.reminders '{"mode":"manage"}' 2>/dev/null) || return 1
+  [[ $output == "ok" ]]
+}
+
+valid_unit() {
+  [[ ${1:-} =~ ^omarchy-reminder-[0-9]+m-[0-9]+$ ]]
+}
+
+# Convert a delay in minutes, or a clock time like 17:00 / 5pm, into a positive
+# whole-minute delay. Times already passed today roll to tomorrow.
+when_to_minutes() {
+  local spec=$1
+  local now target minutes
+
+  if [[ $spec =~ ^[0-9]+$ ]]; then
+    if ((spec == 0)); then
+      return 1
+    fi
+    echo "$spec"
+    return 0
+  fi
+
+  now=$(date +%s)
+  if ! target=$(date -d "$spec" +%s 2>/dev/null); then
+    return 1
+  fi
+  if ((target <= now)); then
+    if ! target=$(date -d "tomorrow $spec" +%s 2>/dev/null); then
+      return 1
+    fi
+  fi
+
+  minutes=$(((target - now + 59) / 60))
+  if ((minutes < 1)); then
+    minutes=1
+  fi
+  echo "$minutes"
+}
+
 show_reminders() {
   local timer next remaining reminder reminder_minutes body=""
   local reminder_dir="${XDG_RUNTIME_DIR:-/tmp}/omarchy-reminders"
   local reminder_message=""
   local now=$(date +%s)
+
+  if open_manager; then
+    return
+  fi
 
   while IFS=$'\t' read -r timer next; do
     remaining=$((next - now))
@@ -117,6 +162,28 @@ show_json() {
   jq -cn --argjson count "$count" --arg tooltip "$tooltip" --argjson reminders "$reminders_json" '{count:$count,active:($count > 0),tooltip:$tooltip,reminders:$reminders}'
 }
 
+cancel_reminder() {
+  local unit=$1
+  local quiet=$2
+  local reminder_dir="${XDG_RUNTIME_DIR:-/tmp}/omarchy-reminders"
+
+  unit=${unit%.timer}
+  unit=${unit%.service}
+
+  if ! valid_unit "$unit"; then
+    echo "Invalid reminder unit: ${1:-}" >&2
+    exit 1
+  fi
+
+  systemctl --user stop "${unit}.timer" "${unit}.service" "$unit" 2>/dev/null || true
+  rm -f "$reminder_dir/${unit}.message"
+  refresh_indicator
+
+  if ((quiet == 0)); then
+    omarchy-notification-send -g 󰢌 "Reminder cancelled"
+  fi
+}
+
 clear_reminders() {
   local units
   local reminder_dir="${XDG_RUNTIME_DIR:-/tmp}/omarchy-reminders"
@@ -134,8 +201,9 @@ clear_reminders() {
 
 usage() {
   echo "Usage: omarchy-reminder [-i|--interactive]"
-  echo "       omarchy-reminder <minutes> [message]"
+  echo "       omarchy-reminder <minutes|HH:MM> [message]"
   echo "       omarchy-reminder show [-j|--json]"
+  echo "       omarchy-reminder cancel [--quiet] <unit>"
   echo "       omarchy-reminder clear"
 }
 
@@ -159,21 +227,35 @@ show | list)
   esac
   exit 0
   ;;
+cancel)
+  shift
+  quiet=0
+  if [[ ${1:-} == --quiet ]]; then
+    quiet=1
+    shift
+  fi
+  if [[ -z ${1:-} ]]; then
+    usage
+    exit 1
+  fi
+  cancel_reminder "$1" "$quiet"
+  exit 0
+  ;;
 clear)
   clear_reminders
   exit 0
   ;;
 esac
 
-minutes=${1:-}
+when=${1:-}
 shift || true
 message="$*"
 custom_message="$message"
 
-if [[ -z $minutes ]] || [[ ! $minutes =~ ^[0-9]+$ ]] || ((minutes == 0)); then
+minutes=$(when_to_minutes "$when") || {
   usage
   exit 1
-fi
+}
 
 if [[ -z $message ]]; then
   message="Your ${minutes} minutes are up"
@@ -185,13 +267,24 @@ unit="omarchy-reminder-${minutes}m-$set_at"
 reminder_dir="${XDG_RUNTIME_DIR:-/tmp}/omarchy-reminders"
 message_file="$reminder_dir/$unit.message"
 confirmation="You'll be reminded at $remind_at"
-confirmation_title="Reminder set for ${minutes} minutes"
+if [[ $when =~ ^[0-9]+$ ]]; then
+  confirmation_title="Reminder set for ${minutes} minutes"
+else
+  confirmation_title="Reminder set for $remind_at"
+  if [[ -z $custom_message ]]; then
+    message="It's $remind_at"
+  fi
+fi
 
 mkdir -p "$reminder_dir"
 
 if [[ -n $custom_message ]]; then
   printf "%s" "$custom_message" >"$message_file"
-  confirmation_title="$custom_message in ${minutes} minutes"
+  if [[ $when =~ ^[0-9]+$ ]]; then
+    confirmation_title="$custom_message in ${minutes} minutes"
+  else
+    confirmation_title="$custom_message at $remind_at"
+  fi
 fi
 
 systemd-run --user --quiet --collect --on-active="${minutes}m" --unit="$unit" \

--- a/default/agents/skills/omarchy/SKILL.md
+++ b/default/agents/skills/omarchy/SKILL.md
@@ -259,10 +259,11 @@ When user requests system changes:
 
 ### Reminder Requests
 
-When the user asks to set a reminder, use `omarchy reminder <minutes> [message]` directly. Convert natural language durations to minutes and title-case short reminder labels when appropriate.
+When the user asks to set a reminder, use `omarchy reminder <minutes|HH:MM> [message]` directly. Convert natural language durations to minutes, keep clock times as `HH:MM` (or a 12-hour form like `5pm`), and title-case short reminder labels when appropriate.
 
 ```bash
 omarchy reminder 15 "Pickup Jack"
+omarchy reminder 17:00 "Pickup Jack"
 omarchy reminder 60 "Check laundry"
 omarchy reminder show
 omarchy reminder clear
@@ -283,6 +284,7 @@ This skill intentionally does not cover Omarchy source development. Do not use t
 - "Make the window gaps smaller" -> Edit `~/.config/hypr/looknfeel.lua`
 - "Turn on night light" -> `omarchy toggle nightlight` (for time-based schedules, edit `~/.config/hypr/hyprsunset.conf` profiles, then `omarchy restart hyprsunset`)
 - "Set a reminder to pickup jack in 15 minutes" -> `omarchy reminder 15 "Pickup Jack"`
+- "Remind me at 17:00 to pickup jack" -> `omarchy reminder 17:00 "Pickup Jack"`
 - "Show my reminders" -> `omarchy reminder show`
 - "Clear all reminders" -> `omarchy reminder clear`
 - "Customize the catppuccin theme colors" -> Overlay: put an edited `colors.toml` in `~/.config/omarchy/themes/catppuccin/`, then re-apply the theme (see `theming.md`)

--- a/manual/09-reminders.md
+++ b/manual/09-reminders.md
@@ -1,5 +1,5 @@
 # Reminders
 
-Omarchy has a built-in way to set simple reminders based on a countdown timer and with a message. You can do this via `Super + Ctrl + R`, seeing all the ones set via `Super + Ctrl + Alt + R`, and clearing all via `Super + Ctrl + Shift + R`. Everything also accessible via _Trigger > Reminder_. You can also use the cli with `omarchy reminder 7 'Tea ready'`.
+Omarchy has a built-in way to set simple reminders, either as a countdown in minutes or at a clock time such as `17:00`. You can do this via `Super + Ctrl + R`. Clicking the reminder glyph in the top bar — or `Super + Ctrl + Alt + R` — opens the list of queued reminders so you can amend one, cancel it, or add another. Clearing all is `Super + Ctrl + Shift + R`. Everything is also accessible via _Trigger > Reminder_. From the cli: `omarchy reminder 7 'Tea ready'`, `omarchy reminder 17:00 'Pickup Jack'`, `omarchy reminder show`, and `omarchy reminder clear`.
 
  ![reminders](images/reminders.webp)

--- a/shell/plugins/reminders/ReminderFlow.qml
+++ b/shell/plugins/reminders/ReminderFlow.qml
@@ -1,4 +1,5 @@
 import Quickshell
+import Quickshell.Io
 import Quickshell.Wayland
 import QtQuick
 import qs.Commons
@@ -15,20 +16,40 @@ Item {
   property bool opened: false
   property string step: "minutes"
   property string minutes: ""
+  property string timeLabel: ""
   property string filterText: ""
   property string fontFamily: Style.font.menuFamily
+  property var reminders: []
+  property int selectedIndex: 0
+  property string amendUnit: ""
+  property string pendingMessage: ""
+  property bool fromManage: false
+  property string cancelNotifyLabel: ""
 
   property color background: Color.menu.background
   property color foreground: Color.menu.text
   property color border: Color.menu.border
   property var borderSpec: Border.surfaceSpec("menu", "border", border, Math.max(1, Style.space(2)))
   property color scrim: Color.menu.scrim
+  property color selectedBackground: Color.menu.selectedBackground
+  property color selectedText: Color.menu.selectedText
   readonly property int cornerRadius: Style.cornerRadius
   property int contentMargin: Style.spacing.panelPadding
   property int headerHeight: Math.max(Style.space(34), Style.font.title + Style.spacing.controlPaddingY * 2)
-  property int cardWidth: Math.min(Style.space(300), panel.width - Style.gapsOut * 2)
-  property int cardHeight: Math.min(contentMargin * 2 + headerHeight, panel.height - Style.gapsOut * 2)
-  readonly property string promptText: root.step === "message" ? "Reminder message" : "Remind in minutes"
+  property int rowHeight: Math.max(Style.space(36), Style.font.body + Style.space(16))
+  property int hintHeight: Style.font.caption + Style.space(14)
+  readonly property bool managing: root.step === "manage"
+  readonly property int manageCount: root.reminders.length + 1
+  property int cardWidth: Math.min(Style.space(root.managing ? 440 : 300), panel.width - Style.gapsOut * 2)
+  property int cardHeight: Math.min(root.managing
+    ? root.contentMargin * 2 + root.headerHeight + root.manageCount * root.rowHeight + root.hintHeight + Style.space(8)
+    : root.contentMargin * 2 + root.headerHeight, panel.height - Style.gapsOut * 2)
+  readonly property string promptText: root.step === "message" ? "Reminder message" : "Minutes or HH:MM"
+  readonly property string hintText: {
+    if (!root.managing) return ""
+    if (root.selectedIndex >= root.reminders.length) return "Enter to set a reminder"
+    return "Enter amend  ·  Del cancel  ·  Esc close"
+  }
 
   function open(payloadJson) {
     var payload = ({})
@@ -36,9 +57,22 @@ Item {
     if (payload.fontFamily) root.fontFamily = payload.fontFamily
 
     root.opened = true
-    root.step = "minutes"
     root.minutes = ""
+    root.timeLabel = ""
     root.filterText = ""
+    root.amendUnit = ""
+    root.pendingMessage = ""
+    root.selectedIndex = 0
+    root.cancelNotifyLabel = ""
+
+    if (payload.mode === "manage") {
+      root.fromManage = true
+      root.step = "manage"
+      root.refreshList()
+    } else {
+      root.fromManage = false
+      root.step = "minutes"
+    }
 
     Qt.callLater(function() { keyCatcher.forceActiveFocus() })
   }
@@ -62,33 +96,134 @@ Item {
     root.filterText = nextFilter
   }
 
+  function refreshList() {
+    if (!listProc.running) listProc.running = true
+  }
+
+  function loadReminders(raw) {
+    root.reminders = ReminderFlowModel.parseList(raw)
+    if (root.selectedIndex >= root.manageCount) root.selectedIndex = Math.max(0, root.manageCount - 1)
+    if (root.selectedIndex < 0) root.selectedIndex = 0
+  }
+
+  function manageItem(index) {
+    if (index < 0) return null
+    if (index < root.reminders.length) return root.reminders[index]
+    if (index === root.reminders.length) return { kind: "new" }
+    return null
+  }
+
+  function select(delta) {
+    if (root.manageCount <= 0) return
+    root.selectedIndex = (root.selectedIndex + delta + root.manageCount) % root.manageCount
+  }
+
+  function startNew() {
+    root.amendUnit = ""
+    root.pendingMessage = ""
+    root.fromManage = true
+    root.minutes = ""
+    root.timeLabel = ""
+    root.filterText = ""
+    root.step = "minutes"
+    Qt.callLater(function() { keyCatcher.forceActiveFocus() })
+  }
+
+  function startAmend(item) {
+    if (!item || item.kind === "new") return
+    root.amendUnit = item.unit || ""
+    root.pendingMessage = item.message || ""
+    root.fromManage = true
+    root.minutes = ""
+    root.timeLabel = ""
+    root.filterText = item.atTime || ""
+    root.step = "minutes"
+    Qt.callLater(function() { keyCatcher.forceActiveFocus() })
+  }
+
+  function activateSelected() {
+    var item = root.manageItem(root.selectedIndex)
+    if (!item) return
+    if (item.kind === "new") root.startNew()
+    else root.startAmend(item)
+  }
+
+  function cancelUnit(unit, notifyLabel) {
+    if (!ReminderFlowModel.validUnit(unit)) return
+    root.cancelNotifyLabel = notifyLabel || ""
+    cancelProc.command = [root.omarchyPath + "/bin/omarchy-reminder", "cancel", "--quiet", unit]
+    cancelProc.running = true
+  }
+
+  function cancelSelected() {
+    var item = root.manageItem(root.selectedIndex)
+    if (!item || item.kind === "new") return
+    root.cancelUnit(item.unit, ReminderFlowModel.rowTitle(item))
+  }
+
+  function backToManage() {
+    root.amendUnit = ""
+    root.pendingMessage = ""
+    root.filterText = ""
+    root.minutes = ""
+    root.timeLabel = ""
+    root.step = "manage"
+    root.refreshList()
+    Qt.callLater(function() { keyCatcher.forceActiveFocus() })
+  }
+
   function submit() {
     var selection = root.filterText
 
     if (root.step === "minutes") {
-      var nextMinutes = ReminderFlowModel.validMinutes(selection)
+      var parsed = ReminderFlowModel.parseWhen(selection)
 
       if (!selection.trim()) {
-        root.dismiss()
+        if (root.fromManage) root.backToManage()
+        else root.dismiss()
         return
       }
 
-      if (!nextMinutes) {
-        Quickshell.execDetached([root.omarchyPath + "/bin/omarchy-notification-send", "Invalid reminder", "Enter the number of minutes"])
+      if (!parsed) {
+        Quickshell.execDetached([root.omarchyPath + "/bin/omarchy-notification-send", "Invalid reminder", "Enter minutes (15) or a time (17:00)"])
         return
       }
 
-      root.minutes = nextMinutes
+      root.minutes = parsed.minutes
+      root.timeLabel = parsed.displayTime || ""
       root.step = "message"
-      root.filterText = ""
+      root.filterText = root.pendingMessage
+      root.pendingMessage = ""
       Qt.callLater(function() { keyCatcher.forceActiveFocus() })
       return
     }
 
     if (root.step === "message") {
-      var args = [root.omarchyPath + "/bin/omarchy-reminder"].concat(ReminderFlowModel.reminderArgs(root.minutes, selection))
+      var args = [root.omarchyPath + "/bin/omarchy-reminder"].concat(ReminderFlowModel.reminderArgs(root.minutes, selection, root.timeLabel))
+      var replacing = root.amendUnit
       root.dismiss()
       Quickshell.execDetached(args)
+      if (replacing) root.cancelUnit(replacing, "")
+    }
+  }
+
+  Process {
+    id: listProc
+    command: ["omarchy-reminder", "show", "--json"]
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: root.loadReminders(text)
+    }
+  }
+
+  Process {
+    id: cancelProc
+    onExited: function() {
+      if (root.cancelNotifyLabel) {
+        Quickshell.execDetached([root.omarchyPath + "/bin/omarchy-notification-send", "-g", "󰢌", "Reminder cancelled", root.cancelNotifyLabel])
+        root.cancelNotifyLabel = ""
+      }
+      if (root.opened && root.managing) root.refreshList()
     }
   }
 
@@ -131,8 +266,35 @@ Item {
 
         Keys.priority: Keys.BeforeItem
         Keys.onPressed: function(event) {
+          if (root.managing) {
+            if (event.key === Qt.Key_Escape) {
+              root.dismiss()
+              event.accepted = true
+            } else if (event.key === Qt.Key_Up) {
+              root.select(-1)
+              event.accepted = true
+            } else if (event.key === Qt.Key_Down) {
+              root.select(1)
+              event.accepted = true
+            } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+              root.activateSelected()
+              event.accepted = true
+            } else if (event.key === Qt.Key_Delete || event.key === Qt.Key_Backspace) {
+              root.cancelSelected()
+              event.accepted = true
+            } else if (event.text === "n" || event.text === "N") {
+              root.startNew()
+              event.accepted = true
+            } else if (event.text === "x" || event.text === "X") {
+              root.cancelSelected()
+              event.accepted = true
+            }
+            return
+          }
+
           if (event.key === Qt.Key_Escape) {
             if (root.filterText) root.setFilter("")
+            else if (root.fromManage) root.backToManage()
             else root.dismiss()
             event.accepted = true
           } else if (Util.editsFilter(event, root.filterText)) {
@@ -141,9 +303,12 @@ Item {
           } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
             root.submit()
             event.accepted = true
-          } else if (event.text && event.text.length === 1 && event.text.charCodeAt(0) >= 32 && event.text.charCodeAt(0) !== 127) {
-            root.setFilter(root.filterText + event.text)
-            event.accepted = true
+          } else {
+            var ch = ReminderFlowModel.typedChar(event.key, event.modifiers, event.nativeScanCode, event.text)
+            if (ch) {
+              root.setFilter(root.filterText + ch)
+              event.accepted = true
+            }
           }
         }
       }
@@ -156,6 +321,7 @@ Item {
         anchors.leftMargin: card.contentLeftInset
 
         Text {
+          visible: !root.managing
           textFormat: Text.PlainText
           anchors.left: parent.left
           anchors.right: parent.right
@@ -166,6 +332,126 @@ Item {
           font.family: root.fontFamily
           font.pixelSize: Style.font.heading
           elide: Text.ElideRight
+        }
+
+        Column {
+          visible: root.managing
+          anchors.fill: parent
+          spacing: 0
+
+          Text {
+            width: parent.width
+            height: root.headerHeight
+            textFormat: Text.PlainText
+            text: "Reminders"
+            color: root.foreground
+            font.family: root.fontFamily
+            font.pixelSize: Style.font.title
+            verticalAlignment: Text.AlignVCenter
+            elide: Text.ElideRight
+          }
+
+          Repeater {
+            model: root.manageCount
+
+            Rectangle {
+              required property int index
+              readonly property var item: root.manageItem(index)
+              readonly property bool isNew: !!(item && item.kind === "new")
+              readonly property bool selected: index === root.selectedIndex
+
+              width: parent.width
+              height: root.rowHeight
+              radius: root.cornerRadius
+              color: selected ? root.selectedBackground : "transparent"
+
+              Text {
+                id: titleLabel
+                textFormat: Text.PlainText
+                anchors.left: parent.left
+                anchors.leftMargin: Style.space(8)
+                anchors.right: metaLabel.left
+                anchors.rightMargin: Style.space(12)
+                anchors.verticalCenter: parent.verticalCenter
+                text: isNew ? "New reminder" : ReminderFlowModel.rowTitle(item)
+                color: selected ? root.selectedText : root.foreground
+                opacity: isNew && !selected ? 0.58 : 1
+                font.family: root.fontFamily
+                font.pixelSize: Style.font.body
+                elide: Text.ElideRight
+              }
+
+              Text {
+                id: metaLabel
+                visible: !isNew
+                textFormat: Text.PlainText
+                anchors.right: cancelHit.left
+                anchors.rightMargin: Style.space(8)
+                anchors.verticalCenter: parent.verticalCenter
+                text: ReminderFlowModel.rowMeta(item)
+                color: selected ? root.selectedText : root.foreground
+                opacity: 0.62
+                font.family: root.fontFamily
+                font.pixelSize: Style.font.caption
+              }
+
+              Text {
+                id: cancelHit
+                visible: !isNew
+                textFormat: Text.PlainText
+                anchors.right: parent.right
+                anchors.rightMargin: Style.space(8)
+                anchors.verticalCenter: parent.verticalCenter
+                width: visible ? implicitWidth : 0
+                text: "✕"
+                color: selected ? root.selectedText : root.foreground
+                opacity: cancelMouse.containsMouse ? 1 : 0.45
+                font.family: root.fontFamily
+                font.pixelSize: Style.font.body
+
+                MouseArea {
+                  id: cancelMouse
+                  anchors.fill: parent
+                  anchors.margins: -Style.space(6)
+                  hoverEnabled: true
+                  cursorShape: Qt.PointingHandCursor
+                  onClicked: {
+                    root.selectedIndex = index
+                    root.cancelSelected()
+                  }
+                }
+              }
+
+              MouseArea {
+                anchors.fill: parent
+                z: -1
+                hoverEnabled: true
+                cursorShape: Qt.PointingHandCursor
+                onEntered: root.selectedIndex = index
+                onClicked: {
+                  root.selectedIndex = index
+                  if (isNew) root.startNew()
+                }
+                onDoubleClicked: {
+                  root.selectedIndex = index
+                  if (!isNew) root.startAmend(item)
+                }
+              }
+            }
+          }
+
+          Text {
+            width: parent.width
+            height: root.hintHeight
+            textFormat: Text.PlainText
+            text: root.hintText
+            color: root.foreground
+            opacity: 0.5
+            font.family: root.fontFamily
+            font.pixelSize: Style.font.caption
+            verticalAlignment: Text.AlignVCenter
+            elide: Text.ElideRight
+          }
         }
       }
     }

--- a/shell/plugins/reminders/ReminderFlowModel.js
+++ b/shell/plugins/reminders/ReminderFlowModel.js
@@ -3,19 +3,181 @@ function validMinutes(value) {
   return /^[0-9]+$/.test(minutes) && Number(minutes) > 0 ? minutes : ""
 }
 
-function reminderArgs(minutes, message) {
+function normalizeWhenInput(value) {
+  return String(value || "").trim().toLowerCase().replace(/\s+/g, "")
+}
+
+function formatHm(hour, minute) {
+  return String(hour) + ":" + (minute < 10 ? "0" : "") + String(minute)
+}
+
+function parseClock(value) {
+  var raw = normalizeWhenInput(value)
+  var match
+  var hour
+  var minute
+  var second
+
+  match = raw.match(/^(\d{1,2})(?:[:.](\d{2}))?(?:[:.](\d{2}))?(am|pm)$/)
+  if (match) {
+    hour = Number(match[1])
+    minute = Number(match[2] || "0")
+    second = Number(match[3] || "0")
+    if (hour < 1 || hour > 12 || minute > 59 || second > 59) return null
+    if (match[4] === "am") hour = hour === 12 ? 0 : hour
+    else hour = hour === 12 ? 12 : hour + 12
+    return { hour: hour, minute: minute, second: second }
+  }
+
+  match = raw.match(/^(\d{1,2})[:.](\d{2})(?:[:.](\d{2}))?$/)
+  if (match) {
+    hour = Number(match[1])
+    minute = Number(match[2])
+    second = Number(match[3] || "0")
+    if (hour > 23 || minute > 59 || second > 59) return null
+    return { hour: hour, minute: minute, second: second }
+  }
+
+  return null
+}
+
+// Qt::Key / modifier values. Layer-shell exclusive focus often starts without
+// the compositor's NumLock lock, so keypad keys arrive as navigation keys
+// with empty event.text until NumLock is toggled on that surface.
+var KEY_0 = 0x30
+var KEY_9 = 0x39
+var KEY_INSERT = 0x01000006
+var KEY_DELETE = 0x01000007
+var KEY_CLEAR = 0x0100000b
+var KEY_HOME = 0x01000010
+var KEY_END = 0x01000011
+var KEY_LEFT = 0x01000012
+var KEY_UP = 0x01000013
+var KEY_RIGHT = 0x01000014
+var KEY_DOWN = 0x01000015
+var KEY_PAGEUP = 0x01000016
+var KEY_PAGEDOWN = 0x01000017
+var KEY_PERIOD = 0x2e
+var KEYPAD_MOD = 0x20000000
+var CTRL_ALT_META = 0x04000000 | 0x08000000 | 0x10000000
+
+// XKB keycodes (Wayland evdev + 8), as QKeyEvent.nativeScanCode on Qt Wayland.
+var XKB_KEYPAD_CHARS = {
+  79: "7", 80: "8", 81: "9",
+  83: "4", 84: "5", 85: "6",
+  87: "1", 88: "2", 89: "3",
+  90: "0", 91: "."
+}
+
+function keypadNavChar(key) {
+  switch (key) {
+    case KEY_INSERT: return "0"
+    case KEY_END: return "1"
+    case KEY_DOWN: return "2"
+    case KEY_PAGEDOWN: return "3"
+    case KEY_LEFT: return "4"
+    case KEY_CLEAR: return "5"
+    case KEY_RIGHT: return "6"
+    case KEY_HOME: return "7"
+    case KEY_UP: return "8"
+    case KEY_PAGEUP: return "9"
+    case KEY_DELETE:
+    case KEY_PERIOD: return "."
+    default: return ""
+  }
+}
+
+function typedChar(key, modifiers, nativeScanCode, text) {
+  modifiers = Number(modifiers) || 0
+  if (modifiers & CTRL_ALT_META) return ""
+
+  if (key >= KEY_0 && key <= KEY_9) return String.fromCharCode(key)
+
+  var fromScan = XKB_KEYPAD_CHARS[Number(nativeScanCode) || 0]
+  if (fromScan) return fromScan
+
+  if (modifiers & KEYPAD_MOD) {
+    var fromNav = keypadNavChar(key)
+    if (fromNav) return fromNav
+  }
+
+  var raw = String(text || "")
+  if (raw.length === 1) {
+    var code = raw.charCodeAt(0)
+    if (code >= 32 && code !== 127) return raw
+  }
+  return ""
+}
+
+function minutesUntil(targetMs, nowMs) {
+  var remainingMs = targetMs - nowMs
+  if (remainingMs <= 0) return "1"
+  return String(Math.max(1, Math.ceil(remainingMs / 60000)))
+}
+
+function parseWhen(value, now) {
+  var minutes = validMinutes(value)
+  if (minutes) return { kind: "minutes", minutes: minutes }
+
+  var clock = parseClock(value)
+  if (!clock) return null
+
+  var current = now instanceof Date ? now : (now ? new Date(now) : new Date())
+  var target = new Date(current.getFullYear(), current.getMonth(), current.getDate(), clock.hour, clock.minute, clock.second, 0)
+  if (target.getTime() <= current.getTime()) target.setDate(target.getDate() + 1)
+
+  return {
+    kind: "time",
+    minutes: minutesUntil(target.getTime(), current.getTime()),
+    displayTime: formatHm(clock.hour, clock.minute)
+  }
+}
+
+function parseList(raw) {
+  try {
+    var data = JSON.parse(String(raw || ""))
+    return Array.isArray(data.reminders) ? data.reminders : []
+  } catch (e) {
+    return []
+  }
+}
+
+function validUnit(unit) {
+  return /^omarchy-reminder-[0-9]+m-[0-9]+$/.test(String(unit || ""))
+}
+
+function rowTitle(item) {
+  return String((item && item.label) || "Reminder")
+}
+
+function rowMeta(item) {
+  var remaining = String((item && item.remaining) || "")
+  var atTime = String((item && item.atTime) || "")
+  if (remaining && atTime) return remaining + "  (" + atTime + ")"
+  return remaining || atTime
+}
+
+function reminderArgs(minutes, message, timeLabel) {
   var valid = validMinutes(minutes)
   if (!valid) return []
 
   var args = [valid]
   var text = String(message || "")
   if (text.length > 0) args.push(text)
+  else if (timeLabel) args.push("It's " + timeLabel)
   return args
 }
 
 if (typeof module !== "undefined") {
   module.exports = {
     validMinutes: validMinutes,
-    reminderArgs: reminderArgs
+    parseClock: parseClock,
+    parseWhen: parseWhen,
+    reminderArgs: reminderArgs,
+    typedChar: typedChar,
+    parseList: parseList,
+    validUnit: validUnit,
+    rowTitle: rowTitle,
+    rowMeta: rowMeta
   }
 }

--- a/test/shell.d/reminders-test.sh
+++ b/test/shell.d/reminders-test.sh
@@ -13,6 +13,62 @@ assertEqual(reminders.validMinutes('0'), '', 'reminders rejects zero minutes')
 assertEqual(reminders.validMinutes('-5'), '', 'reminders rejects negative minutes')
 assertEqual(reminders.validMinutes('1.5'), '', 'reminders rejects fractional minutes')
 assertEqual(reminders.validMinutes('soon'), '', 'reminders rejects non-numeric minutes')
+assertEqual(reminders.validMinutes('17:00'), '', 'clock times are not raw minutes')
+
+assertDeepEqual(
+  reminders.parseClock('17:00'),
+  { hour: 17, minute: 0, second: 0 },
+  'reminders parse 24-hour clock times'
+)
+assertDeepEqual(
+  reminders.parseClock('9:05'),
+  { hour: 9, minute: 5, second: 0 },
+  'reminders parse unpadded 24-hour clock times'
+)
+assertDeepEqual(
+  reminders.parseClock('5pm'),
+  { hour: 17, minute: 0, second: 0 },
+  'reminders parse 12-hour clock times'
+)
+assertDeepEqual(
+  reminders.parseClock('5:30 PM'),
+  { hour: 17, minute: 30, second: 0 },
+  'reminders parse spaced 12-hour clock times'
+)
+assertEqual(reminders.parseClock('24:00'), null, 'reminders reject 24:00')
+assertEqual(reminders.parseClock('7:60'), null, 'reminders reject invalid minutes')
+
+const sixteen = new Date(2026, 8, 10, 16, 0, 0)
+const atFive = reminders.parseWhen('17:00', sixteen)
+assertEqual(atFive.kind, 'time', 'clock input is a time reminder')
+assertEqual(atFive.minutes, '60', '17:00 from 16:00 is 60 minutes')
+assertEqual(atFive.displayTime, '17:00', 'clock reminders keep a display time')
+assertEqual(reminders.parseWhen('5pm', sixteen).minutes, '60', '5pm from 16:00 is 60 minutes')
+assertEqual(reminders.parseWhen('15', sixteen).kind, 'minutes', 'plain integers stay minute delays')
+assertEqual(reminders.parseWhen('17.00', sixteen).minutes, '60', 'numpad decimal is a time separator')
+
+const KEY_8 = 0x38
+const KEY_UP = 0x01000013
+const KEYPAD = 0x20000000
+const CTRL = 0x04000000
+assertEqual(reminders.typedChar(KEY_8, KEYPAD, 80, '8'), '8', 'synced numpad digit types 8')
+assertEqual(reminders.typedChar(KEY_UP, 0, 80, ''), '8', 'unsynced numpad 8 types via scan code')
+assertEqual(reminders.typedChar(KEY_UP, KEYPAD, 0, ''), '8', 'unsynced numpad 8 types via keypad modifier')
+assertEqual(reminders.typedChar(KEY_UP, 0, 111, ''), '', 'dedicated Up arrow does not type a digit')
+assertEqual(reminders.typedChar(65, 0, 38, 'a'), 'a', 'ordinary characters still type')
+assertEqual(reminders.typedChar(KEY_8, CTRL, 80, '8'), '', 'ctrl+digit is ignored')
+
+const listed = reminders.parseList(JSON.stringify({
+  count: 1,
+  reminders: [{ unit: 'omarchy-reminder-15m-1', label: 'Pickup Jack', remaining: '12m', atTime: '17:00' }]
+}))
+assertEqual(listed.length, 1, 'reminder json lists reminders')
+assertEqual(reminders.rowTitle(listed[0]), 'Pickup Jack', 'reminder rows use the label')
+assertEqual(reminders.rowMeta(listed[0]), '12m  (17:00)', 'reminder rows show remaining time')
+assertEqual(reminders.validUnit('omarchy-reminder-15m-1710000000'), true, 'valid reminder units match the systemd name')
+assertEqual(reminders.validUnit('omarchy-reminder-15m-1710000000.timer'), false, 'timer suffix is not a unit id')
+assertEqual(reminders.validUnit('../evil'), false, 'paths are not valid reminder units')
+assertEqual(reminders.parseList('nope').length, 0, 'invalid reminder json is empty')
 
 assertDeepEqual(
   reminders.reminderArgs('10', 'Check the oven'),
@@ -24,6 +80,12 @@ assertDeepEqual(
   reminders.reminderArgs('10', ''),
   ['10'],
   'reminders omits empty message arg'
+)
+
+assertDeepEqual(
+  reminders.reminderArgs('60', '', '17:00'),
+  ['60', "It's 17:00"],
+  'clock reminders default to a time label'
 )
 
 assertDeepEqual(


### PR DESCRIPTION
## Summary

Reminders were minute-only, keypad digits were dropped until NumLock was toggled on the overlay, and the only view of queued reminders was a notification with no actions.

This makes the overlay and CLI accept a clock time as well as a delay, types keypad digits even when exclusive keyboard focus has not inherited NumLock, and turns **show** into a list you can amend, cancel, or add to.

## Changes

- **Clock times.** `15`, `17:00`, `17.00`, and `5pm` all work in the overlay. The CLI accepts the same: `omarchy reminder 17:00 "Pickup Jack"`. Times already past today roll to tomorrow.
- **Keypad.** Layer-shell exclusive focus often starts without the compositor's NumLock lock, so keypad keys arrived as arrows with empty `event.text`. The overlay maps those keys (and XKB keypad scan codes) to digits.
- **Manage list.** `omarchy reminder show`, the bar glyph (when something is queued), and Super+Ctrl+Alt+R open the overlay in manage mode instead of a dead notification. Enter amends, Delete/x or the row ✕ cancels, and **New reminder** starts another. `omarchy reminder cancel [--quiet] <unit>` cancels one timer. If the shell is not running, `show` still falls back to the old notification.

## Tests

- Extended `test/shell.d/reminders-test.sh` for clock parsing, keypad mapping, list JSON, and unit-name validation.
- `./test/shell.d/reminders-test.sh` and `./test/cli` pass.
- `./test/all`: reminder tests pass. The six failing files (`config-test`, `launch-about-test`, `locate-test`, `runtime-smoke-test`, `snapper-test`, `unowned-system-paths-test`) look environmental (missing `omarchy-pkgs` checkout, non-executable scripts, about-window animation) and are unrelated to this change.

## Manual verification

Exercised on a live Omarchy 4.0.3 session: clock times, keypad entry without toggling NumLock, cancel/amend from the list, and adding another reminder from **New reminder**.