### PR TITLE
fix(update): default OMARCHY_PATH under sudo nounset

### DIFF
--- a/bin/omarchy-update-dev
+++ b/bin/omarchy-update-dev
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 
-[[ $OMARCHY_PATH != "/usr/share/omarchy" ]] || exit 0
+[[ ${OMARCHY_PATH:-/usr/share/omarchy} != "/usr/share/omarchy" ]] || exit 0
 
 if ! git -C "$OMARCHY_PATH" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   echo "Error: OMARCHY_PATH is not a git checkout: $OMARCHY_PATH" >&2

--- a/test/shell.d/update-dev-test.sh
+++ b/test/shell.d/update-dev-test.sh
@@ -58,6 +58,20 @@ run_dev_update /usr/share/omarchy
 [[ ! -s $git_log ]] || fail "package-backed updates do not invoke git" "$(cat "$git_log")"
 pass "package-backed updates skip the dev checkout step"
 
+# Mimic `sudo` wiping the environment: OMARCHY_PATH must not unbound-error under set -u.
+: >"$git_log"
+if ! env -u OMARCHY_PATH \
+  TEST_GIT_LOG="$git_log" \
+  PATH="$stub_bin:$PATH" \
+  "$ROOT/bin/omarchy-update-dev" >"$test_tmp/unset.out" 2>"$test_tmp/unset.err"; then
+  fail "unset OMARCHY_PATH exits cleanly (sudo-like)" "$(cat "$test_tmp/unset.err")"
+fi
+if grep -Fq "OMARCHY_PATH: unbound variable" "$test_tmp/unset.err"; then
+  fail "unset OMARCHY_PATH does not trip nounset" "$(cat "$test_tmp/unset.err")"
+fi
+[[ ! -s $git_log ]] || fail "unset OMARCHY_PATH does not invoke git" "$(cat "$git_log")"
+pass "unset OMARCHY_PATH (sudo-like) skips without unbound-variable"
+
 : >"$git_log"
 run_dev_update "$checkout"
 grep -Fx -- "-C $checkout pull --ff-only" "$git_log" >/dev/null ||


### PR DESCRIPTION
## Summary
- `omarchy-update-dev` uses `set -u` and reads `$OMARCHY_PATH` before any default.
- Under `sudo omarchy update`, that env var is wiped, so the script dies with `OMARCHY_PATH: unbound variable`.
- Default unset/empty to `/usr/share/omarchy` so packaged installs still take the early-exit path.

Fixes #11065

## Test plan
- [ ] `env -u OMARCHY_PATH bash -c 'set -u; [[ ${OMARCHY_PATH:-/usr/share/omarchy} != /usr/share/omarchy ]] || echo early_exit'` → early_exit
- [ ] With `OMARCHY_PATH` unset, running the script (or the guard line under `set -u`) no longer unbound-errors
- [ ] With `OMARCHY_PATH` pointing at a real git checkout that has upstream, update still pulls as before