### PR TITLE
Show longer sibling routes in prefixed command help

### DIFF
--- a/bin/omarchy
+++ b/bin/omarchy
@@ -843,15 +843,24 @@ show_prefix_help() {
 show_related_commands() {
   local key="$1"
   local group="${COMMAND_GROUP[$key]}"
+  local route_prefix="${COMMAND_ROUTE[$key]} "
   local child_key=""
   local rows=""
 
-  [[ -z ${COMMAND_NAME[$key]} ]] || return
-
-  while IFS= read -r child_key; do
-    [[ -n $child_key && $child_key != "$key" ]] || continue
-    rows+="$(command_usage_for_group "$child_key" "$group")"$'\t'$'\t'"${COMMAND_SUMMARY[$child_key]}"$'\n'
-  done < <(sorted_group_keys "$group" false)
+  if [[ -n ${COMMAND_NAME[$key]} ]]; then
+    # A named command lists only siblings extending its own route.
+    while IFS= read -r child_key; do
+      [[ $child_key != "$key" ]] || continue
+      if [[ ${COMMAND_ROUTE[$child_key]} == "$route_prefix"* ]]; then
+        rows+="${COMMAND_USAGE[$child_key]}"$'\t'$'\t'"${COMMAND_SUMMARY[$child_key]}"$'\n'
+      fi
+    done < <(sorted_keys false)
+  else
+    while IFS= read -r child_key; do
+      [[ $child_key != "$key" ]] || continue
+      rows+="$(command_usage_for_group "$child_key" "$group")"$'\t'$'\t'"${COMMAND_SUMMARY[$child_key]}"$'\n'
+    done < <(sorted_group_keys "$group" false)
+  fi
 
   if [[ -n $rows ]]; then
     echo ""
@@ -962,9 +971,8 @@ dispatch_fast_or_help() {
         return 127
       fi
 
-      if (( DIRECT_RESOLVED_COUNT == 1 )); then
-        load_child_commands_by_binary "$DIRECT_RESOLVED_BINARY"
-      fi
+      # The help below lists this binary's longer siblings in Related commands.
+      load_child_commands_by_binary "$DIRECT_RESOLVED_BINARY"
 
       key="${BINARY_TO_KEY[$DIRECT_RESOLVED_BINARY]}"
       if remaining_has_json_flag "${remaining[@]}"; then
@@ -984,6 +992,7 @@ dispatch_fast_or_help() {
           load_group_commands "$1"
           show_group_help "$1"
         else
+          load_child_commands_by_binary "$DIRECT_RESOLVED_BINARY"
           show_command_help "$key"
         fi
         return 0

--- a/docs/cli-router.md
+++ b/docs/cli-router.md
@@ -79,6 +79,13 @@ none were given, the router shows help instead of executing — `omarchy theme
 set` prints usage rather than running an interactive setter. A bare group name
 with child commands shows the group help.
 
+Command help ends with a "Related commands" section. A group-root command
+(its filename stem is one segment) lists its whole group. A named command lists
+only siblings whose route extends its own: `omarchy hyprland monitor internal
+--help` also prints `omarchy hyprland monitor internal mirror`. Hidden commands
+never appear there. On the fast path the router registers only the resolved
+binary's filename descendants rather than every group member.
+
 Dispatch is `exec`: the router process is replaced, the binary sees only the
 leftover arguments, and the exit code is the binary's own. The router itself
 exits 127 for unknown routes or missing binaries.

--- a/test/cli
+++ b/test/cli
@@ -661,6 +661,51 @@ assert_output_contains "partial metadata command dispatches" "$output" "partial-
 output=$("$TMPDIR/omarchy" body metadata test)
 assert_output_contains "body metadata command dispatches by filename" "$output" "body-metadata-ok"
 
+# A named command whose route other commands extend must reveal those longer
+# siblings in its own help (`monitor internal` vs `monitor internal mirror`),
+# both for an explicit --help and for a bare required-args invocation.
+{
+  printf '#!/bin/bash\n\n'
+  printf '# omarchy:summary=Prefixhelp internal laptop display\n'
+  printf '# omarchy:args=<on|off>\n'
+  printf 'echo internal-ok\n'
+} >"$TMPDIR/omarchy-prefixhelp-internal"
+chmod +x "$TMPDIR/omarchy-prefixhelp-internal"
+
+{
+  printf '#!/bin/bash\n\n'
+  printf '# omarchy:summary=Prefixhelp internal display mirroring\n'
+  printf '# omarchy:args=<on|off>\n'
+  printf 'echo mirror-ok\n'
+} >"$TMPDIR/omarchy-prefixhelp-internal-mirror"
+chmod +x "$TMPDIR/omarchy-prefixhelp-internal-mirror"
+
+{
+  printf '#!/bin/bash\n\n'
+  printf '# omarchy:summary=Prefixhelp unrelated command with no longer siblings\n'
+  printf '# omarchy:args=<x>\n'
+  printf 'echo unrelated-ok\n'
+} >"$TMPDIR/omarchy-prefixhelp-unrelated"
+chmod +x "$TMPDIR/omarchy-prefixhelp-unrelated"
+
+output=$("$TMPDIR/omarchy" prefixhelp internal --help)
+assert_output_contains "prefix-sibling help renders" "$output" "Related commands:"
+assert_output_contains "prefix-sibling help lists longer sibling route" "$output" "omarchy prefixhelp internal mirror"
+assert_output_contains "prefix-sibling help lists longer sibling summary" "$output" "Prefixhelp internal display mirroring"
+
+output=$("$TMPDIR/omarchy" prefixhelp internal)
+assert_output_contains "bare prefix command help renders" "$output" "omarchy prefixhelp internal mirror"
+if [[ $output == *"internal-ok"* ]]; then
+  fail "bare required-arg prefix command does not execute"
+fi
+pass "bare required-arg prefix command does not execute"
+
+output=$("$TMPDIR/omarchy" prefixhelp unrelated --help)
+if [[ $output == *"Related commands:"* ]]; then
+  fail "a named command without longer siblings omits related commands"
+fi
+pass "a named command without longer siblings omits related commands"
+
 # A trailing --help must render help even when the route only partially
 # resolves, leaving unresolved words ahead of the flag (e.g. `update aur --help`
 # used to start a real update because only the first leftover token was checked).


### PR DESCRIPTION
Fixes #11007

`omarchy hyprland monitor internal --help` (and any bare invocation of a
required-args command) now ends with a "Related commands" section listing
siblings whose route extends the command's own:

    Related commands:
      omarchy hyprland monitor internal mirror <on|off|toggle|recover>  Enable, disable, toggle, or recover mirroring the internal display to an external monitor

Previously the sibling was only visible at group level
(`omarchy hyprland --help`), so the shared `internal` prefix and identical
argument shape made `omarchy hyprland monitor internal toggle` easy to mistake
for a mirroring toggle.

## How it works

- `bin/omarchy` / `show_related_commands`: group-root commands keep their
  whole-group "Related commands" listing; named commands now fall through and
  list only siblings whose canonical route is a strict extension of their own
  route. Hidden commands stay hidden.
- `bin/omarchy` / `dispatch_fast_or_help`: when command help is rendered on
  the fast path, the router registers the resolved binary's filename
  descendants (`omarchy-hyprland-monitor-internal-*`) instead of only at group
  depth, so prefix siblings are known to the help renderer. This applies to
  both the `--help` branch and the bare required-args branch; plain dispatch
  still pays no metadata cost.
- `test/cli`: regressions cover the sibling listing via `--help`, via bare
  invocation, and the absence of the section when a command has no longer
  siblings.
- `docs/cli-router.md`: documents the related-commands behavior.

## Verification

- `./test/cli` passes.
- `omarchy commands --check` passes (452 commands).
- Group help, hidden-command suppression (`update perform`), and the `--json`
  help path are unchanged.
