### PR TITLE
Fix Display panel monitor toggle under the Lua config parser

### DIFF
--- a/shell/plugins/panels/monitor/Panel.qml
+++ b/shell/plugins/panels/monitor/Panel.qml
@@ -300,7 +300,15 @@ Panel {
     if (!name) return
     if (enabled && root.enabledDisplayCount <= 1) return
 
-    actionProc.command = ["hyprctl", "keyword", "monitor", name + (enabled ? ",disable" : ",preferred,auto,auto")]
+    // `hyprctl keyword` is rejected under Hyprland's Lua config parser, which
+    // Omarchy uses by default ("keyword can't work with non-legacy parsers.
+    // Use eval."). Drive the Lua monitor helper instead. `name` is a Hyprland
+    // connector name; guard it like the bin/ monitor helpers before it lands
+    // in an eval'd string.
+    if (!/^[A-Za-z0-9._-]+$/.test(name)) return
+
+    actionProc.command = ["hyprctl", "eval",
+      "hl.monitor({ output = \"" + name + "\", disabled = " + (enabled ? "true" : "false") + " })"]
     if (!actionProc.running) actionProc.running = true
   }
 


### PR DESCRIPTION
> **Authorship:** this fix was investigated and written by Claude Code
> (Anthropic's agentic CLI). I reviewed it and am submitting it on its behalf.

## Problem

The Display bar panel (`shell/plugins/panels/monitor/Panel.qml`) lists every
display with an enable/disable row, but `toggleDisplay()` runs:

```
hyprctl keyword monitor <name>,disable        # off
hyprctl keyword monitor <name>,preferred,auto,auto   # on
```

Hyprland disables the legacy `hyprctl keyword` IPC whenever the config is read
by the Lua parser:

```
$ hyprctl keyword monitor DP-3,disable
keyword can't work with non-legacy parsers. Use eval.
```

Omarchy v4 ships the Lua hypr config as the sole default (`config/hypr/*.lua`,
no `hyprland.conf`), so on a stock v4 install every monitor on/off row in the
panel is a silent no-op — the command errors on stderr, which the panel
doesn't surface. Brightness and scale in the same panel are unaffected; they
go through `omarchy-*` helpers.

## Fix

Drive the Lua `hl.monitor` helper through `hyprctl eval` instead, which is the
same mechanism `bin/omarchy-hyprland-monitor-internal` already uses to disable
the internal display (`hl.monitor({ output = ..., disabled = true })`). The
connector name comes from `omarchy-monitor-state` (Hyprland `.name`), and is
guarded with the same `^[A-Za-z0-9._-]+$` check the `bin/` monitor helpers
apply before interpolating a name into eval'd Lua.

```diff
-    actionProc.command = ["hyprctl", "keyword", "monitor", name + (enabled ? ",disable" : ",preferred,auto,auto")]
+    if (!/^[A-Za-z0-9._-]+$/.test(name)) return
+    actionProc.command = ["hyprctl", "eval",
+      "hl.monitor({ output = \"" + name + "\", disabled = " + (enabled ? "true" : "false") + " })"]
```

Re-enabling with `disabled = false` picks the mode/position back up from the
catch-all `hl.monitor({ output = "", mode = "preferred", position = "auto" })`
rule, matching the previous `,preferred,auto,auto` behaviour. Like the old
code this is a runtime change and doesn't persist across a config reload —
semantics are unchanged there.

## Testing

- `./test/shell` — no new failures (the 6 pre-existing failures on my machine —
  `config`, `locate`, `runtime-smoke`, `screenshot-sanity`, `snapper`,
  `unowned-system-paths` — reproduce on a clean `quattro` checkout and are
  environmental).
- Manual, on Omarchy 4.0.3 with two external monitors: toggling each display
  row off/on from the panel now disables/re-enables the output
  (`hyprctl monitors` `disabled:` flips); before the patch the rows did
  nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)