### PR TITLE
Give the plugin commands an IPC budget that fits a reload

### DIFF
--- a/bin/omarchy-plugin-disable
+++ b/bin/omarchy-plugin-disable
@@ -6,6 +6,16 @@
 
 set -euo pipefail
 
+# A rescan makes the shell rebuild every plugin instance, which blocks its IPC
+# for seconds, and these commands normally run right inside that window:
+# omarchy-plugin-add and omarchy-plugin-clone call them a step after their own
+# rescan, and saving a file under ~/.config/omarchy/plugins/ starts the same
+# reload through inotify. The 2s default expires there and reports a shell that
+# is not responding, when the shell is merely busy with work this command is
+# waiting on. A shell that is genuinely not running still fails at once, since
+# that is a connection error rather than a timeout.
+export OMARCHY_SHELL_IPC_TIMEOUT="${OMARCHY_SHELL_IPC_TIMEOUT:-15s}"
+
 fail() {
   echo "omarchy-plugin-disable: $*" >&2
   exit 1

--- a/bin/omarchy-plugin-enable
+++ b/bin/omarchy-plugin-enable
@@ -7,6 +7,16 @@
 
 set -euo pipefail
 
+# A rescan makes the shell rebuild every plugin instance, which blocks its IPC
+# for seconds, and these commands normally run right inside that window:
+# omarchy-plugin-add and omarchy-plugin-clone call them a step after their own
+# rescan, and saving a file under ~/.config/omarchy/plugins/ starts the same
+# reload through inotify. The 2s default expires there and reports a shell that
+# is not responding, when the shell is merely busy with work this command is
+# waiting on. A shell that is genuinely not running still fails at once, since
+# that is a connection error rather than a timeout.
+export OMARCHY_SHELL_IPC_TIMEOUT="${OMARCHY_SHELL_IPC_TIMEOUT:-15s}"
+
 fail() {
   echo "omarchy-plugin-enable: $*" >&2
   exit 1

--- a/bin/omarchy-plugin-remove
+++ b/bin/omarchy-plugin-remove
@@ -7,6 +7,16 @@
 
 set -euo pipefail
 
+# A rescan makes the shell rebuild every plugin instance, which blocks its IPC
+# for seconds, and these commands normally run right inside that window:
+# omarchy-plugin-add and omarchy-plugin-clone call them a step after their own
+# rescan, and saving a file under ~/.config/omarchy/plugins/ starts the same
+# reload through inotify. The 2s default expires there and reports a shell that
+# is not responding, when the shell is merely busy with work this command is
+# waiting on. A shell that is genuinely not running still fails at once, since
+# that is a connection error rather than a timeout.
+export OMARCHY_SHELL_IPC_TIMEOUT="${OMARCHY_SHELL_IPC_TIMEOUT:-15s}"
+
 PLUGINS_DIR="$HOME/.config/omarchy/plugins"
 ASSUME_YES=0
 

--- a/test/shell.d/plugin-ipc-budget-test.sh
+++ b/test/shell.d/plugin-ipc-budget-test.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command jq
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# How long the stub shell takes to answer. Longer than the 2s default these
+# commands used to run with, shorter than the budget they ask for now, so the
+# same call fails or succeeds purely on the budget.
+BUSY_SECONDS=3
+
+stub_dir="$TMPDIR/stubs"
+mkdir -p "$stub_dir"
+
+# A stand-in for omarchy-shell that keeps the part under test: the caller's
+# budget wraps the call, and expiry becomes "is not responding" on exit 1.
+cat >"$stub_dir/omarchy-shell" <<'STUB'
+#!/bin/bash
+
+[[ ${1:-} == "-q" ]] && shift
+
+printf '%s\n' "${OMARCHY_SHELL_IPC_TIMEOUT:-unset}" >>"$BUDGET_LOG"
+
+answer=$(timeout "${OMARCHY_SHELL_IPC_TIMEOUT:-2s}" \
+  bash -c 'sleep "$1"; printf ok' _ "${SHELL_BUSY_SECONDS:-0}")
+status=$?
+
+if (( status == 124 || status == 137 )); then
+  echo "omarchy-shell is not responding" >&2
+  exit 1
+fi
+
+if [[ ${2:-} == "listPlugins" ]]; then
+  printf '%s\n' "${STUB_PLUGINS:-[]}"
+else
+  printf '%s\n' "$answer"
+fi
+exit 0
+STUB
+chmod +x "$stub_dir/omarchy-shell"
+
+export BUDGET_LOG="$TMPDIR/budgets"
+
+run_plugin_cmd() {
+  local home="$1"
+  shift
+
+  HOME="$home" OMARCHY_PATH="$ROOT" PATH="$stub_dir:$ROOT/bin:$PATH" "$@"
+}
+
+home="$TMPDIR/home"
+mkdir -p "$home/.config/omarchy/plugins"
+
+# --- enable and disable ride out a busy shell ------------------------------
+#
+# omarchy-plugin-add and omarchy-plugin-clone call these one step after their
+# own rescan, and an editor saving into ~/.config/omarchy/plugins/ starts the
+# same reload through inotify. Reporting an unreachable shell there turns work
+# in progress into a failure (#9304).
+
+: >"$BUDGET_LOG"
+output=$(SHELL_BUSY_SECONDS="$BUSY_SECONDS" run_plugin_cmd "$home" \
+  omarchy-plugin-disable acme.busy 2>&1) ||
+  fail "plugin disable waits out a shell that is rebuilding plugins" "$output"
+grep -qF "Disabled acme.busy" <<<"$output" ||
+  fail "plugin disable reports the change it made" "$output"
+pass "plugin disable waits for a shell busy with a plugin reload"
+
+: >"$BUDGET_LOG"
+output=$(SHELL_BUSY_SECONDS="$BUSY_SECONDS" run_plugin_cmd "$home" \
+  omarchy-plugin-enable acme.busy 2>&1) ||
+  fail "plugin enable waits out a shell that is rebuilding plugins" "$output"
+grep -qF "Enabled acme.busy" <<<"$output" ||
+  fail "plugin enable reports the change it made" "$output"
+pass "plugin enable waits for a shell busy with a plugin reload"
+
+# --- remove asks for the same budget ---------------------------------------
+#
+# Its setPluginEnabled call sits between the confirmation and the deletion, so
+# an expiry there aborts a removal that was already agreed to.
+
+write_plugin() {
+  mkdir -p "$1"
+  jq -n --arg id "$2" '{
+    schemaVersion: 1, id: $id, name: "Busy", version: "1.0.0",
+    kinds: ["bar-widget"], entryPoints: {barWidget: "Widget.qml"},
+    barWidget: {displayName: "Busy", category: "Test", allowMultiple: false}
+  }' >"$1/manifest.json"
+  printf 'import QtQuick\nItem {}\n' >"$1/Widget.qml"
+}
+
+write_plugin "$home/.config/omarchy/plugins/acme.removable" "acme.removable"
+: >"$BUDGET_LOG"
+output=$(STUB_PLUGINS='[{"id":"acme.removable","enabled":true}]' \
+  run_plugin_cmd "$home" omarchy-plugin-remove acme.removable --yes 2>&1) ||
+  fail "plugin remove runs against the stub shell" "$output"
+grep -qFx '15s' "$BUDGET_LOG" ||
+  fail "plugin remove asks for the raised budget" "$(cat "$BUDGET_LOG")"
+pass "plugin remove asks the shell for a budget that fits a reload"
+
+# --- an explicit budget still wins -----------------------------------------
+#
+# The commands raise the default; they do not override someone who set one.
+
+: >"$BUDGET_LOG"
+output=$(OMARCHY_SHELL_IPC_TIMEOUT=1s SHELL_BUSY_SECONDS="$BUSY_SECONDS" \
+  run_plugin_cmd "$home" omarchy-plugin-disable acme.busy 2>&1) &&
+  fail "an explicit 1s budget still expires against a busy shell" "$output"
+grep -qFx '1s' "$BUDGET_LOG" ||
+  fail "plugin disable keeps the caller's budget" "$(cat "$BUDGET_LOG")"
+pass "an explicit OMARCHY_SHELL_IPC_TIMEOUT is left alone"


### PR DESCRIPTION
Fixes #9304.

## The problem

`omarchy-plugin-enable`, `-disable` and `-remove` each hang on a single IPC call, made in a command substitution under `set -euo pipefail`:

```bash
result=$(omarchy-shell shell enablePlugin "$id" "$placement")
```

`omarchy-shell` wraps every call in `timeout ${OMARCHY_SHELL_IPC_TIMEOUT:-2s}` and exits 1 when it expires, so the substitution fails and `set -e` ends the command right there with `omarchy-shell is not responding`.

These commands are normally run inside the exact window where that happens. `omarchy-plugin-add` and `omarchy-plugin-clone` call enable a step after their own `rescanPlugins`, and saving a file under `~/.config/omarchy/plugins/` starts the same reload through inotify. Rebuilding every plugin instance blocks the shell's IPC for longer than two seconds, so the call expires and the command reports an unreachable shell, when the shell is busy with the very work the command is waiting on.

#9304 reports the user-visible half of this: `omarchy plugin add --enable` leaves the plugin installed but disabled, and running `omarchy plugin enable <id>` a few seconds later works every time.

## Reproducing it

`does.not.exist` is used deliberately: no outcome changes anything, so the only variable is which error comes back. Run against a live shell while a real plugin update is reloading:

```
installed  exit=1 | omarchy-shell is not responding
patched    exit=1 | omarchy-plugin-enable: plugin 'does.not.exist' is not known; run: omarchy-shell shell rescanPlugins
```

Same command, same moment. Without the change the shell never gets asked; with it, the question is answered correctly.

The window is real but timing dependent. It opens only when the shell has plugin code to reload: a rescan with nothing to load answers in 0.05 s, one right after a real plugin update takes 1.65 s, and one arriving while another is still rebuilding took 7.32 s on this machine with 9 git managed plugins.

## The change

```bash
export OMARCHY_SHELL_IPC_TIMEOUT="${OMARCHY_SHELL_IPC_TIMEOUT:-15s}"
```

in those three commands, with a comment explaining why they are the ones that need it.

Three things this deliberately does not do:

- It does not use `-q`. A failed enable is a real failure, and swallowing it would leave `result` empty and produce `fail ""`. Only a genuinely best-effort call may be quieted, which is what #11117 does for the closing rescan.
- It does not slow down a dead shell. `qs` reports a missing connection as a connection error, not a timeout, so `omarchy-shell` still fails at once on its "is not running" path. The budget only applies to a shell that is up and busy.
- It does not override an explicit `OMARCHY_SHELL_IPC_TIMEOUT`. Someone who set one keeps it.

15 s comes from the 7.32 s worst case measured here, doubled. #9304 reports a slower reload still with 15 third-party plugins installed.

## Testing

New `test/shell.d/plugin-ipc-budget-test.sh`. Its `omarchy-shell` stub keeps the part under test: the caller's budget wraps the call through a real `timeout`, and expiry becomes `is not responding` on exit 1. A stub shell that takes 3 s to answer is longer than the old 2 s default and shorter than the new budget, so the same call fails or succeeds purely on the budget. Four assertions: enable and disable both ride out the busy shell, remove asks for the raised budget, and an explicitly set budget is left alone.

Each of the three changes was reverted on its own to confirm the test fails without it:

```
without omarchy-plugin-disable  exit=1  not ok - plugin disable waits out a shell that is rebuilding plugins
without omarchy-plugin-enable   exit=1  not ok - plugin enable waits out a shell that is rebuilding plugins
without omarchy-plugin-remove   exit=1  not ok - plugin remove asks for the raised budget
```

`./test/all` fails the same 6 of its test files before and after, none of them plugin related: `config`, `locate`, `runtime-smoke`, `screenshot-sanity`, `snapper`, `unowned-system-paths`. They want an `omarchy-pkgs` checkout or a live compositor, neither of which this machine has.

## Relation to #11117

Same root cause, opposite remedy, and they are independent. #11117 quiets the closing `rescanPlugins` in add, clone, remove and update, where the call is genuinely best effort and its failure should not be fatal. This one gives the calls whose result actually matters enough time to arrive. Both touch `bin/omarchy-plugin-remove`, in different places; whichever lands second may need a trivial rebase.

## Unrelated thing noticed while testing

`omarchy-shell shell setPluginEnabled <unknown-id> false` answers `ok`, where `enablePlugin` correctly answers `unknown`. So `omarchy plugin disable <typo>` prints `Disabled <typo>` and exits 0 without doing anything. That is shell side and out of scope here; I can file it separately if it is not already known.
