### PR TITLE
Add Empty Trash to the Omarchy Menu

### DIFF
--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -67,6 +67,7 @@
   "trigger.capture.screenrecord.microphone": {"icon":"","label":"With desktop + microphone audio","action":"omarchy-capture-screenrecording --with-desktop-audio --with-microphone-audio"},
   "trigger.capture.screenrecord.webcam": {"icon":"","label":"With desktop + microphone audio + webcam","when":"omarchy-hw-webcam","action":"omarchy-capture-screenrecording-with-webcam"},
   "trigger.transcode": {"icon":"󰧸","label":"Transcode","action":"omarchy-transcode"},
+  "trigger.empty-trash": {"icon":"󰩹","label":"Empty Trash","when":"[[ -n $(ls -A \"$HOME/.local/share/Trash/files\" 2>/dev/null) ]]","action":"gio trash --empty && omarchy-notification-send 'Trash emptied' -g 󰩹"},
   "trigger.share": {"icon":"","label":"Share","aliases":["share"]},
   "trigger.toggle": {"icon":"󰔎","label":"Toggle","aliases":["toggle","toggles"]},
   "trigger.hardware": {"icon":"","label":"Hardware","aliases":["hardware","hw"]},


### PR DESCRIPTION
This PR adds an "Empty Trash" option to the Trigger menu, next to Screenshot and Transcode. It runs `gio trash --empty`, so the trash can be cleared without opening a file manager, and sends a notification when it is done.

The row hides itself while the trash is already empty, the same way the Remove rows hide what is not there to remove.

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/63ed8d6a-74fe-4bb5-b0cd-f25b6868f5a3" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)