### PR TITLE
Retry first-run when user finalization fails

### DIFF
--- a/bin/omarchy-provision-first-run
+++ b/bin/omarchy-provision-first-run
@@ -43,8 +43,6 @@ if omarchy-done check "$FIRST_RUN_DONE" && (( force == 0 )); then
   exit 0
 fi
 
-omarchy-provision-user "${finalize_user_args[@]}" || true
-
 mkdir -p "$state_dir"
 
 FIRST_RUN_LOG="$state_dir/first-run.log"
@@ -67,6 +65,9 @@ run_first_run_step() {
     log_first_run "Failed: $name (exit code: $status)"
   fi
 }
+
+run_first_run_step "finalize user setup" \
+  omarchy-provision-user "${finalize_user_args[@]}"
 
 run_first_run_step "install Voxtype post-update hook" \
   omarchy-hook-install post-update "$OMARCHY_PATH/install/user/first-run/install-voxtype.hook"

--- a/docs/file-layout.md
+++ b/docs/file-layout.md
@@ -266,11 +266,9 @@ transaction in the already-visible update terminal, then runs
 
 ## First-run (`omarchy-provision-first-run`)
 
-Runs once on first interactive login, after the user manager is live. It
-first runs `omarchy-provision-user || true` so finalize catches up if it
-never ran, then handles the steps that need a running graphical session
-and/or a working user systemd instance:
+Runs once on first interactive login, after the user manager is live. Every step below runs through the same wrapper: it logs the step, and a failure is recorded and lets the remaining steps run rather than aborting the sequence.
 
+- `omarchy-provision-user`, so finalize catches up if it never ran.
 - `omarchy-hook-install post-update` for the three shipped hooks
   (`install-voxtype.hook`, `setup-fingerprint.hook`, `setup-agent.hook`).
 - `install/user/first-run/enable-user-units.sh` — daemon-reload, then

--- a/test/shell.d/first-run-test.sh
+++ b/test/shell.d/first-run-test.sh
@@ -33,3 +33,52 @@ if grep -F 'skip-first-run-update-notification' "$ROOT/install/user/first-run/wi
 fi
 
 pass "first-run uses one lifecycle completion marker"
+
+# Finalization is a first-run step like any other: a failure has to leave the
+# marker unwritten so the next login retries, rather than being swallowed into
+# a completed first-run the user can never get back to.
+run_bin="$test_tmp/run-bin"
+run_omarchy="$test_tmp/run-omarchy/install/user/first-run"
+mkdir -p "$run_bin" "$run_omarchy"
+
+for hook in install-voxtype setup-fingerprint setup-agent; do
+  touch "$run_omarchy/$hook.hook"
+done
+for step in enable-user-units gnome-theme gtk-primary-paste audio-tuning welcome wifi; do
+  printf '#!/bin/bash\n' >"$run_omarchy/$step.sh"
+done
+
+cat >"$run_bin/omarchy-done" <<'SH'
+#!/bin/bash
+[[ $1 != "check" ]] || exit 1
+[[ $1 != "mark" ]] || printf '%s\n' "$2" >>"$OMARCHY_TEST_MARKED"
+SH
+printf '#!/bin/bash\n' >"$run_bin/omarchy-hook-install"
+printf '#!/bin/bash\n' >"$run_bin/omarchy-notification-wait"
+chmod +x "$run_bin"/*
+
+first_run() {
+  local finalize_exit="$1" home="$2"
+  printf '#!/bin/bash\nexit %s\n' "$finalize_exit" >"$run_bin/omarchy-provision-user"
+  chmod +x "$run_bin/omarchy-provision-user"
+  rm -rf "$home"
+  mkdir -p "$home"
+  HOME="$home" PATH="$run_bin:$PATH" OMARCHY_PATH="$test_tmp/run-omarchy" \
+    OMARCHY_TEST_MARKED="$home/marked" \
+    bash "$ROOT/bin/omarchy-provision-first-run" >/dev/null 2>&1
+}
+
+failed_home="$test_tmp/home-finalize-failed"
+first_run 1 "$failed_home"
+if grep -Fx 'first-run-user' "$failed_home/marked" >/dev/null 2>&1; then
+  fail "a failed finalization leaves first-run unmarked" "$(cat "$failed_home/.local/state/omarchy/first-run.log")"
+fi
+grep -F 'Failed: finalize user setup' "$failed_home/.local/state/omarchy/first-run.log" >/dev/null ||
+  fail "a failed finalization is recorded in the first-run log"
+pass "a failed finalization keeps first-run retryable"
+
+passed_home="$test_tmp/home-finalize-passed"
+first_run 0 "$passed_home"
+grep -Fx 'first-run-user' "$passed_home/marked" >/dev/null ||
+  fail "a successful run still marks first-run complete"
+pass "a successful finalization completes first-run"


### PR DESCRIPTION
`omarchy-provision-first-run` runs `omarchy-provision-user` with `|| true`, so a failed finalization is neither recorded nor able to affect the outcome: the remaining steps succeed, `first-run-user` gets marked, and the lifecycle gate at the top then refuses to run again. The user is left permanently half-finalized, with nothing in `first-run.log` to say so.

Running it through `run_first_run_step` like every other step logs the failure and leaves the marker unwritten, so the next login retries. That is what `docs/file-layout.md` already promises for first-run as a whole ("On failure the marker is not written and the sequence retries next login"), and what `omarchy-provision-owner` already does around the same call, warning the user to retry after login.

`omarchy-provision-user` exits 0 when `finalize-user` is already marked, so the guard was only ever reached by a real failure in the catch-up case the call exists to cover. Retrying is safe: `omarchy-hook-install` copies, the unit and settings steps are idempotent.

`docs/file-layout.md` described the `|| true` explicitly, so it is updated alongside.

`test/shell.d/first-run-test.sh` gains coverage for both outcomes — it fails on `quattro` and passes with the change. `./test/cli` and `./test/shell` show no other difference from the branch point.
