### PR TITLE
Prevent shell.json edits from replacing symlinked configs

### DIFF
--- a/bin/omarchy-shell-config
+++ b/bin/omarchy-shell-config
@@ -44,6 +44,12 @@ NORMALIZE='
 # Apply a jq program to the source file and atomically write the result to the
 # user config, then refresh the running shell. Extra args after the program are
 # forwarded to jq (e.g. --arg/--argjson).
+#
+# The config is often a symlink into a dotfiles repo (the manual recommends
+# Stow), so stage the result beside the resolved target and rename onto that.
+# A rename onto the path itself would swap the link for a regular file, and a
+# staging file in /tmp usually sits on another filesystem, so the "atomic" mv
+# was a copy anyway.
 _SHELL_CONFIG_TMP=""
 cleanup_shell_config_tmp() {
   if [[ -n $_SHELL_CONFIG_TMP ]]; then rm -f "$_SHELL_CONFIG_TMP"; fi
@@ -53,10 +59,14 @@ trap cleanup_shell_config_tmp EXIT
 commit() {
   local program="$1"
   shift
-  mkdir -p "$(dirname "$CONFIG_FILE")"
-  _SHELL_CONFIG_TMP=$(mktemp)
+  local target
+  target=$(readlink -m -- "$CONFIG_FILE")
+  mkdir -p "$(dirname "$target")"
+  _SHELL_CONFIG_TMP=$(mktemp -p "$(dirname "$target")" .shell.json.XXXXXX)
   jq -S -e "$@" "$program" "$(source_file)" >"$_SHELL_CONFIG_TMP" || fail "could not update shell config"
-  mv "$_SHELL_CONFIG_TMP" "$CONFIG_FILE"
+  # mktemp creates 0600; keep the mode the config already had (0644 for a new one).
+  chmod --reference="$target" "$_SHELL_CONFIG_TMP" 2>/dev/null || chmod 644 "$_SHELL_CONFIG_TMP"
+  mv -- "$_SHELL_CONFIG_TMP" "$target"
   _SHELL_CONFIG_TMP=""
   refresh_shell_config
 }

--- a/test/shell.d/shell-config-test.sh
+++ b/test/shell.d/shell-config-test.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command jq
+
+# omarchy-shell-config reads the shipped defaults from OMARCHY_PATH.
+export OMARCHY_PATH="$ROOT"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/bin" "$tmp/home/.config/omarchy" "$tmp/dotfiles"
+
+# Every commit refreshes the running shell; stand in for it.
+printf '#!/bin/bash\nexit 0\n' >"$tmp/bin/omarchy-shell"
+chmod +x "$tmp/bin/omarchy-shell"
+
+config="$tmp/home/.config/omarchy/shell.json"
+tracked="$tmp/dotfiles/shell.json"
+
+bar() {
+  HOME="$tmp/home" PATH="$tmp/bin:$ROOT/bin:$PATH" "$ROOT/bin/omarchy-bar" "$@"
+}
+
+install -m 644 "$ROOT/config/omarchy/shell.json" "$config"
+bar position bottom >/dev/null
+jq -e '.bar.position == "bottom"' "$config" >/dev/null || fail "position updates a plain config"
+[[ $(stat -c %a "$config") == 644 ]] || fail "position keeps a plain config's mode" "$(stat -c %a "$config")"
+pass "position keeps a plain config's mode"
+
+rm -f "$config"
+install -m 644 "$ROOT/config/omarchy/shell.json" "$tracked"
+ln -s "$tracked" "$config"
+bar position left >/dev/null
+[[ -L $config ]] || fail "position keeps a symlinked config a symlink"
+jq -e '.bar.position == "left"' "$tracked" >/dev/null || fail "position writes through to the tracked file"
+[[ $(stat -c %a "$tracked") == 644 ]] || fail "position keeps the tracked file's mode" "$(stat -c %a "$tracked")"
+pass "position writes through a dotfiles symlink"
+
+[[ -z $(find "$tmp/dotfiles" -name '.shell.json.*') ]] || fail "no staging file is left beside the tracked file"
+pass "no staging file is left beside the tracked file"
+
+printf 'not json\n' >"$tracked"
+! bar position top >/dev/null 2>&1 || fail "a broken config fails the update"
+[[ $(cat "$tracked") == "not json" && -L $config ]] || fail "a failed update leaves the config alone"
+[[ -z $(find "$tmp/dotfiles" -name '.shell.json.*') ]] || fail "a failed update removes its staging file"
+pass "a failed update leaves the config alone"
+
+rm -f "$config" "$tracked"
+ln -s "$tracked" "$config"
+bar position top >/dev/null
+[[ -L $config && -f $tracked ]] || fail "position fills in a dangling symlink's target"
+jq -e '.bar.position == "top"' "$tracked" >/dev/null || fail "position seeds a dangling target from the defaults"
+pass "position fills in a dangling symlink's target"


### PR DESCRIPTION
I keep `~/.config/omarchy/shell.json` symlinked into my dotfiles repo, which the manual recommends (Stow). After `omarchy refresh shell` the widgets I had re-added in the repo never showed up: the link had been silently replaced by a detached 0600 copy.

The cause is `commit()` in `omarchy-shell-config`, which stages the new JSON in /tmp and `mv`s it over the config path. `mv` onto a symlink replaces the link itself. This is reached by `omarchy bar defaults|position|transparent`, `omarchy refresh shell`, and the Quattro upgrader. Every other writer already preserves links: the shell's FileView goes through QSaveFile, and #9372 fixes the migrations. This was the last one.

## Fix

`commit()` now resolves the path with `readlink -m`, stages beside the resolved target, copies the existing mode onto the staging file, and renames onto the target. I kept the rename rather than switching to the write-through `cat` used in #9372 because the shell watches this file and reacts to a partial one (#7100). Staging next to the target also makes the rename a real one; /tmp is usually a different filesystem, so the old "atomic" mv was a copy.

Behavior changes beyond the link surviving:

- The file keeps its mode instead of becoming 0600 (#9326). A new config is 0644.
- A dangling link gets its target created and stays a link, matching #10710's upgrade test.
- The staging file briefly lives beside the target as `.shell.json.XXXXXX` instead of in /tmp; the existing EXIT trap still removes it on failure.

Subsumes #9858, which keeps the `mv` and so still breaks the link.

`test/shell.d/shell-config-test.sh` covers the plain, symlinked, dangling, and failed-write cases, and fails on the symlink assertion without the fix.