### PR TITLE
Survive an unset OMARCHY_PATH in the update pipeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,8 +60,9 @@ guidance does not drift from the router.
 
 # Runtime Environment
 
-- `$OMARCHY_PATH` is set at the top level by the uwsm session environment and is always available to Omarchy runtime code.
+- `$OMARCHY_PATH` is established by `default/bash/env-bootstrap`, which runs only from a login shell, an interactive rc, or the uwsm session environment. `sudo` execs the router under its default `env_reset`, so it drops `OMARCHY_PATH` and no shell that would re-establish it runs.
 - Commands in `bin/` and Quickshell QML should rely on `$OMARCHY_PATH` / `Quickshell.env("OMARCHY_PATH")`; do not derive fallback paths from `HOME`, `Quickshell.shellDir`, or re-export/default `OMARCHY_PATH` manually.
+- Root entry points are the exception: a command reachable as root may resolve an unset `OMARCHY_PATH` from the root-owned `/etc/omarchy.conf` that `omarchy-dev-link` writes, defaulting it to the packaged `/usr/share/omarchy`.
 
 # Privileged Commands
 

--- a/bin/omarchy-snapshot
+++ b/bin/omarchy-snapshot
@@ -6,6 +6,17 @@
 
 set -e
 
+# sudo's env_reset drops OMARCHY_PATH, so resolve it from the root-owned
+# /etc/omarchy.conf that omarchy-dev-link writes. Otherwise the hint below
+# prints a bare /install/config path on a sudo-run update.
+if [[ -z ${OMARCHY_PATH:-} ]]; then
+  if [[ -f /etc/omarchy.conf ]]; then
+    # shellcheck disable=SC1091
+    . /etc/omarchy.conf
+  fi
+  OMARCHY_PATH="${OMARCHY_PATH:-/usr/share/omarchy}"
+fi
+
 COMMAND="$1"
 
 if [[ -z $COMMAND ]]; then

--- a/bin/omarchy-update-available
+++ b/bin/omarchy-update-available
@@ -4,6 +4,10 @@
 
 set -euo pipefail
 
+# Reached from `sudo omarchy update` through omarchy-update-status, where sudo's
+# env_reset has already dropped the session's OMARCHY_PATH.
+OMARCHY_PATH="${OMARCHY_PATH:-/usr/share/omarchy}"
+
 updates=()
 
 if [[ $OMARCHY_PATH != "/usr/share/omarchy" ]]; then

--- a/bin/omarchy-update-dev
+++ b/bin/omarchy-update-dev
@@ -4,6 +4,10 @@
 
 set -euo pipefail
 
+# `sudo omarchy update` runs no shell that sources default/bash/env-bootstrap,
+# and sudo's env_reset has already dropped the session's copy.
+OMARCHY_PATH="${OMARCHY_PATH:-/usr/share/omarchy}"
+
 [[ $OMARCHY_PATH != "/usr/share/omarchy" ]] || exit 0
 
 if ! git -C "$OMARCHY_PATH" rev-parse --is-inside-work-tree >/dev/null 2>&1; then

--- a/bin/omarchy-update-dev
+++ b/bin/omarchy-update-dev
@@ -5,10 +5,27 @@
 set -euo pipefail
 
 # `sudo omarchy update` runs no shell that sources default/bash/env-bootstrap,
-# and sudo's env_reset has already dropped the session's copy.
-OMARCHY_PATH="${OMARCHY_PATH:-/usr/share/omarchy}"
+# and sudo's env_reset has already dropped the session's copy. Resolve the
+# truth from the root-owned /etc/omarchy.conf that omarchy-dev-link writes and
+# env-bootstrap itself reads, rather than guessing the package default.
+if [[ -z ${OMARCHY_PATH:-} ]]; then
+  if [[ -f /etc/omarchy.conf ]]; then
+    # shellcheck disable=SC1091
+    . /etc/omarchy.conf
+  fi
+  OMARCHY_PATH="${OMARCHY_PATH:-/usr/share/omarchy}"
+fi
 
 [[ $OMARCHY_PATH != "/usr/share/omarchy" ]] || exit 0
+
+# omarchy-dev-link grants sudo a secure_path but no env_keep, so root can reach
+# this checkout's copy of the script while pulling the user-owned checkout here
+# would leave root-owned objects behind. Skip and say why instead of exiting
+# mute.
+if (( EUID == 0 )); then
+  echo -e "\e[33m\nSkip Omarchy dev checkout update (run omarchy update as your user to pull the dev checkout)\e[0m"
+  exit 0
+fi
 
 if ! git -C "$OMARCHY_PATH" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   echo "Error: OMARCHY_PATH is not a git checkout: $OMARCHY_PATH" >&2

--- a/test/shell.d/snapshot-create-test.sh
+++ b/test/shell.d/snapshot-create-test.sh
@@ -56,6 +56,32 @@ grep -qF 'No Snapper configs found' <<<"$stderr" ||
   fail "snapshot create does not invent a config to snapshot"
 pass "snapshot create fails loudly when Snapper is installed but unconfigured"
 
+# The Configure Snapper hint names $OMARCHY_PATH, which sudo's env_reset drops.
+# It has to print a real path rather than a bare /install/config one, resolving
+# the dev-link checkout from a test-local copy of /etc/omarchy.conf.
+snapshot_unset="$test_tmp/omarchy-snapshot-unset"
+sed "s#/etc/omarchy.conf#$test_tmp/omarchy.conf#g" "$snapshot" >"$snapshot_unset"
+
+: >"$test_tmp/calls.log"
+set +e
+stderr=$(env -u OMARCHY_PATH TEST_LOG="$test_tmp/calls.log" PATH="$fake_bin:$PATH" \
+  bash "$snapshot_unset" create 2>&1 >/dev/null)
+set -e
+
+grep -qF 'sudo bash -euo pipefail "/usr/share/omarchy/install/config/snapper.sh"' <<<"$stderr" ||
+  fail "snapshot create prints the packaged snapper path when OMARCHY_PATH is unset" "$stderr"
+
+printf 'export OMARCHY_PATH="%s"\n' "$test_tmp/checkout" >"$test_tmp/omarchy.conf"
+: >"$test_tmp/calls.log"
+set +e
+stderr=$(env -u OMARCHY_PATH TEST_LOG="$test_tmp/calls.log" PATH="$fake_bin:$PATH" \
+  bash "$snapshot_unset" create 2>&1 >/dev/null)
+set -e
+
+grep -qF "sudo bash -euo pipefail \"$test_tmp/checkout/install/config/snapper.sh\"" <<<"$stderr" ||
+  fail "snapshot create prints the dev-linked snapper path when OMARCHY_PATH is unset" "$stderr"
+pass "snapshot create names a real snapper path when OMARCHY_PATH is unset"
+
 cat >"$fake_bin/snapper" <<'STUB'
 #!/bin/bash
 printf 'snapper %s\n' "$*" >>"$TEST_LOG"

--- a/test/shell.d/update-available-test.sh
+++ b/test/shell.d/update-available-test.sh
@@ -211,3 +211,17 @@ grep -Fx 'omarchy-dev-checkout 1 new commit on origin/quattro' "$stdout" >/dev/n
   fail "update checker reports cached dev commits after a fetch failure" "$(cat "$stdout")"
 [[ ! -s $stderr ]] || fail "update checker keeps dev fetch failures quiet" "$(cat "$stderr")"
 pass "update checker uses cached dev state when fetching is unavailable"
+
+: >"$git_log"
+if TEST_CHECKUPDATES=updates TEST_INSTALLED_PACKAGE=omarchy TEST_GIT_LOG="$git_log" \
+  PATH="$stub_bin:$PATH" env -u OMARCHY_PATH \
+  "$ROOT/bin/omarchy-update-available" >"$stdout" 2>"$stderr"; then
+  status=0
+else
+  status=$?
+fi
+[[ ! -s $stderr ]] || fail "sudo's stripped environment does not break the update checker" "$(cat "$stderr")"
+[[ $status -eq 0 ]] || fail "update checker still reports package updates without OMARCHY_PATH"
+grep -q '^omarchy ' "$stdout" || fail "update checker still reports package updates without OMARCHY_PATH" "$(cat "$stdout")"
+[[ ! -s $git_log ]] || fail "an unset OMARCHY_PATH checks no dev checkout" "$(cat "$git_log")"
+pass "an unset OMARCHY_PATH means the package install"

--- a/test/shell.d/update-available-test.sh
+++ b/test/shell.d/update-available-test.sh
@@ -224,4 +224,4 @@ fi
 [[ $status -eq 0 ]] || fail "update checker still reports package updates without OMARCHY_PATH"
 grep -q '^omarchy ' "$stdout" || fail "update checker still reports package updates without OMARCHY_PATH" "$(cat "$stdout")"
 [[ ! -s $git_log ]] || fail "an unset OMARCHY_PATH checks no dev checkout" "$(cat "$git_log")"
-pass "an unset OMARCHY_PATH means the package install"
+pass "the update checker reports package updates without OMARCHY_PATH"

--- a/test/shell.d/update-dev-test.sh
+++ b/test/shell.d/update-dev-test.sh
@@ -59,6 +59,14 @@ run_dev_update /usr/share/omarchy
 pass "package-backed updates skip the dev checkout step"
 
 : >"$git_log"
+if ! TEST_GIT_LOG="$git_log" PATH="$stub_bin:$PATH" \
+  env -u OMARCHY_PATH "$ROOT/bin/omarchy-update-dev" 2>"$test_tmp/unset.err"; then
+  fail "sudo's stripped environment does not abort the update" "$(cat "$test_tmp/unset.err")"
+fi
+[[ ! -s $git_log ]] || fail "an unset OMARCHY_PATH means the package install" "$(cat "$git_log")"
+pass "an unset OMARCHY_PATH means the package install"
+
+: >"$git_log"
 run_dev_update "$checkout"
 grep -Fx -- "-C $checkout pull --ff-only" "$git_log" >/dev/null ||
   fail "dev checkout update pulls its upstream with fast-forward only" "$(cat "$git_log")"

--- a/test/shell.d/update-dev-test.sh
+++ b/test/shell.d/update-dev-test.sh
@@ -58,13 +58,30 @@ run_dev_update /usr/share/omarchy
 [[ ! -s $git_log ]] || fail "package-backed updates do not invoke git" "$(cat "$git_log")"
 pass "package-backed updates skip the dev checkout step"
 
+# An unset OMARCHY_PATH resolves through /etc/omarchy.conf, which the test has
+# to control rather than inherit from a dev-linked host, so run a copy with the
+# conf path rewritten to a test-local file.
+dev_update="$test_tmp/omarchy-update-dev"
+sed "s#/etc/omarchy.conf#$test_tmp/omarchy.conf#g" "$ROOT/bin/omarchy-update-dev" >"$dev_update"
+chmod +x "$dev_update"
+
 : >"$git_log"
 if ! TEST_GIT_LOG="$git_log" PATH="$stub_bin:$PATH" \
-  env -u OMARCHY_PATH "$ROOT/bin/omarchy-update-dev" 2>"$test_tmp/unset.err"; then
+  env -u OMARCHY_PATH "$dev_update" 2>"$test_tmp/unset.err"; then
   fail "sudo's stripped environment does not abort the update" "$(cat "$test_tmp/unset.err")"
 fi
-[[ ! -s $git_log ]] || fail "an unset OMARCHY_PATH means the package install" "$(cat "$git_log")"
-pass "an unset OMARCHY_PATH means the package install"
+[[ ! -s $git_log ]] || fail "an unset OMARCHY_PATH without a dev link means the package install" "$(cat "$git_log")"
+pass "an unset OMARCHY_PATH without a dev link means the package install"
+
+printf 'export OMARCHY_PATH="%s"\n' "$checkout" >"$test_tmp/omarchy.conf"
+: >"$git_log"
+if ! TEST_GIT_LOG="$git_log" PATH="$stub_bin:$PATH" \
+  env -u OMARCHY_PATH "$dev_update" 2>"$test_tmp/link.err"; then
+  fail "a dev link resolves an unset OMARCHY_PATH" "$(cat "$test_tmp/link.err")"
+fi
+grep -Fx -- "-C $checkout pull --ff-only" "$git_log" >/dev/null ||
+  fail "an unset OMARCHY_PATH pulls the checkout named by the dev link" "$(cat "$git_log")"
+pass "an unset OMARCHY_PATH pulls the checkout named by the dev link"
 
 : >"$git_log"
 run_dev_update "$checkout"


### PR DESCRIPTION
`sudo omarchy update` aborts right after the snapshot — `OMARCHY_PATH: unbound variable` — before anything upgrades. On a dev-linked box it also silently skipped the dev checkout and printed a broken snapper setup path.

`OMARCHY_PATH` is set by `default/bash/env-bootstrap`, which only runs from a login shell, an interactive rc, or the uwsm session. `sudo` runs the router under `env_reset`, so the variable is gone and nothing re-establishes it.

Changes:

- `omarchy-update-dev` and `omarchy-snapshot` resolve an unset `OMARCHY_PATH` from the root-owned `/etc/omarchy.conf` that `omarchy-dev-link` writes, falling back to `/usr/share/omarchy`.
- `omarchy-update-dev` skips a dev-linked checkout when run as root and says so, instead of exiting silently — pulling a user-owned checkout as root would leave root-owned objects behind.
- `omarchy-snapshot` prints the checkout's real snapper path instead of a bare `/install/config`.
- `omarchy-update-available` keeps the plain packaged default: its `git fetch` shouldn't run as root on a user checkout.

This stops the abort. It doesn't make a root-run update correct — migrations, hooks, AUR/mise updates, and `omarchy-restart-shell` still read root's `$HOME`. Whether `sudo omarchy update` should be supported, refused, or drop privileges is a separate call.

Fixes #8369
Fixes #9953
