### PR TITLE
docs: add omarchy-nixos to the NixOS section

### DIFF
--- a/manual/49-omarchy-on.md
+++ b/manual/49-omarchy-on.md
@@ -22,7 +22,12 @@ The Steam Deck runs on Arch, which means you can run Omarchy on your Steam Deck.
 
 ### NixOS
 
-Omarchy is really Arch + Hyprland, but Henry Sipp has [ported the essence of the setup to NixOS](https://github.com/henrysipp/omarchy-nix). So if you've been nix-pilled, here's a good starting point. It may or may not stay up-to-date with the latest Omarchy changes, but it's pretty cool none the less!
+Omarchy is really Arch + Hyprland, but the essence has been ported to NixOS:
+
+- [omarchy-nix](https://github.com/henrysipp/omarchy-nix) — the first NixOS port.
+- [omarchy-nixos](https://github.com/gaoqiaominfu/omarchy-nixos) — a pure NixOS system configuration (no flakes, no home-manager) that reproduces the Omarchy look & feel with waybar, rofi, mako, hyprlock and a ported SDDM theme, targeting NixOS 26.05.
+
+So if you've been nix-pilled, these are good starting points. They may or may not stay up-to-date with the latest Omarchy changes, but they're pretty cool none the less!
 
 ### Something else!
 


### PR DESCRIPTION
This adds a second community NixOS port to the "Omarchy on... NixOS" section. It complements the existing [omarchy-nix](https://github.com/henrysipp/omarchy-nix) port with [omarchy-nixos](https://github.com/gaoqiaominfu/omarchy-nixos): a pure NixOS system configuration (no flakes, no home-manager) targeting NixOS 26.05, reproducing the Omarchy look & feel with waybar, rofi, mako, hyprlock, a ported SDDM theme, and Tokyo Night theming.