### PR TITLE
Tint the Claude Code diff panel with the Omarchy theme

### DIFF
--- a/default/themed/claude.json.tpl
+++ b/default/themed/claude.json.tpl
@@ -32,6 +32,7 @@
     "diffRemovedWord": "{{ mix background red 32% }}",
     "userMessageBackground": "{{ mix background foreground 6% }}",
     "userMessageBackgroundHover": "{{ mix background foreground 10% }}",
+    "composerSidebarBackground": "{{ mix background foreground 5% }}",
     "bashMessageBackgroundColor": "{{ mix background foreground 6% }}",
     "memoryBackgroundColor": "{{ mix background foreground 6% }}",
     "selectionBg": "{{ selection_background }}",

--- a/test/cli
+++ b/test/cli
@@ -494,7 +494,7 @@ HOME="$PI_TMPDIR" "$ROOT/bin/omarchy-theme-set-pi" --activate
 jq -e '.theme == "omarchy-system" and .model == "keep-me"' "$PI_TMPDIR/.pi/agent/settings.json" >/dev/null
 pass "pi theme activation preserves existing settings"
 
-jq -e '.name == "Omarchy" and .base == "light" and .overrides.text == "#ffffff"' "$NEXT_THEME/claude.json" >/dev/null
+jq -e '.name == "Omarchy" and .base == "light" and .overrides.text == "#ffffff" and .overrides.composerSidebarBackground == "#0d0d0d"' "$NEXT_THEME/claude.json" >/dev/null
 pass "claude theme template is generated from standard themed templates"
 cp "$NEXT_THEME/claude.json" "$CURRENT_THEME/claude.json"
 


### PR DESCRIPTION
Claude Code 2.1.260 added a diff panel that opens beside the conversation in fullscreen mode. Its background comes from a new `composerSidebarBackground` theme key, which the Omarchy template doesn't set, so the panel renders in Claude's built-in gray next to an otherwise themed session.

This renders the key from the theme palette at a 5% background->foreground mix, just under the 6% used for user-message bubbles, matching Claude's own ordering where the sidebar sits darker than message backgrounds.

Claude Code drops override keys it doesn't recognise, so older versions are unaffected. The CLI test's Claude template assertion now covers the key.

Screenshots below are using Retro 82 as the Omarchy theme:

### Before:

<img width="2498" height="978" alt="screenshot-2026-09-10_13-49-21" src="https://github.com/user-attachments/assets/1005e182-b9ee-4136-9cb9-e4e6ba570d96" />

### After:

<img width="2498" height="1010" alt="screenshot-2026-09-10_13-52-18" src="https://github.com/user-attachments/assets/9fa9ce68-44e9-4ba3-bb2f-2ef01daebffb" />
