### PR TITLE
Label a Claude Team seat by its subscription, not its rate-limit tier

### DIFF
--- a/bin/omarchy-agent-usage-claude
+++ b/bin/omarchy-agent-usage-claude
@@ -593,14 +593,16 @@ def oauth_login(claude_dir: Path) -> tuple[str, int, str]:
   return str(login.get("accessToken") or ""), number(login.get("expiresAt")), plan
 
 
+# The rate-limit tier names the ceiling, not the plan: a Team premium seat
+# runs on `default_claude_max_5x` while paying for Team. Lead with the
+# subscription and keep the multiplier as its qualifier, so Max still reads
+# "Max 5x" and a Team seat reads "Team 5x" rather than passing as Max.
 def plan_label(tier: str, subscription: str) -> str:
-  if tier:
-    match = re.search(r"max_(\d+x)", tier, re.IGNORECASE)
-    if match:
-      return "Max " + match.group(1)
-  if subscription:
-    return subscription[0].upper() + subscription[1:]
-  return ""
+  plan = subscription[0].upper() + subscription[1:] if subscription else ""
+  match = re.search(r"max_(\d+x)", tier, re.IGNORECASE) if tier else None
+  if not match:
+    return plan
+  return (plan or "Max") + " " + match.group(1)
 
 
 def parse_utilization(value: Any) -> float:

--- a/test/shell.d/agent-usage-claude-limits-test.sh
+++ b/test/shell.d/agent-usage-claude-limits-test.sh
@@ -72,6 +72,41 @@ for payload in '{"five_hour":{"utilization":78.0},"limits":[{"kind":"session","p
 done
 pass "Claude collector adds no limit when the payload scopes none"
 
+# The saved login carries two plan facts: the subscription and the rate-limit
+# tier it runs under. Read the label off a planted credential store so the
+# whole path is exercised, not just the formatter.
+plan_label() {
+  COLLECTOR="$ROOT/bin/omarchy-agent-usage-claude" TIER="$1" SUBSCRIPTION="$2" python3 - <<'PY'
+import importlib.machinery, importlib.util, json, os, pathlib, tempfile
+
+loader = importlib.machinery.SourceFileLoader("collector", os.environ["COLLECTOR"])
+spec = importlib.util.spec_from_loader(loader.name, loader)
+collector = importlib.util.module_from_spec(spec)
+loader.exec_module(collector)
+
+claude_dir = pathlib.Path(tempfile.mkdtemp())
+(claude_dir / ".credentials.json").write_text(json.dumps({"claudeAiOauth": {
+  "accessToken": "token", "expiresAt": 1,
+  "rateLimitTier": os.environ["TIER"], "subscriptionType": os.environ["SUBSCRIPTION"],
+}}), encoding="utf-8")
+print(collector.oauth_login(claude_dir)[2])
+PY
+}
+
+# A Team premium seat runs on the Max 5x rate-limit tier, and the tier alone
+# used to label it "Max 5x" — the plan the seat is not on.
+[[ $(plan_label default_claude_max_5x team) == "Team 5x" ]] ||
+  fail "Claude collector labels a Team seat by its subscription, not its rate-limit tier" "$(plan_label default_claude_max_5x team)"
+pass "Claude collector labels a Team seat by its subscription, not its rate-limit tier"
+
+# Max keeps its multiplier, with or without a subscription type alongside the
+# tier, and a plan whose tier names no multiplier is just the plan.
+[[ $(plan_label default_claude_max_20x max) == "Max 20x" && $(plan_label default_claude_max_5x "") == "Max 5x" ]] ||
+  fail "Claude collector still labels Max by its multiplier" "$(plan_label default_claude_max_20x max) / $(plan_label default_claude_max_5x "")"
+[[ $(plan_label default_claude_pro pro) == "Pro" && $(plan_label "" team) == "Team" ]] ||
+  fail "Claude collector labels a plan without a multiplier by its subscription alone" "$(plan_label default_claude_pro pro) / $(plan_label "" team)"
+pass "Claude collector keeps Max multipliers and plain plan names"
+
 # Only the Claude Code CLI refreshes the saved token, so between its runs the
 # collector can find a lapsed one. Drive collect_limits over a planted cache
 # with the network unreachable, so nothing but the credential state decides


### PR DESCRIPTION
Sign in to Claude Code on a Team premium seat and the agents panel's hero line says **Max 5x**. The seat isn't on Max; it's a Team seat whose Claude Code allowance happens to run on the Max 5x rate-limit tier.

## Why

`plan_label` in `bin/omarchy-agent-usage-claude` reads two fields off the saved login, `rateLimitTier` and `subscriptionType`, and lets the tier win whenever it matches `max_<N>x`. That's right for a Max account, where the two agree. On a Team premium seat the login looks like this:

```json
{ "subscriptionType": "team", "rateLimitTier": "default_claude_max_5x" }
```

The tier names the ceiling, not the plan, so the panel labels the seat as the plan it is not on. Enterprise seats take the same path.

## The fix

Lead with the subscription and keep the multiplier as its qualifier. The label stays exactly as it was for every case that worked before, and only the mislabelled one moves:

| `subscriptionType` | `rateLimitTier` | before | after |
|---|---|---|---|
| `max` | `default_claude_max_5x` | Max 5x | Max 5x |
| `max` | `default_claude_max_20x` | Max 20x | Max 20x |
| *(absent)* | `default_claude_max_5x` | Max 5x | Max 5x |
| `pro` | `default_claude_pro` | Pro | Pro |
| `team` | `default_claude_max_5x` | **Max 5x** | **Team 5x** |
| `team` | *(no multiplier)* | Team | Team |

Keeping the `5x` on a Team seat is a judgment call. It's the one thing the tier does tell you, it's what makes a premium seat different from a standard one, and it mirrors the "Max 20x" / "Max 5x" shape the panel already uses. Happy to drop it to a plain "Team" if you'd rather.

## Testing

`test/shell.d/agent-usage-claude-limits-test.sh` gains two cases that plant a `.credentials.json` and read the label back through `oauth_login`, so the whole path is covered rather than the formatter alone. The Team case fails on the current collector and passes with the fix; the Max, Pro and multiplier-less cases pin the labels that must not move. The Claude scanner, usage-update, agents-panel and bin-style suites all pass.

Verified on the real thing: running the patched collector against a signed-in Team premium seat prints `"tierLabel": "Team 5x"` in the usage record where the shipped one prints `"Max 5x"`. The panel draws `tierLabel` as-is, so no shell change is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
