### PR TITLE
Fix keybindings menu Lua mock spinning on Lua 5.4+ ipairs

### DIFF
--- a/bin/omarchy-menu-keybindings
+++ b/bin/omarchy-menu-keybindings
@@ -186,7 +186,13 @@ end
 
 local noop
 noop = setmetatable({}, {
-  __index = function()
+  -- Return nil for numeric keys so ipairs/pairs see an empty table. Lua 5.4+
+  -- makes ipairs consult __index; returning noop for every integer key would
+  -- loop forever over a config that walks a mock value (e.g. window.tags).
+  __index = function(_, key)
+    if type(key) == "number" then
+      return nil
+    end
     return noop
   end,
   __call = function()

--- a/test/shell.d/keybindings-menu-test.sh
+++ b/test/shell.d/keybindings-menu-test.sh
@@ -220,3 +220,44 @@ for action in "${expected_alternatives[@]}"; do
     fail "every action named as having an alternative is bound twice" "$action"
 done
 pass "every action named as having an alternative is bound twice"
+
+# A config that walks a mock value with ipairs must not hang the Lua bind scan.
+# Lua 5.4+ makes ipairs consult __index; before the mock returned nil for
+# numeric keys, iterating a window-derived value spun forever and pegged a core.
+# The trigger sits at the top of hyprland.lua so it runs ahead of
+# default.hypr.omarchy, whose qconsole.lua compares a mock monitor's scale and
+# errors early, which would otherwise mask this hang.
+{
+  cat <<'LUA'
+local function walk_window_tags()
+  local window = hl.get_active_window()
+  if not window then
+    return
+  end
+
+  local tags = window.tags
+  if type(tags) == "table" then
+    for _, tag in ipairs(tags) do
+      if tag:gsub("%*$", "") == "terminal" then
+        return
+      end
+    end
+  end
+end
+walk_window_tags()
+LUA
+  cat "$home/.config/hypr/hyprland.lua"
+} >"$home/.config/hypr/hyprland.lua.tmp"
+mv "$home/.config/hypr/hyprland.lua.tmp" "$home/.config/hypr/hyprland.lua"
+
+stub_hyprctl <<BINDS
+$(exec_bind 64 "SUPER + K" "Keybindings" "omarchy-menu-keybindings")
+BINDS
+
+rendered=$(timeout 10 env -i PATH="$stub_bin:$ROOT/bin:$PATH" HOME="$home" \
+  XDG_CACHE_HOME="$tmpdir/cache" OMARCHY_PATH="$ROOT" \
+  bash "$ROOT/bin/omarchy-menu-keybindings" --print) ||
+  fail "the Lua bind scan hangs on a config that iterates a mock value"
+grep -q 'SUPER + K  *→ Keybindings' <<<"$rendered" ||
+  fail "the menu renders after iterating a mock value" "$rendered"
+pass "the Lua bind scan survives a config that iterates a mock value"


### PR DESCRIPTION
Fixes #11094

The keybindings menu's Lua bind scan hangs at 100% CPU when a config iterates a mock value with `ipairs`/`pairs`. Lua 5.4 changed `ipairs` to consult `__index`; the mock's `noop` answered every integer key with itself, so `ipairs(noop)` looped forever (e.g. iterating `hl.get_active_window().tags`).

The fix makes `__index` return `nil` for numeric keys so iteration terminates, while named keys still return `noop` so chaining (`window.tags`, `:set_enabled()`, `hl.dsp.*`) keeps working.

Adds a regression test that walks `hl.get_active_window().tags` at config load — it hangs without the fix and passes with it.
