### PR TITLE
Keep the powerprofilesctl shebang fix applied across daemon upgrades (#11031)

### DIFF
--- a/default/libalpm/hooks/70-omarchy-powerprofilesctl-shebang.hook
+++ b/default/libalpm/hooks/70-omarchy-powerprofilesctl-shebang.hook
@@ -1,0 +1,10 @@
+[Trigger]
+Operation = Install
+Operation = Upgrade
+Type = Package
+Target = power-profiles-daemon
+
+[Action]
+Description = Re-applying the powerprofilesctl system python3 shebang...
+When = PostTransaction
+Exec = /bin/bash /usr/share/omarchy/install/config/fix-powerprofilesctl-shebang.sh

--- a/docs/file-layout.md
+++ b/docs/file-layout.md
@@ -309,8 +309,7 @@ the legacy finalization marker from `~/.local/state/omarchy/` into `done/`.
 `omarchy-apply-system` (root, in chroot) runs target-side setup at ISO
 finalization. It sources:
 
-- `install/config/all.sh` — theme links, lockout limits, lockscreen PAM,
-  powerprofilesctl shebang fix, SSH command path and keepalive, docker setup,
+- `install/config/all.sh` — theme links, lockout limits, lockscreen PAM, powerprofilesctl shebang fix (kept durable across `power-profiles-daemon` upgrades by the omarchy libalpm hook that Execs the same script), SSH command path and keepalive, docker setup,
   Snapper retention, locate index tuning, service enablement, firewall.
 - `install/hardware/all.sh` via `omarchy-apply-hardware` — vendor- and
   device-specific kernel modules, udev rules, microcode, wireless regdom,

--- a/docs/update-process.md
+++ b/docs/update-process.md
@@ -95,8 +95,16 @@ the guard with:
 sudo env OMARCHY_ALLOW_DIRECT_PACMAN=1 pacman -Syu
 ```
 
-The guard does not start `omarchy update` itself because pacman is already in a
-transaction setup path; it only aborts with instructions.
+The guard does not start `omarchy update` itself because pacman is already in a transaction setup path; it only aborts with instructions.
+
+The `omarchy` package also installs an ALPM post-transaction hook that re-applies the `powerprofilesctl` system python3 shebang fix after every `power-profiles-daemon` install or upgrade:
+
+```text
+/usr/share/libalpm/hooks/70-omarchy-powerprofilesctl-shebang.hook
+/usr/share/omarchy/install/config/fix-powerprofilesctl-shebang.sh
+```
+
+The daemon package owns `/usr/bin/powerprofilesctl`, and its upgrades restore the packaged `#!/usr/bin/env python3` shebang. Leaving that shebang in place breaks the CLI wherever `mise` supplies `python3` without PyGObject on `PATH`.
 
 The `omarchy` package also installs ALPM hooks for `omarchy-settings` /
 `omarchy-settings-dev` installs and upgrades. The pre-transaction hook runs

--- a/install/config/fix-powerprofilesctl-shebang.sh
+++ b/install/config/fix-powerprofilesctl-shebang.sh
@@ -1,4 +1,14 @@
-# Ensure we use system python3 and not mise's python3
-if [[ -f /usr/bin/powerprofilesctl ]]; then
-  sudo sed -i '/env python3/ c\#!/bin/python3' /usr/bin/powerprofilesctl
+# Ensure we use system python3 and not mise's python3 in powerprofilesctl.
+# Runs at install, and again from the omarchy libalpm hook after every
+# power-profiles-daemon install or upgrade, since the upgrade restores the
+# packaged #!/usr/bin/env python3 shebang. The migration that repairs installs
+# whose upgrade already reverted the fix sources this script too. Skipping an
+# already-fixed client keeps re-runs from reaching for privileges.
+target=${OMARCHY_POWERPROFILESCTL_PATH:-/usr/bin/powerprofilesctl}
+if [[ -f $target && $(head -n1 "$target") == "#!/usr/bin/env python3" ]]; then
+  if (( EUID == 0 )); then
+    sed -i '1c\#!/bin/python3' "$target"
+  else
+    sudo sed -i '1c\#!/bin/python3' "$target"
+  fi
 fi

--- a/migrations/1789023127.sh
+++ b/migrations/1789023127.sh
@@ -1,0 +1,11 @@
+echo "Re-apply powerprofilesctl shebang fix reverted by daemon upgrades"
+
+# The install-time rewrite of /usr/bin/powerprofilesctl to #!/bin/python3 ran
+# once, and every power-profiles-daemon upgrade since restored the packaged
+# #!/usr/bin/env python3 shebang. On a PATH where mise's python3 shadows the
+# system one, the CLI then dies with ImportError inside Omarchy's power
+# profile callers. The libalpm hook shipped alongside this migration
+# maintains the fix from now on; this repairs installs that already lost it.
+# The packaged script only elevates when the packaged shebang is actually
+# present, so a second user on the machine re-runs it without a prompt.
+source "$OMARCHY_PATH/install/config/fix-powerprofilesctl-shebang.sh"

--- a/test/shell.d/agent-usage-claude-limits-test.sh
+++ b/test/shell.d/agent-usage-claude-limits-test.sh
@@ -10,7 +10,11 @@ require_command python3
 # stands in for the response.
 read_limits() {
   COLLECTOR="$ROOT/bin/omarchy-agent-usage-claude" PAYLOAD="$1" python3 - <<'PY'
-import importlib.machinery, importlib.util, io, json, os
+import importlib.machinery, importlib.util, io, json, os, sys
+
+# Keep the load from dropping a bytecode cache beside the collector: a stray
+# bin/__pycache__ is tracked nowhere and breaks text scans over bin/.
+sys.dont_write_bytecode = True
 
 loader = importlib.machinery.SourceFileLoader("collector", os.environ["COLLECTOR"])
 spec = importlib.util.spec_from_loader(loader.name, loader)
@@ -82,7 +86,11 @@ trap 'rm -rf "$CACHE_HOME"' EXIT
 collect_limits() {
   COLLECTOR="$ROOT/bin/omarchy-agent-usage-claude" TOKEN="$1" EXPIRES_AT="$2" CACHED="$3" \
     XDG_CACHE_HOME="$CACHE_HOME" python3 - <<'PY'
-import importlib.machinery, importlib.util, json, os, pathlib
+import importlib.machinery, importlib.util, json, os, pathlib, sys
+
+# Keep the load from dropping a bytecode cache beside the collector: a stray
+# bin/__pycache__ is tracked nowhere and breaks text scans over bin/.
+sys.dont_write_bytecode = True
 
 loader = importlib.machinery.SourceFileLoader("collector", os.environ["COLLECTOR"])
 spec = importlib.util.spec_from_loader(loader.name, loader)
@@ -160,7 +168,11 @@ pass "Claude collector falls back to cache when the probe cannot connect"
 probe_with_cache() {
   COLLECTOR="$ROOT/bin/omarchy-agent-usage-claude" FORCE="$1" CACHED="$2" PAYLOAD="$3" \
     XDG_CACHE_HOME="$CACHE_HOME" python3 - <<'PY'
-import importlib.machinery, importlib.util, io, json, os
+import importlib.machinery, importlib.util, io, json, os, sys
+
+# Keep the load from dropping a bytecode cache beside the collector: a stray
+# bin/__pycache__ is tracked nowhere and breaks text scans over bin/.
+sys.dont_write_bytecode = True
 
 loader = importlib.machinery.SourceFileLoader("collector", os.environ["COLLECTOR"])
 spec = importlib.util.spec_from_loader(loader.name, loader)

--- a/test/shell.d/agent-usage-claude-scanner-test.sh
+++ b/test/shell.d/agent-usage-claude-scanner-test.sh
@@ -138,7 +138,10 @@ import threading
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
 
-# The collector has no .py suffix, so name its loader explicitly.
+# The collector has no .py suffix, so name its loader explicitly. Keep the load
+# from dropping a bytecode cache beside the collector: a stray bin/__pycache__
+# is tracked nowhere and breaks text scans over bin/.
+sys.dont_write_bytecode = True
 spec = importlib.util.spec_from_loader("collector", SourceFileLoader("collector", sys.argv[1]))
 collector = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(collector)

--- a/test/shell.d/agent-usage-fireworks-scanner-test.sh
+++ b/test/shell.d/agent-usage-fireworks-scanner-test.sh
@@ -56,6 +56,9 @@ os.environ["TZ"] = "UTC"
 time.tzset()
 os.environ.pop("FIREWORKS_ACCOUNT_ID", None)
 
+# Keep the load from dropping a bytecode cache beside the collector: a stray
+# bin/__pycache__ is tracked nowhere and breaks text scans over bin/.
+sys.dont_write_bytecode = True
 loader = importlib.machinery.SourceFileLoader("fireworks_collector", collector_path)
 spec = importlib.util.spec_from_loader(loader.name, loader)
 scanner = importlib.util.module_from_spec(spec)

--- a/test/shell.d/locate-test.sh
+++ b/test/shell.d/locate-test.sh
@@ -36,8 +36,15 @@ check(not (root / "install/config/locate.sh").exists() and not (root / "migratio
       "the retired locate configuration helper and migration are absent")
 for directory in ("bin", "install", "migrations"):
   for path in (root / directory).rglob("*"):
-    if path.is_file():
+    # Bytecode caches and other non-UTF-8 files carry no scripts; reading them
+    # is pointless, and a stray __pycache__ from a module-loading test would
+    # break the scan entirely.
+    if not path.is_file() or "__pycache__" in path.parts:
+      continue
+    try:
       content = path.read_text()
+    except UnicodeDecodeError:
+      continue
       if "OMARCHY_UPDATEDB_CONF_PATH" in content or "config/locate.sh" in content:
         raise SystemExit("not ok - retired locate configuration path remains in " + str(path))
 check(True, "runtime and installation no longer reference the configuration rewrite")

--- a/test/shell.d/powerprofiles-shebang-hook-test.sh
+++ b/test/shell.d/powerprofiles-shebang-hook-test.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+hook="$ROOT/default/libalpm/hooks/70-omarchy-powerprofilesctl-shebang.hook"
+fix_script="$ROOT/install/config/fix-powerprofilesctl-shebang.sh"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+stub_dir="$tmp_dir/stub"
+mkdir -p "$stub_dir"
+
+# The script elevates with sudo only as a non-root caller, as the migration
+# path does. The stub records the call and performs the edit for real so the
+# transformation itself is exercised end to end.
+export TEST_LOG="$stub_dir/sudo.log"
+cat >"$stub_dir/sudo" <<'STUB'
+#!/bin/bash
+printf 'sudo %s\n' "$*" >>"$TEST_LOG"
+shift
+exec /usr/bin/sed "$@"
+STUB
+chmod +x "$stub_dir/sudo"
+
+run_fix() {
+  OMARCHY_POWERPROFILESCTL_PATH="$1" PATH="$stub_dir:$PATH" \
+    bash -eE -c 'source "$1"' bash "$fix_script"
+}
+
+write_target() {
+  printf '%s\n' "$1" >"$tmp_dir/powerprofilesctl"
+  chmod 755 "$tmp_dir/powerprofilesctl"
+}
+
+# A packaged shebang is rewritten to the system python3 interpreter.
+write_target '#!/usr/bin/env python3'
+: >"$TEST_LOG"
+run_fix "$tmp_dir/powerprofilesctl"
+[[ $(head -n1 "$tmp_dir/powerprofilesctl") == "#!/bin/python3" ]] ||
+  fail "packaged shebang is rewritten" "actual: $(head -n1 "$tmp_dir/powerprofilesctl")"
+pass "packaged shebang is rewritten"
+(( $(wc -l <"$TEST_LOG") == 1 )) ||
+  fail "non-root fix elevates exactly once" "log: $(cat "$TEST_LOG")"
+pass "non-root fix elevates exactly once"
+
+# An already-fixed file is left alone, so re-runs and second users do not
+# reach for privileges at all.
+: >"$TEST_LOG"
+run_fix "$tmp_dir/powerprofilesctl"
+[[ $(head -n1 "$tmp_dir/powerprofilesctl") == "#!/bin/python3" ]] ||
+  fail "already-fixed shebang is preserved"
+[[ ! -s $TEST_LOG ]] ||
+  fail "already-fixed shebang skips elevation" "log: $(cat "$TEST_LOG")"
+pass "already-fixed shebang skips elevation"
+
+# A shebang that never resolved python through env is not ours to touch.
+write_target '#!/bin/sh'
+: >"$TEST_LOG"
+run_fix "$tmp_dir/powerprofilesctl"
+[[ $(head -n1 "$tmp_dir/powerprofilesctl") == "#!/bin/sh" ]] ||
+  fail "foreign shebang is preserved"
+[[ ! -s $TEST_LOG ]] ||
+  fail "foreign shebang skips elevation" "log: $(cat "$TEST_LOG")"
+pass "foreign shebang skips elevation"
+
+# An absent client is a no-op, not an error, so the hook stays quiet on
+# systems that never had the package.
+: >"$TEST_LOG"
+run_fix "$tmp_dir/absent"
+[[ ! -s $TEST_LOG ]] ||
+  fail "absent client skips elevation" "log: $(cat "$TEST_LOG")"
+pass "absent client skips elevation"
+
+# The hook re-applies the fix whenever the daemon package is installed or
+# upgraded, and never aborts a package transaction over its failure.
+[[ -f $hook ]] || fail "libalpm hook ships in default/libalpm/hooks"
+grep -Fq 'Operation = Install' "$hook" &&
+  grep -Fq 'Operation = Upgrade' "$hook" ||
+  fail "hook triggers on daemon install and upgrade"
+grep -Fq 'Type = Package' "$hook" || fail "hook trigger is package-typed"
+grep -Fq 'Target = power-profiles-daemon' "$hook" ||
+  fail "hook targets power-profiles-daemon"
+grep -Fq 'When = PostTransaction' "$hook" || fail "hook runs post-transaction"
+grep -Fq 'Exec = /bin/bash /usr/share/omarchy/install/config/fix-powerprofilesctl-shebang.sh' "$hook" ||
+  fail "hook execs the packaged fix script"
+! grep -Fq 'AbortOnFail' "$hook" ||
+  fail "hook failure does not abort the transaction"
+pass "libalpm hook re-applies the fix on daemon install and upgrade"
+
+# Install still wires the script in as the initial application.
+grep -Fq 'config/fix-powerprofilesctl-shebang.sh' "$ROOT/install/config/all.sh" ||
+  fail "install wires the fix into install/config/all.sh"
+pass "install wires the fix into install/config/all.sh"
+
+# One migration repairs installs whose upgrade already reverted the fix, by
+# sourcing the packaged script whose own guard keeps the elevation away from
+# machines and users that are already fixed.
+mapfile -t referencing_migrations < <(grep -lF 'fix-powerprofilesctl-shebang' "$ROOT"/migrations/*.sh || true)
+(( ${#referencing_migrations[@]} == 1 )) ||
+  fail "exactly one migration references the fix script" \
+    "found: ${referencing_migrations[*]:-none}"
+migration=${referencing_migrations[0]}
+grep -Fq 'source "$OMARCHY_PATH/install/config/fix-powerprofilesctl-shebang.sh"' "$migration" ||
+  fail "migration sources the packaged fix script"
+pass "migration repairs already-reverted installs"


### PR DESCRIPTION
Fixes omacom/omarchy#11031.

## Problem

`install/config/fix-powerprofilesctl-shebang.sh` rewrote `/usr/bin/powerprofilesctl`'s shebang to `#!/bin/python3` exactly once at install time. Every `power-profiles-daemon` upgrade restored the packaged `#!/usr/bin/env python3` and silently undid the fix. On a PATH where `mise` supplies `python3`, the CLI then dies with `ImportError` inside Omarchy's power profile callers (`omarchy-powerprofiles-set`, `omarchy-powerprofiles-list`, the Quickshell menu and battery service).

## Fix

- `default/libalpm/hooks/70-omarchy-powerprofilesctl-shebang.hook` — a new ALPM post-transaction hook firing on Install/Upgrade of `power-profiles-daemon` (no `AbortOnFail`), Execs the packaged fix script. The fix is durable from this point forward.
- `install/config/fix-powerprofilesctl-shebang.sh` — still the single source of truth; now guards on the exact packaged shebang so an already-fixed client costs nothing and needs no elevation, and uses `sudo` only when not already root.
- `migrations/1789023127.sh` — repairs installs whose upgrade already reverted the fix (the hook alone only helps future upgrades). Idempotent: a second user re-runs it without a prompt once the machine is fixed.

Companion PR: omacom/omarchy-pkgs ships the new hook file in the `omarchy` and `omarchy-dev` PKGBUILDs (`config-test.sh` asserts that pairing once the `omarchy-pkgs` checkout resolves).

## Tests

- New `test/shell.d/powerprofiles-shebang-hook-test.sh` (8 ok): hook trigger/shape per `pacman-hooks(5)`, rewrite, idempotency, foreign shebang preserved, missing file tolerated, elevation stubbed end-to-end.
- Also cleans up a broken-environment test flake: `agent-usage-*` collector loaders stopped writing `bin/__pycache__`, and `locate-test.sh` tolerates such caches when scanning `bin`/`install`/`migrations` (separate commit, same PR).
- `./test/shell` → 237/237, `./test/cli` → 112/112.
