### PR TITLE
Allow derived bars to provide a passive background component

### DIFF
--- a/shell/plugins/bar/Bar.qml
+++ b/shell/plugins/bar/Bar.qml
@@ -78,6 +78,9 @@ Item {
   property color barForeground: useTransparentForeground ? transparentForeground : themeForeground
   property bool foregroundAnimationEnabled: true
   property color background: Color.bar.background
+  // Optional passive background supplied by a derived bar. Null keeps the
+  // theme fill; transparent mode unloads the component on every monitor.
+  property Component backgroundComponent: null
   property color urgent: Color.bar.active
 
   Behavior on barForeground { enabled: root.foregroundAnimationEnabled; ColorAnimation { duration: 420; easing.type: Easing.InOutCubic } }
@@ -1263,10 +1266,24 @@ Item {
 
     implicitWidth: root.vertical ? root.barSize : 0
     implicitHeight: root.vertical ? 0 : root.barSize
-    color: root.transparent ? "transparent" : root.background
+    color: root.transparent || backgroundLoader.item ? "transparent" : root.background
     surfaceFormat.opaque: false
     WlrLayershell.namespace: "omarchy-bar"
     WlrLayershell.layer: WlrLayer.Top
+
+    Loader {
+      id: backgroundLoader
+      anchors.fill: parent
+      z: -1
+      enabled: false
+      active: !root.transparent && root.backgroundComponent !== null
+      sourceComponent: root.backgroundComponent
+
+      // Scalar rendering inputs, available through the created item's parent.
+      readonly property color backgroundColor: root.background
+      readonly property string barPosition: root.position
+      readonly property bool barVertical: root.vertical
+    }
 
     Loader {
       anchors.fill: parent

--- a/shell/plugins/bar/README.md
+++ b/shell/plugins/bar/README.md
@@ -178,3 +178,29 @@ declaring `kinds: ["bar-widget"]` and a `barWidget` entry point. See
 [../../README.md](../../README.md) for the manifest schema. Rescan, enable,
 and place third-party plugins with `omarchy-shell shell rescanPlugins`,
 `omarchy plugin enable`, and `omarchy bar move`.
+
+## Background components in derived bars
+
+A bar derived from `Bar.qml` can set `backgroundComponent` to a QML `Component` whose root is an `Item`. The component is instantiated separately for each monitor and sized to that monitor's bar. Its parent exposes `backgroundColor` (the live theme fill), `barPosition` (`top`, `bottom`, `left`, `right`) and `barVertical`. The item's own width and height track the bar; it should not impose a different size on its parent.
+
+Within an Omarchy shell that provides this hook, a replacement bar can inherit the stock type without copying its implementation:
+
+```qml
+import QtQuick
+import qs.plugins.bar as Stock
+
+Stock.Bar {
+  backgroundComponent: Component {
+    Rectangle {
+      id: fill
+      gradient: Gradient {
+        orientation: fill.parent.barVertical ? Gradient.Vertical : Gradient.Horizontal
+        GradientStop { position: 0; color: fill.parent.backgroundColor }
+        GradientStop { position: 1; color: "#253653" }
+      }
+    }
+  }
+}
+```
+
+Use an explicit id for the background item when binding from nested objects (for example, `id: fill` and `fill.parent.backgroundColor`). The loader sits behind widgets and is disabled for input, so backgrounds cannot intercept bar clicks. Full transparency unloads the component. Setting `backgroundComponent` back to `null`, or a component that fails to create, restores the theme fill. A successfully created transparent item intentionally replaces the fill with transparency. This hook only paints inside the bar window; it does not add space for external shadows, style popup controls.

--- a/test/shell.d/bar-background-test.sh
+++ b/test/shell.d/bar-background-test.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -euo pipefail
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+require_command python3
+[[ -x /usr/lib/qt6/bin/qmltestrunner ]] || fail "Qt 6 qmltestrunner is available"
+background_test_dir=$(mktemp -d)
+trap 'rm -rf "$background_test_dir"' EXIT
+# Exercise the actual loader and fallback expression, without launching a
+# second desktop shell or depending on monitors/services unrelated to paint.
+python3 - "$ROOT" "$background_test_dir" <<'PY'
+from pathlib import Path
+import sys
+root, target = map(Path, sys.argv[1:])
+source = (root / "shell/plugins/bar/Bar.qml").read_text()
+start = source.rfind("    Loader {", 0, source.index("id: backgroundLoader"))
+end, depth = source.index("{", start) + 1, 1
+while depth:
+    depth += (source[end] == "{") - (source[end] == "}")
+    end += 1
+loader = source[start:end]
+color = next(line.strip() for line in source.splitlines() if "color: root.transparent || backgroundLoader.item" in line)
+(target / "BackgroundHarness.qml").write_text('''import QtQuick
+Rectangle {
+  id: root
+  property color background: "#223344"
+  property bool transparent: false
+  property string position: "top"
+  property bool vertical: false
+  property Component backgroundComponent: null
+  property alias painted: backgroundLoader.item
+''' + color + "\n" + loader + "\n}\n")
+PY
+cp "$SHELL_TEST_DIR/fixtures/bar-background/tst_background.qml" "$background_test_dir/"
+QT_QPA_PLATFORM=offscreen QT_QPA_PLATFORMTHEME=generic QT_QUICK_BACKEND=software /usr/lib/qt6/bin/qmltestrunner -input "$background_test_dir"
+pass "bar backgrounds follow geometry/theme, ignore input and restore on removal/transparency"

--- a/test/shell.d/fixtures/bar-background/tst_background.qml
+++ b/test/shell.d/fixtures/bar-background/tst_background.qml
@@ -1,0 +1,63 @@
+import QtQuick
+import QtTest
+
+TestCase {
+  name: "BarBackground"
+  when: windowShown
+  width: 400
+  height: 100
+
+  Component {
+    id: material
+    Rectangle {
+      property color themeColor: parent.backgroundColor
+      property string position: parent.barPosition
+      property bool vertical: parent.barVertical
+      color: themeColor
+    }
+  }
+
+  BackgroundHarness { id: first; width: 300; height: 30 }
+  BackgroundHarness { id: second; width: 30; height: 100; position: "left"; vertical: true }
+
+  function cleanup() {
+    first.backgroundComponent = null
+    second.backgroundComponent = null
+    first.transparent = false
+  }
+
+  function test_defaultAndRemoval() {
+    compare(first.color, first.background)
+    compare(first.painted, null)
+    first.backgroundComponent = material
+    verify(first.painted !== null)
+    compare(first.color, "#00000000")
+    first.backgroundComponent = null
+    compare(first.painted, null)
+    compare(first.color, first.background)
+  }
+
+  function test_inputsAndIndependentInstances() {
+    first.backgroundComponent = material
+    second.backgroundComponent = material
+    verify(first.painted !== second.painted)
+    compare(first.painted.width, 300)
+    compare(second.painted.width, 30)
+    compare(second.painted.position, "left")
+    compare(second.painted.vertical, true)
+    first.background = "#123456"
+    compare(first.painted.themeColor, "#123456")
+    first.width = 250
+    compare(first.painted.width, 250)
+    verify(!first.painted.enabled)
+  }
+
+  function test_transparencyUnloads() {
+    first.backgroundComponent = material
+    first.transparent = true
+    compare(first.painted, null)
+    compare(first.color, "#00000000")
+    first.transparent = false
+    verify(first.painted !== null)
+  }
+}


### PR DESCRIPTION
Derived bar plugins currently need to duplicate Bar.qml to change how its background is painted. Add an optional `backgroundComponent` so they can inherit the stock bar's widgets, layout, input handling and multi-monitor behavior while supplying their own passive background.

Each monitor gets its own disabled Loader beneath the widgets, with the bar's background color, position and orientation exposed as context properties. Null keeps the existing theme fill, and transparent mode unloads the custom background. No appearance change for existing bars. Includes a usage example and focused QML tests.

Validation:
- Existing bar tests and new Qt 6 background tests pass (default/removal, geometry/theme/orientation, independent instances, disabled input and transparency).
- Verified the modified Bar.qml through a derived plugin in the running desktop shell: gradient background, transparency, and return to the default fill. The local shell predates this branch, so the current PluginBarApi was included in the temporary test plugin.
- Ran `./test/all`: six shell test files fail on this machine (`config`, `launch-about`, `locate`, `network-qr`, `snapper`, `unowned-system-paths`). Re-ran each against the unmodified base and reproduced all six failures; some require the separate packaging checkout. Relevant bar tests pass.

### Visual verification

Actual desktop captures of the same derived bar with the stock clock, on an empty workspace. Cropped to the bar and wallpaper immediately below it.

Custom gradient supplied through `backgroundComponent`

![Custom gradient supplied through backgroundComponent](https://raw.githubusercontent.com/adamritter/omarchy-surface-studio/6d6884a8f54b524039e3d1ce999219a6a6bb508a/docs/screenshots/upstream-custom-background.png)

Transparent mode: custom background unloaded

![Transparent mode: custom background unloaded](https://raw.githubusercontent.com/adamritter/omarchy-surface-studio/6d6884a8f54b524039e3d1ce999219a6a6bb508a/docs/screenshots/upstream-transparent.png)

Component removed: stock theme fill restored

![Component removed: stock theme fill restored](https://raw.githubusercontent.com/adamritter/omarchy-surface-studio/6d6884a8f54b524039e3d1ce999219a6a6bb508a/docs/screenshots/upstream-default.png)

