### PR TITLE
Add providerOrder to agents panel

### DIFF
--- a/shell/plugins/agents/Main.qml
+++ b/shell/plugins/agents/Main.qml
@@ -206,7 +206,30 @@ Item {
       var syncedDisplay = displayProvider({ id: syncedId, name: stats.providerName || syncedId })
       if (providerHasData(syncedDisplay)) result.push(syncedDisplay)
     }
+    // Tab order follows `providerOrder` in shell.json: position 0 is the
+    // default tab shown on open. Providers not listed there keep the
+    // historical alphabetical fallback, keeping this fully backwards
+    // compatible when `providerOrder` is absent or partial.
+    result.sort(function(a, b) {
+      var ra = providerRank(a.providerId), rb = providerRank(b.providerId)
+      if (ra !== rb) return ra - rb
+      return a.providerId < b.providerId ? -1 : (a.providerId > b.providerId ? 1 : 0)
+    })
     return result
+  }
+
+  // Index of the provider in the user's explicit `providerOrder` list.
+  // Unlisted providers sort last, alphabetically among themselves.
+  // NOTE: no Array.isArray gate — the shell delivers settings lists as
+  // array-like sequences that fail that check while supporting length and
+  // indexOf just fine.
+  function providerRank(id) {
+    var order = settings ? settings.providerOrder : null
+    if (order && typeof order.indexOf === "function") {
+      var idx = order.indexOf(id)
+      if (idx !== -1) return idx
+    }
+    return 1000000
   }
 
   function providerEnabled(id) {

--- a/shell/plugins/agents/README.md
+++ b/shell/plugins/agents/README.md
@@ -136,6 +136,19 @@ omarchy bar set omarchy.agents providers '{
 hide a subscription that is installed. Disabled agents are also skipped when
 the records regenerate.
 
+Tab order follows `providerOrder`: the first entry is position 0 and the
+default tab shown on open. Providers not listed keep the historical
+alphabetical fallback, so existing configs without an explicit order behave
+exactly as before. Edit `shell.json` directly (arrays don't survive
+`omarchy bar set` argument parsing):
+
+```json
+{
+  "id": "omarchy.agents",
+  "providerOrder": ["opencode-go", "codex", "claude", "fireworks"]
+}
+```
+
 With `syncMode` on, every `*.json` snapshot in `syncDir` is merged, so today,
 the last 7 days, and the all-time totals cover every machine you code on —
 active days are unioned by date rather than summed. Rate limits stay

--- a/shell/plugins/agents/manifest.json
+++ b/shell/plugins/agents/manifest.json
@@ -18,6 +18,7 @@
     "aliases": ["agents", "model-usage"],
     "allowMultiple": false,
     "defaults": {
+      "providerOrder": [],
       "providers": {
         "claude": { "enabled": true },
         "codex": { "enabled": true },

--- a/test/shell.d/agents-panel-test.sh
+++ b/test/shell.d/agents-panel-test.sh
@@ -14,4 +14,10 @@ assert(/if \(buttonCode === Qt\.RightButton\) root\.launchAgent\(\)/.test(panelS
 assert(/else if \(buttonCode === Qt\.MiddleButton\) root\.selectProvider\(root\.providerIndex \+ 1\)/.test(panelSource), 'agents middle click still advances the subscription')
 assert(/else root\.toggle\(\)/.test(panelSource), 'agents left click still toggles the panel')
 assert(!/if \(buttonCode === Qt\.RightButton\) root\.refreshNow\(\)/.test(panelSource), 'agents right click no longer refreshes')
+
+const mainSource = fs.readFileSync(root + '/shell/plugins/agents/Main.qml', 'utf8')
+
+assert(/function providerRank\(id\)/.test(mainSource), 'agents provider order follows providerOrder list')
+assert(/settings\.providerOrder/.test(mainSource), 'agents rank reads providerOrder setting')
+assert(/providerRank\(a\.providerId\), rb = providerRank\(b\.providerId\)/.test(mainSource) || /providerRank\(a\.providerId\)/.test(mainSource), 'agents enabledProviders sorts by rank')
 JS


### PR DESCRIPTION
The agents widget orders tabs alphabetically with no way to choose the default shown tab (position 0).

This adds an optional top-level `providerOrder` list to the widget settings. Tabs sort by their index in that list; providers not listed keep the historical alphabetical fallback, so configs without it behave exactly as before.

```json
{
  "id": "omarchy.agents",
  "providerOrder": ["opencode-go", "codex", "claude", "fireworks"]
}
```

Notes:
- No `Array.isArray` gate on purpose: the shell delivers settings lists as array-like sequences that fail that check while supporting `length` and `indexOf`.
- Manifest gains a `providerOrder: []` default. No schema entry: like nested `providers`, it is configured via `shell.json` directly.
- Verified live on my machine via a cloned widget (opencode-go first, codex second) plus `test/shell.d/agents-panel-test.sh` (3 new assertions, all green).