### PR TITLE
Add Kilo AI

### DIFF
--- a/bin/omarchy-agent
+++ b/bin/omarchy-agent
@@ -54,8 +54,8 @@ fi
 # Agents launched from the keybinding or menu run unattended, so each one starts
 # with its own spelling of "don't stop to ask". Pi and Ori have none to skip.
 case "$agent" in
-opencode)
-  command=(opencode --auto)
+opencode | kilo)
+  command=("$agent" --auto)
   [[ -n ${prompt:-} ]] && command+=(--prompt "$prompt")
   ;;
 agy)

--- a/bin/omarchy-default-agent
+++ b/bin/omarchy-default-agent
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # omarchy:summary=Set and launch the default coding agent
-# omarchy:args=[pi|omp|opencode|ori|claude|codex|grok|openclaw|agy|hermes|copilot|crush|cursor-agent|muse]
+# omarchy:args=[pi|omp|opencode|ori|claude|codex|grok|openclaw|agy|hermes|kilo|copilot|crush|cursor-agent|muse]
 # omarchy:examples=omarchy default agent | omarchy default agent codex | omarchy default agent claude
 
 installing=false
@@ -35,6 +35,7 @@ grok) agent="grok"; name="Grok"; agent_package="npm:@xai-official/grok" ;;
 openclaw) agent="openclaw"; name="OpenClaw"; agent_installer="omarchy-install-openclaw-cli" ;;
 agy | antigravity | antigravity-cli | gemini | gemini-cli) agent="agy"; name="Antigravity"; agent_package="antigravity-cli" ;;
 hermes) agent="hermes"; name="Hermes"; agent_installer="omarchy-install-hermes-cli" ;;
+kilo) agent="kilo"; name="kilo"; agent_package="npm:@kilocode/cli" ;;
 copilot | github-copilot) agent="copilot"; name="GitHub Copilot" ;;
 muse | muse-code | musecode)
   agent="muse"; name="Muse Code"
@@ -43,7 +44,7 @@ muse | muse-code | musecode)
   ;;
 cursor | cursor-agent) agent="cursor-agent"; name="Cursor CLI" ;;
 *)
-  echo "Usage: omarchy-default-agent <pi|omp|opencode|ori|claude|codex|grok|openclaw|agy|hermes|copilot|crush|cursor-agent|muse>"
+  echo "Usage: omarchy-default-agent <pi|omp|opencode|ori|claude|codex|grok|openclaw|agy|hermes|kilo|copilot|crush|cursor-agent|muse>"
   exit 1
   ;;
 esac

--- a/bin/omarchy-remove-preinstalls
+++ b/bin/omarchy-remove-preinstalls
@@ -30,6 +30,12 @@ if gum confirm "Are you sure you want to remove all preinstalled web apps, TUI w
     rm -f ~/.local/bin/muse
   fi
 
+  # Preserve a user-managed kilo launcher at the same path, such as kilo-bin.
+  if [[ -f ~/.local/bin/kilo && ! -L ~/.local/bin/kilo ]] &&
+    grep -Eq '^mise use -g .*"npm:@kilocode/cli"' ~/.local/bin/kilo; then
+    rm -f ~/.local/bin/kilo
+  fi
+
   # Only the wrapper omarchy-install-hermes-cli wrote is a preinstall. Hermes
   # Desktop's command, an official install, or anything else at that path is
   # the user's, so it is the installer that decides whether the wrapper is its

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -143,6 +143,7 @@
   "setup.default.agent.cursor-agent": {"icon":"","iconFont":"omarchy","label":"Cursor CLI","checked":"[[ \"$(omarchy-default-agent)\" == \"cursor-agent\" ]]","action":"omarchy-default-agent cursor-agent"},
   "setup.default.agent.grok": {"icon":"","iconFont":"omarchy","label":"Grok","checked":"[[ \"$(omarchy-default-agent)\" == \"grok\" ]]","action":"omarchy-default-agent grok"},
   "setup.default.agent.hermes": {"icon":"","iconFont":"omarchy","label":"Hermes","checked":"[[ \"$(omarchy-default-agent)\" == \"hermes\" ]]","action":"omarchy-default-agent hermes"},
+  "setup.default.agent.kilo": {"icon":"󰚩","label":"kilo","checked":"[[ \"$(omarchy-default-agent)\" == \"kilo\" ]]","action":"omarchy-default-agent kilo"},
   "setup.default.agent.muse": {"icon":"󰛤","label":"Muse Code","checked":"[[ \"$(omarchy-default-agent)\" == \"muse\" ]]","action":"omarchy-default-agent muse"},
   "setup.default.agent.omp": {"icon":"","iconFont":"omarchy","label":"omp","checked":"[[ \"$(omarchy-default-agent)\" == \"omp\" ]]","action":"omarchy-default-agent omp"},
   "setup.default.agent.openclaw": {"icon":"","iconFont":"omarchy","label":"OpenClaw","checked":"[[ \"$(omarchy-default-agent)\" == \"openclaw\" ]]","action":"omarchy-default-agent openclaw"},

--- a/install/user/mise.sh
+++ b/install/user/mise.sh
@@ -15,6 +15,8 @@ omarchy-mise-install github:can1357/oh-my-pi omp
 omarchy-mise-install npm:@xai-official/grok grok
 # Cursor's own installer links the same path, so a re-provision keeps it.
 omarchy-cmd-missing cursor-agent && omarchy-mise-install cursor-agent
+# Same for a kilo the user manages themselves, such as kilo-bin from the AUR.
+omarchy-cmd-missing kilo && omarchy-mise-install npm:@kilocode/cli kilo
 omarchy-mise-install npm:@kitlangton/ghui ghui
 omarchy-mise-install aqua:modem-dev/hunk hunk
 omarchy-mise-install github:basecamp/hey-cli hey

--- a/manual/17-ai.md
+++ b/manual/17-ai.md
@@ -17,6 +17,7 @@ Omarchy treats AI coding agents as first-class citizens, but it doesn't pick a f
 | `hermes`   | [Hermes](https://hermes-agent.nousresearch.com/), Nous Research's agent  |
 | `muse`     | [Muse Code](https://dev.meta.ai), Meta's coding agent           |
 | `cursor-agent` | [Cursor CLI](https://cursor.com/cli)                         |
+| `kilo`     | [Kilo](https://kilo.ai/docs/code-with-ai/platforms/cli), an OpenCode-derived coding agent |
 
 `ori` is the odd one out: it runs the other harnesses against OpenRouter's whole model catalog, so `ori claude`, `ori codex`, or `ori opencode` start those agents on whichever model you point them at, and `ori code` is Ori's own agent.
 
@@ -27,6 +28,8 @@ To wrap an additional CLI the same way, run `omarchy-mise-install <package> [com
 Pick your default agent with `omarchy default agent <name>` or under _Setup > Defaults > Agent_ in the Omarchy Menu (`Super + Space`). If the agent isn't installed yet, picking it installs it first. A fresh Omarchy will invite you to make this choice with a one-time notification.
 
 [Muse Code](https://dev.meta.ai) — Meta's `muse` — uses a preinstalled mise stub like the other agents. Picking it as the default installs Meta's official launcher through mise's HTTP backend. The launcher verifies and updates the native binary for your machine.
+
+[Kilo](https://kilo.ai/docs/code-with-ai/platforms/cli) — the `kilo` command — is an open-source, OpenCode-derived coding agent that talks to the [Kilo Gateway](https://kilo.ai/docs/gateway) as well as other model providers. Picking it with `omarchy default agent kilo` installs the `@kilocode/cli` npm package through mise; then run `/connect` inside `kilo` to authenticate. The AUR's [`kilo-bin`](https://aur.archlinux.org/packages/kilo-bin) package works too, but the picker manages the npm edition only and doesn't detect an AUR install, so stick to one of the two: a mise-installed `kilo` shadows an AUR one further down `PATH`.
 
 Once you've chosen, `Super + Shift + Ctrl + A` launches the default agent in a dedicated terminal window (or brings up the picker if you haven't chosen yet). You can also launch it straight into a task with `omarchy agent prompt "Review this project"`. Agents launched this way run unattended in their respective don't-stop-to-ask modes, so be ready for them to actually do things! And since agents refuse to remember trust for your home directory, launches from `$HOME` start in `~/Work` instead.
 

--- a/migrations/1789043987.sh
+++ b/migrations/1789043987.sh
@@ -1,0 +1,5 @@
+echo "Install kilo via mise wrapper"
+
+if omarchy-cmd-missing kilo && [[ ! -f $HOME/.local/state/omarchy/preinstalls-removed ]]; then
+  omarchy-mise-install npm:@kilocode/cli kilo
+fi

--- a/test/shell.d/default-agent-test.sh
+++ b/test/shell.d/default-agent-test.sh
@@ -47,6 +47,11 @@ cat >"$mock_bin/opencode" <<'SH'
 printf '%s\0' opencode "$@" >"$OMARCHY_TEST_AGENT_INLINE_LOG"
 SH
 
+cat >"$mock_bin/kilo" <<'SH'
+#!/bin/bash
+printf '%s\0' kilo "$@" >"$OMARCHY_TEST_AGENT_INLINE_LOG"
+SH
+
 cat >"$mock_bin/omarchy-mise-install" <<'SH'
 #!/bin/bash
 printf '%s\n' "$*" >>"$OMARCHY_TEST_STUB_LOG"
@@ -118,6 +123,7 @@ agy_package="antigravity-cli"
 ori_package="github:OpenRouterLabs/ori-releases"
 cursor_agent_package="cursor-agent"
 muse_package="http:muse[url=https://api.meta.ai/muse-launcher.sh,bin=muse,version_list_url=https://api.meta.ai/muse-code/channels/muse-stable,version_json_path=.version]"
+kilo_package="npm:@kilocode/cli"
 
 assert_lazy_stub() {
   local package=$1
@@ -138,6 +144,7 @@ assert_lazy_stub "$crush_package" crush
 assert_lazy_stub "$ori_package" ori
 assert_lazy_stub "$cursor_agent_package" cursor-agent
 assert_lazy_stub "$muse_package" muse
+assert_lazy_stub "$kilo_package" kilo
 pass "custom agent lazy stubs preserve their mise packages"
 
 OMARCHY_TEST_MISSING_COMMAND=cursor-agent source "$ROOT/install/user/mise.sh"
@@ -149,6 +156,8 @@ grep -Fx "$crush_package" "$stub_log" >/dev/null || fail "user setup creates the
 grep -Fx "$ori_package ori" "$stub_log" >/dev/null || fail "user setup creates the Ori lazy stub"
 OMARCHY_TEST_MISSING_COMMAND=muse source "$ROOT/install/user/mise.sh"
 grep -Fx "$muse_package muse" "$stub_log" >/dev/null || fail "user setup creates the Muse lazy stub"
+OMARCHY_TEST_MISSING_COMMAND=kilo source "$ROOT/install/user/mise.sh"
+grep -Fx "$kilo_package kilo" "$stub_log" >/dev/null || fail "user setup creates the Kilo lazy stub"
 pass "user setup creates the custom agent lazy stubs"
 
 : >"$stub_log"
@@ -156,6 +165,7 @@ source "$ROOT/install/user/mise.sh"
 grep -Fx "$cursor_agent_package" "$stub_log" >/dev/null && fail "user setup replaces an existing cursor-agent command"
 pass "user setup keeps an existing Cursor CLI install"
 grep -Fx "$muse_package muse" "$stub_log" >/dev/null && fail "user setup replaces an existing Muse command"
+grep -Fx "$kilo_package kilo" "$stub_log" >/dev/null && fail "user setup replaces an existing kilo command"
 
 : >"$stub_log"
 OMARCHY_TEST_MISSING_COMMAND=muse source "$ROOT/migrations/1788724825.sh" >/dev/null
@@ -170,6 +180,18 @@ OMARCHY_TEST_MISSING_COMMAND=muse source "$ROOT/migrations/1788724825.sh" >/dev/
 rm "$test_home/.local/state/omarchy/preinstalls-removed"
 pass "Muse migration preserves existing installs and the preinstall opt-out"
 
+: >"$stub_log"
+OMARCHY_TEST_MISSING_COMMAND=kilo source "$ROOT/migrations/1789043987.sh" >/dev/null
+grep -Fx "$kilo_package kilo" "$stub_log" >/dev/null || fail "Kilo migration creates its lazy stub"
+: >"$stub_log"
+source "$ROOT/migrations/1789043987.sh" >/dev/null
+[[ ! -s $stub_log ]] || fail "Kilo migration replaces an existing command"
+mkdir -p "$test_home/.local/state/omarchy"
+touch "$test_home/.local/state/omarchy/preinstalls-removed"
+OMARCHY_TEST_MISSING_COMMAND=kilo source "$ROOT/migrations/1789043987.sh" >/dev/null
+[[ ! -s $stub_log ]] || fail "Kilo migration ignores the preinstall opt-out"
+rm "$test_home/.local/state/omarchy/preinstalls-removed"
+pass "Kilo migration preserves existing installs and the preinstall opt-out"
 
 : >"$stub_log"
 source "$ROOT/migrations/1785617047.sh" >/dev/null
@@ -298,9 +320,10 @@ rm -f "$agent_file"
 pass "agent migrations install working wrappers without overriding the preinstall opt-out"
 
 "$ROOT/bin/omarchy-mise-install" "$muse_package" muse
+"$ROOT/bin/omarchy-mise-install" "$kilo_package" kilo
 touch "$test_home/.local/bin/agy" "$test_home/.local/bin/ori"
 omarchy-remove-preinstalls >/dev/null
-for command in agy omp ori grok crush cursor-agent muse; do
+for command in agy omp ori grok crush cursor-agent kilo muse; do
   [[ ! -e $test_home/.local/bin/$command ]] || fail "Remove Preinstalls deletes the $command lazy stub"
 done
 pass "Remove Preinstalls deletes every optional agent lazy stub"
@@ -319,7 +342,12 @@ omarchy-remove-preinstalls >/dev/null
 [[ $("$test_home/.local/bin/muse") == "user-muse" ]] || fail "Remove Preinstalls deletes a user-managed Muse"
 rm "$test_home/.local/bin/muse"
 pass "Remove Preinstalls keeps a user-managed Muse install"
-
+printf '#!/bin/bash\necho user-kilo\n' >"$test_home/.local/bin/kilo"
+chmod +x "$test_home/.local/bin/kilo"
+omarchy-remove-preinstalls >/dev/null
+[[ $("$test_home/.local/bin/kilo") == "user-kilo" ]] || fail "Remove Preinstalls deletes a user-managed kilo"
+rm "$test_home/.local/bin/kilo"
+pass "Remove Preinstalls keeps a user-managed kilo install"
 
 [[ -z $(omarchy-default-agent) ]] || fail "default agent is unset until one is chosen"
 pass "default agent is unset until one is chosen"
@@ -381,6 +409,7 @@ declare -A expected_agents=(
   [gemini-cli]="agy"
   [copilot]="copilot"
   [github-copilot]="copilot"
+  [kilo]="kilo"
   [cursor]="cursor-agent"
   [cursor-agent]="cursor-agent"
   [muse]="muse"
@@ -401,6 +430,7 @@ declare -A expected_packages=(
   [copilot]="copilot"
   [cursor-agent]="$cursor_agent_package"
   [muse]="$muse_package"
+  [kilo]="$kilo_package"
 )
 
 for selection in "${!expected_agents[@]}"; do
@@ -598,6 +628,63 @@ omarchy-default-agent muse
 rm "$test_home/.local/bin/muse"
 pass "selecting a user-installed Muse preserves its launcher"
 
+# kilo follows the shared mise installation path.
+: >"$notification_history"
+: >"$agent_open_log"
+: >"$terminal_log"
+omarchy-default-agent kilo
+mapfile -d '' -t terminal_args <"$terminal_log"
+[[ ${terminal_args[0]} == "omarchy-default-agent" && ${terminal_args[1]} == "--install" && ${terminal_args[2]} == "kilo" ]] ||
+  fail "missing kilo installation opens in a terminal"
+[[ ! -s $notification_history ]] || fail "missing kilo installation skips notifications"
+[[ ! -s $agent_open_log ]] || fail "missing kilo installation waits to open the agent"
+[[ $(omarchy-default-agent) == "muse" ]] || fail "missing kilo installation waits to change the selection"
+
+if OMARCHY_TEST_MISE_FAIL=true omarchy-default-agent --install kilo >"$test_tmp/kilo-failure-output" 2>&1; then
+  fail "missing kilo rejects a failed mise installation"
+fi
+[[ $(omarchy-default-agent) == "muse" ]] || fail "failed kilo installation preserves the current default"
+grep -F "Could not install kilo with mise" "$test_tmp/kilo-failure-output" >/dev/null ||
+  fail "failed kilo installation identifies mise"
+[[ ! -s $agent_open_log ]] || fail "failed kilo installation does not open an agent"
+pass "failed kilo installation preserves the selection"
+
+: >"$mise_log"
+: >"$agent_open_log"
+omarchy-default-agent --install kilo >"$test_tmp/kilo-install-output"
+mapfile -d '' -t mise_args <"$mise_log"
+[[ ${mise_args[0]} == "use" && ${mise_args[1]} == "-g" && ${mise_args[2]} == "$kilo_package" ]] ||
+  fail "visible kilo installation uses its managed npm package through mise"
+[[ $(omarchy-default-agent) == "kilo" ]] || fail "visible kilo installation changes the selection"
+mapfile -d '' -t agent_open_args <"$agent_open_log"
+[[ ${#agent_open_args[@]} == 2 && ${agent_open_args[0]} == "omarchy-agent" && ${agent_open_args[1]} == "--inline" ]] ||
+  fail "newly installed kilo opens in the installation terminal"
+pass "kilo installs visibly through mise and opens directly"
+
+: >"$terminal_log"
+OMARCHY_TEST_AGENT_INSTALLED=true omarchy-default-agent kilo
+[[ ! -s $terminal_log ]] || fail "installed kilo selection skips the terminal"
+mapfile -d '' -t agent_open_args <"$agent_open_log"
+[[ ${#agent_open_args[@]} == 1 && ${agent_open_args[0]} == "omarchy-agent" ]] ||
+  fail "installed kilo opens in a new terminal after selection"
+pass "installed kilo selects and opens directly"
+
+# A kilo the user manages at the wrapper's path is theirs; selecting it installs
+# no second copy through mise and replaces nothing.
+printf '%s\n' pi >"$agent_file"
+printf '#!/bin/bash\necho user-kilo\n' >"$test_home/.local/bin/kilo"
+chmod +x "$test_home/.local/bin/kilo"
+: >"$mise_history"
+: >"$stub_log"
+: >"$terminal_log"
+omarchy-default-agent kilo
+[[ $(omarchy-default-agent) == "kilo" ]] || fail "a user-installed kilo can be selected"
+[[ ! -s $mise_history && ! -s $stub_log && ! -s $terminal_log ]] ||
+  fail "a user-installed kilo skips installation and wrapper creation"
+[[ $("$test_home/.local/bin/kilo") == "user-kilo" ]] || fail "a user-installed kilo is preserved"
+rm "$test_home/.local/bin/kilo"
+pass "selecting a user-installed kilo preserves its launcher"
+
 rm "$mock_bin/omarchy-agent"
 hash -r
 
@@ -643,6 +730,7 @@ assert_bypass() {
 assert_launch pi pi "Review this project"
 assert_launch omp omp --auto-approve -- "Review this project"
 assert_launch opencode opencode --auto --prompt "Review this project"
+assert_launch kilo kilo --auto --prompt "Review this project"
 assert_launch ori ori code --interactive --prompt "Review this project"
 assert_launch claude claude --permission-mode auto -- "Review this project"
 assert_launch codex codex --approve-for-me -- "Review this project"
@@ -668,9 +756,20 @@ assert_launched hermes "binds its literal initial prompt" env -u HERMES_SESSION_
   hermes chat --yolo --tui "--query=$literal_hermes_prompt"
 pass "Hermes receives prompted launches as one literal query argument"
 
+# --prompt takes the next argument whatever it looks like, so a prompt starting
+# with a dash or carrying quotes and shell characters stays prompt text.
+literal_kilo_prompt=$'-- surreal \'single\' "double" !Crash {$(touch must-not-run)}\ntrailing\\ '
+printf '%s\n' "kilo" >"$agent_file"
+( cd "$test_tmp" && omarchy-agent-prompt "$literal_kilo_prompt" )
+[[ ! -e $test_tmp/must-not-run ]] || fail "kilo's prompt text never runs as shell"
+assert_launched kilo "separates prompt text from options" kilo --auto --prompt "$literal_kilo_prompt"
+pass "kilo receives option-like prompts as one literal argument"
+
 assert_bypass pi pi
 assert_bypass omp omp --auto-approve
 assert_bypass opencode opencode --auto
+# kilo shares OpenCode's launch path, so it produces the same argv.
+assert_bypass kilo kilo --auto
 assert_bypass ori ori code
 assert_bypass claude claude --permission-mode auto
 assert_bypass codex codex --approve-for-me
@@ -695,6 +794,17 @@ mapfile -d '' -t inline_args <"$inline_log"
 [[ ${inline_args[*]} == "opencode --auto --prompt Review this project" ]] ||
   fail "inline agent launcher runs in the current terminal"
 pass "inline agent launcher runs in the current terminal"
+
+# The shared OpenCode launch path serves kilo inline as well, proving no other
+# agent's argv moves when the same case block serves two agents.
+printf '%s\n' "kilo" >"$agent_file"
+omarchy-agent-prompt --inline "Review this project"
+mapfile -d '' -t inline_args <"$inline_log"
+[[ ${inline_args[*]} == "kilo --auto --prompt Review this project" ]] ||
+  fail "inline kilo launcher runs in the current terminal"
+pass "inline kilo launcher runs in the current terminal"
+
+printf '%s\n' "opencode" >"$agent_file"
 
 # The prompt route exists so the router can tell a prompt from a subcommand, so
 # cover the public routes and not only the binaries behind them.

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -230,6 +230,7 @@ const expectedAgents = {
   crush: { icon: '󰋑', label: 'Crush' },
   muse: { icon: '󰛤', label: 'Muse Code' },
   'cursor-agent': { icon: '\ue90d', iconFont: 'omarchy', label: 'Cursor CLI' },
+  kilo: { icon: '󰚩', label: 'kilo' },
 
 }
 assert(
@@ -245,11 +246,16 @@ assert(
   }),
   'menu exposes every supported coding agent with its own glyph under Defaults > Agent'
 )
+assert(
+  !defaultById['setup.default.agent.kilo'].aliases.length,
+  'menu lists kilo under its own name only, without aliases'
+)
+assert(!defaultById['install.ai.kilo'], 'menu keeps kilo a default-agent choice rather than an Install > AI entry')
 assertDeepEqual(
   defaultItems
     .filter(item => item.parent === 'setup.default.agent')
     .map(item => item.label),
-  ['Antigravity', 'Claude', 'Codex', 'Copilot', 'Crush', 'Cursor CLI', 'Grok', 'Hermes', 'Muse Code', 'omp', 'OpenClaw', 'OpenCode', 'Ori', 'Pi'],
+  ['Antigravity', 'Claude', 'Codex', 'Copilot', 'Crush', 'Cursor CLI', 'Grok', 'Hermes', 'kilo', 'Muse Code', 'omp', 'OpenClaw', 'OpenCode', 'Ori', 'Pi'],
   'menu sorts coding agents alphabetically'
 )
 const expectedDefaults = {

--- a/test/shell.d/mise-install-test.sh
+++ b/test/shell.d/mise-install-test.sh
@@ -42,6 +42,29 @@ grep -Fqx $'mise\tuse\t-g\t--quiet\tnpm:playwright' "$log" ||
 
 pass "a normal install writes a wrapper that names its package"
 
+# A scoped npm package whose command differs from its name: @kilocode/cli
+# installs the kilo binary, and naming it in the wrapper is what selects it. The
+# log stays empty across stub creation, which is what keeps first provisioning
+# download-free.
+kilo_create_log="$tmpdir/kilo-create.log"
+: >"$kilo_create_log"
+OMARCHY_MISE_TEST_LOG="$kilo_create_log" install_wrapper npm:@kilocode/cli kilo >/dev/null
+[[ ! -s $kilo_create_log ]] ||
+  fail "kilo stub creation performs no mise download" "$(cat "$kilo_create_log")"
+[[ -x $home/.local/bin/kilo ]] ||
+  fail "the kilo install writes an executable wrapper"
+
+kilo_log="$tmpdir/kilo.log"
+: >"$kilo_log"
+OMARCHY_MISE_TEST_LOG="$kilo_log" PATH="$stub_bin:$PATH" \
+  "$home/.local/bin/kilo" stay --together 'two words' >/dev/null
+grep -Fqx $'mise\tuse\t-g\t--quiet\tnpm:@kilocode/cli' "$kilo_log" ||
+  fail "the kilo wrapper asks mise for its npm package" "$(cat "$kilo_log")"
+grep -Fqx $'mise\tx\tnpm:@kilocode/cli\t--\tkilo\tstay\t--together\ttwo words' "$kilo_log" ||
+  fail "the kilo wrapper preserves its arguments" "$(cat "$kilo_log")"
+
+pass "a scoped npm package names its own binary and preserves argv"
+
 # A package name is data. Quoted with %q it reaches mise as one argument
 # instead of being read as shell source when the wrapper runs.
 install_wrapper 'npm:pkg$(touch '"$tmpdir"'/PWNED)end' hostile >/dev/null

--- a/test/shell.d/preinstalls-test.sh
+++ b/test/shell.d/preinstalls-test.sh
@@ -132,3 +132,55 @@ ln -s "$test_home/nowhere/hermes" "$hermes"
 "$ROOT/bin/omarchy-remove-preinstalls" >/dev/null
 [[ -L $hermes ]] || fail "Remove Preinstalls keeps a foreign hermes link"
 pass "Remove Preinstalls keeps a foreign hermes link"
+
+# Only the mise wrapper omarchy-mise-install wrote is a preinstall: the kilo
+# stub line identifies it, and anything else at the same path is the user's,
+# including the configuration and state the runtime keeps elsewhere.
+kilo="$test_home/.local/bin/kilo"
+mkdir -p "$test_home/.kilo"
+printf '%s\n' '{}' >"$test_home/.kilo/tui.json"
+
+"$ROOT/bin/omarchy-mise-install" npm:@kilocode/cli kilo
+"$ROOT/bin/omarchy-remove-preinstalls" >/dev/null
+[[ ! -e $kilo ]] || fail "Remove Preinstalls deletes the Omarchy kilo wrapper"
+[[ -f $test_home/.kilo/tui.json ]] || fail "Remove Preinstalls keeps kilo's configuration and state"
+pass "Remove Preinstalls deletes the Omarchy kilo wrapper and nothing else"
+
+printf '#!/bin/bash\necho user-kilo\n' >"$kilo"
+chmod +x "$kilo"
+"$ROOT/bin/omarchy-remove-preinstalls" >/dev/null
+[[ $("$kilo") == "user-kilo" ]] || fail "Remove Preinstalls keeps a user-managed kilo"
+pass "Remove Preinstalls keeps a user-managed kilo install"
+
+printf '#!/bin/bash\n# replaced: mise use -g --quiet "npm:@kilocode/cli"\nexec /opt/apps/kilo "$@"\n' >"$kilo"
+chmod +x "$kilo"
+"$ROOT/bin/omarchy-remove-preinstalls" >/dev/null
+[[ -x $kilo ]] || fail "Remove Preinstalls keeps a wrapper that merely mentions the kilo package"
+pass "Remove Preinstalls keeps a wrapper that merely mentions the kilo package"
+
+rm -f "$kilo"
+ln -s "$test_home/nowhere/kilo" "$kilo"
+"$ROOT/bin/omarchy-remove-preinstalls" >/dev/null
+[[ -L $kilo ]] || fail "Remove Preinstalls keeps a foreign kilo link"
+rm -f "$kilo"
+pass "Remove Preinstalls keeps a foreign kilo link"
+
+# Restore reaches the mise provisioning script through application refresh, so
+# with the real refresher in place, the stub Remove Preinstalls deleted comes
+# back. mise and the command probes stay mocked, so nothing downloads and no
+# settings change.
+rm -f "$mock_bin/omarchy-refresh-applications"
+printf '#!/bin/bash\nexec "$OMARCHY_TEST_REAL_REFRESH" "$@"\n' >"$mock_bin/omarchy-refresh-applications"
+printf '#!/bin/bash\n[[ $1 == ${OMARCHY_TEST_MISSING_COMMAND:-} ]]\n' >"$mock_bin/omarchy-cmd-missing"
+printf '#!/bin/bash\nexit 0\n' >"$mock_bin/mise"
+chmod +x "$mock_bin/omarchy-refresh-applications" "$mock_bin/omarchy-cmd-missing" "$mock_bin/mise"
+export OMARCHY_TEST_REAL_REFRESH="$ROOT/bin/omarchy-refresh-applications"
+export OMARCHY_PATH="$ROOT"
+export OMARCHY_TEST_MISSING_COMMAND=kilo
+
+"$ROOT/bin/omarchy-install-preinstalls" >/dev/null
+[[ -x $kilo ]] || fail "Install Preinstalls recreates the kilo lazy stub"
+grep -Fq 'mise use -g --quiet "npm:@kilocode/cli"' "$kilo" ||
+  fail "the restored kilo stub selects its npm package"
+[[ ! -f $marker ]] || fail "Install Preinstalls clears the kilo stub's opt-out marker"
+pass "Install Preinstalls recreates the kilo lazy stub through application refresh"


### PR DESCRIPTION
Adds [Kilo](https://kilo.ai/docs/code-with-ai/platforms/cli) (`@kilocode/cli`) as a supported default coding agent, following the existing lazy-installed mise tool pattern.

## Generated changes

- `bin/omarchy-default-agent`: a `kilo` case selecting `agent="kilo"` with the `npm:@kilocode/cli` backend; usage and `omarchy:args` metadata list kilo. No aliases.
- `bin/omarchy-agent`: kilo shares the OpenCode case, launching as `kilo --auto` and `kilo --auto --prompt <prompt>` inline or in the agent terminal. The OpenCode case keeps its exact prior argv.
- `default/omarchy/omarchy-menu.jsonc`: `setup.default.agent.kilo` between Hermes and Muse Code (alphabetical by label), labeled `kilo`, acting on `omarchy-default-agent kilo`, using the existing generic Agent glyph U+F06A9 — not a new icon-font glyph. No `when`/aliases, and no duplicate Install > AI entry.
- `install/user/mise.sh`: `omarchy-cmd-missing kilo && omarchy-mise-install npm:@kilocode/cli kilo`, keeping a user-managed launcher (e.g. `kilo-bin` from the AUR) safe across re-provisions, like Cursor's guard.
- `migrations/1789043987.sh` (0644, no shebang): a Muse-shaped migration — creates the same stub only when `kilo` is missing and the preinstalls opt-out marker is absent, then leaves both alone.
- `bin/omarchy-remove-preinstalls`: deletes `~/.local/bin/kilo` only when a nonsymlink wrapper's generated `mise use -g` line names `"npm:@kilocode/cli"`. Symlinks, mention-only wrappers, and other executables survive, as does kilo's own configuration and state.
- `manual/17-ai.md`: table row plus a Defaults section paragraph covering `omarchy default agent kilo`, the npm backend, `/connect` login, `kilo-bin` on the AUR, and the shadowing caveat recommending one installation method.

Agent usage collectors, the agents panel, quick console, first-run picker, and crash diagnosis carry over through the shared agent path with no list edits on my part.

## Verification

Validated on this machine (macOS, only Bash 3.2 available):

- `test/shell.d/menu-test.sh` — full pass, including the kilo entry assertions, ordering, alias-free and no-Install-entry checks, and the icon-font glyph check.
- `test/shell.d/mise-install-test.sh` — full pass, including the new scoped-npm kilo case. The local sandbox blocks `mktemp`, so it ran with a workspace-backed mktemp shim on PATH — the only environmental deviation in that run.
- A 41-assertion behavior probe mirroring the suites' assertions passed under Bash 3.2 with a temp HOME and mocked command binaries: wrapper generation and mise-invocation argv, cold selection, failed install (nonzero exit, message names mise, selection preserved), inline open on success, installed-selection and user-owned-launcher flows, bypass/prompted/literal leading-dash argv, unchanged OpenCode argv through the shared case, migration create/preserve/opt-out, user-setup provisioning create/preserve, remove-preinstalls delete-vs-preserve for all four wrapper shapes, and the usage line.

Not runnable here — this machine has no Bash 5, no container/VM tooling, and no sibling ISO checkout:

- `test/shell.d/default-agent-test.sh` and `test/shell.d/preinstalls-test.sh` — require Bash ≥ 4.4 (`declare -A`, `mapfile -d ''`); with the extensions in this PR, `./test/shell` as a whole needs that environment too.
- `./test/cli` — its runner uses `local -n` namerefs (Bash ≥ 4.3).
- VM-based graphical acceptance and real-package runtime checks: the actual `mise use` download, second-run `--version` latency, third-party `kilo --help`, `/connect`, and skill-file discovery by the CLI at runtime.
