### PR TITLE
Keep screensaver/lock from engaging during Steam games

### DIFF
--- a/default/hypr/apps/steam.lua
+++ b/default/hypr/apps/steam.lua
@@ -2,3 +2,9 @@ o.window("steam", { float = true, idle_inhibit = "fullscreen" })
 o.window({ class = "steam", title = "Steam" }, { center = true, size = { 1100, 700 } })
 o.window("steam.*", { tag = "-default-opacity", opacity = "1 1" })
 o.window({ class = "steam", title = "Friends List" }, { size = { 460, 800 } })
+
+-- A running game is a separate window from the Steam client above, and Steam
+-- classes it steam_app_<appid> (both native and Proton titles). Without this,
+-- the screensaver and lock still engage during play since controller/gamepad
+-- input doesn't register as activity.
+o.window("^steam_app_[0-9]+$", { idle_inhibit = "fullscreen" })

--- a/test/shell.d/steam-idle-inhibit-test.sh
+++ b/test/shell.d/steam-idle-inhibit-test.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+steam_rules="$ROOT/default/hypr/apps/steam.lua"
+
+# Steam classes the running game's own window steam_app_<appid>, separate from
+# the Steam client window matched above it. Without this rule the screensaver
+# and lock still engage during play, since gamepad input doesn't register as
+# activity.
+rg -q '^o\.window\("\^steam_app_\[0-9\]\+\$", \{ idle_inhibit = "fullscreen" \}\)$' "$steam_rules" ||
+  fail "Steam game windows (steam_app_<appid>) inhibit idle while fullscreen"
+pass "Steam game windows (steam_app_<appid>) inhibit idle while fullscreen"


### PR DESCRIPTION
## Summary

- Steam's client window already inhibits idle while fullscreen (`default/hypr/apps/steam.lua`), but the actual game runs in a separate window that Steam classes `steam_app_<appid>` (true for both native Linux titles and Proton). That window wasn't covered, so the screensaver and lock still engaged mid-game — controller/gamepad input doesn't register as user activity to the compositor.
- Adds one window rule following the exact pattern already used for Steam's own window and for RetroArch/Moonlight/GeForce Now: `idle_inhibit = "fullscreen"` scoped to `^steam_app_[0-9]+$`, so idle suppression is tied to the game window actually being on screen, not to input.

## Test plan

- [x] Added `test/shell.d/steam-idle-inhibit-test.sh` asserting the new rule is present
- [x] `./test/all` — no new failures (5 pre-existing, unrelated failures reproduce identically on a clean checkout of this branch's base: missing sibling `omarchy-pkgs` checkout, two scripts losing their exec bit through the fork/clone, and one shell-IPC sandbox flake)
- [x] Verified manually against Hyprland's own window-rule semantics; `idleinhibit fullscreen, class:^(steam_app_)` is the documented community-standard fix for this exact issue (see https://forum.hypr.land/t/window-rule-for-games/988)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Pt2Qi6SP9TN6Rmr9LiL4V