### PR TITLE
Complete plugin IDs for enable and disable

### DIFF
--- a/default/bash/completions
+++ b/default/bash/completions
@@ -7,6 +7,14 @@ _omarchy_complete() {
   bin_dir=$(dirname -- "$(readlink -f -- "$omarchy_path" 2>/dev/null || printf '%s' "$omarchy_path")")
   [[ -d $bin_dir ]] || return 0
 
+  if (( COMP_CWORD == 3 )) && [[ ${COMP_WORDS[1]} == "plugin" && ${COMP_WORDS[2]} == @(enable|disable) ]]; then
+    compopt +o default
+    local plugin_ids
+    plugin_ids=$("$bin_dir/omarchy-plugin-catalog" | jq -r '.[].id') || return 0
+    mapfile -t COMPREPLY < <(compgen -W "$plugin_ids" -- "$cur")
+    return 0
+  fi
+
   local prefix="omarchy"
   local i part
   for ((i = 1; i < COMP_CWORD; i++)); do

--- a/test/shell.d/plugin-completion-test.sh
+++ b/test/shell.d/plugin-completion-test.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+source "$ROOT/default/bash/completions"
+
+test_home=$(mktemp -d)
+trap 'rm -rf "$test_home"' EXIT
+export HOME="$test_home" OMARCHY_PATH="$ROOT" PATH="$ROOT/bin:$PATH"
+mkdir -p "$HOME/.config/omarchy/plugins/weather"
+printf '%s\n' '{"id":"acme.weather"}' >"$HOME/.config/omarchy/plugins/weather/manifest.json"
+
+# compopt requires an actual readline completion; record its option here.
+compopt() {
+  completion_options="$*"
+}
+
+for action in enable disable; do
+  COMP_WORDS=(omarchy plugin "$action" "")
+  COMP_CWORD=3
+  completion_options=""
+  _omarchy_complete
+  [[ " ${COMPREPLY[*]} " == *" omarchy.clock "* ]] || fail "$action completes stock plugins"
+  [[ " ${COMPREPLY[*]} " == *" acme.weather "* ]] || fail "$action completes user plugins"
+  [[ $completion_options == "+o default" ]] || fail "$action disables filename fallback"
+
+  COMP_WORDS[3]="acme.w"
+  _omarchy_complete
+  [[ ${COMPREPLY[*]} == "acme.weather" ]] || fail "$action filters plugin prefixes"
+
+  COMP_WORDS[3]="nonexistent"
+  _omarchy_complete
+  (( ${#COMPREPLY[@]} == 0 )) || fail "$action has no matches for unknown plugins"
+  pass "$action completes plugin IDs without filename fallback"
+done
+
+COMP_WORDS=(omarchy plugin "")
+COMP_CWORD=2
+completion_options=""
+_omarchy_complete
+[[ " ${COMPREPLY[*]} " == *" enable "* ]] || fail "plugin subcommands still complete"
+[[ -z $completion_options ]] || fail "other completion keeps its default options"
+pass "plugin subcommand completion is unchanged"


### PR DESCRIPTION
Tab after `omarchy plugin enable` or `omarchy plugin disable` falls back to filenames because plugin IDs are not completion candidates.

Complete IDs from the existing plugin catalog, covering both stock and user plugins. Disable filename fallback for this argument, including when no plugin matches. Other command completion stays unchanged.
