### PR TITLE
Pin recording audio sample rate at 48 kHz

### DIFF
--- a/bin/omarchy-capture-screenrecording
+++ b/bin/omarchy-capture-screenrecording
@@ -268,7 +268,9 @@ finalize_recording() {
     # Hard-mute the first 400ms to drop the PipeWire capture-open pop (a near-clipping
     # transient around 130-200ms that a gentle fade-in can't attenuate enough), then a
     # 50ms fade avoids a click at the boundary before loudnorm normalizes the rest.
-    args+=(-af "volume=enable='lt(t,0.4)':volume=0,afade=t=in:st=0.4:d=0.05,loudnorm=I=-14:TP=-1.5:LRA=11")
+    # loudnorm analyses at 192 kHz and declares that as its output rate; pin -ar 48000
+    # so ffmpeg doesn't negotiate the AAC encoder's 96 kHz ceiling instead.
+    args+=(-ar 48000 -af "volume=enable='lt(t,0.4)':volume=0,afade=t=in:st=0.4:d=0.05,loudnorm=I=-14:TP=-1.5:LRA=11")
   fi
 
   local processed="${latest%.mp4}-processed.mp4"


### PR DESCRIPTION
Every screen recording made with audio was written at 96 kHz AAC instead of the 48 kHz the recorder captured, because ffmpeg's `loudnorm` filter analyses at 192 kHz and declares that as its output rate. With no `-ar` pinned, the finalize pass negotiated that against the AAC encoder's 96 kHz ceiling, silently resampling the audio up. 96 kHz AAC is poorly supported downstream — DaVinci Resolve, for one, imports the clip with correct metadata but decodes no samples (silent audio, blank waveform) — and it costs bitrate for no benefit since the source is 48 kHz.

Fix by adding `-ar 48000` to the finalize invocation in `finalize_recording()`. Loudness normalization is unaffected: a -21.1 dB source still lands at -13.6 dB against the -14 LUFS target.

Fixes #10970