### PR TITLE
Reject disabling unknown plugin IDs in PluginRegistry

### DIFF
--- a/shell/services/PluginRegistry.qml
+++ b/shell/services/PluginRegistry.qml
@@ -479,7 +479,9 @@ QtObject {
       return false
     }
     var manifest = installedPlugins[key]
-    if (value && !manifest) {
+    var config = shellConfigProvider ? shellConfigProvider() : null
+    var location = findEntryLocation(config, key)
+    if (!manifest && (!location.found || value)) {
       console.warn("PluginRegistry.setEnabled: unknown plugin " + key)
       return false
     }

--- a/test/shell.d/fixtures/plugin-registry/shell.qml
+++ b/test/shell.d/fixtures/plugin-registry/shell.qml
@@ -162,6 +162,8 @@ ShellRoot {
     root.assertTrue(!registry.isEnabled("third.bar"), "third-party bar options start inactive")
     root.assertTrue(!registry.isEnabled("third.panel"), "third-party plugins start disabled")
     root.assertEqual(registry.resolveEnabledId("omarchy.first-widget"), "omarchy.first-widget", "inactive clones do not replace their source id")
+    root.assertTrue(!registry.setEnabled("does.not.exist", true), "enabling an unknown plugin is refused")
+    root.assertTrue(!registry.setEnabled("does.not.exist", false), "disabling an unknown plugin is refused")
 
     registry.setEnabled("third.bar", true)
     root.assertEqual(root.config.bar.id, "third.bar", "enabling third-party bar options writes bar id")
@@ -176,6 +178,10 @@ ShellRoot {
     root.assertTrue(registry.isEnabled("third.panel"), "enabled third-party panels are found")
     registry.setEnabled("third.panel", false)
     root.assertDeepEqual(root.config.plugins, [], "disabling third-party panels removes plugins array entry")
+    root.config.plugins = [{ id: "ghost.panel" }]
+    root.assertTrue(registry.setEnabled("ghost.panel", false), "disabling an uninstalled plugin cleans up config")
+    root.assertDeepEqual(root.config.plugins, [], "uninstalled plugin entry is removed from config")
+    root.assertTrue(!registry.setEnabled("ghost.panel", false), "disabling a cleaned up uninstalled plugin is refused")
 
     registry.setEnabled("third.widget", true)
     root.assertDeepEqual(root.config.bar.layout.left, [{ id: "third.widget" }], "enabling bar widgets uses their default section")

--- a/test/shell.d/plugin-disable-test.sh
+++ b/test/shell.d/plugin-disable-test.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+mkdir -p "$TMPDIR/home" "$TMPDIR/bin"
+calls="$TMPDIR/calls"
+
+cat >"$TMPDIR/bin/omarchy-shell" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$OMARCHY_TEST_CALLS"
+if [[ ${3:-} == "does.not.exist" ]]; then
+  printf 'unknown\n'
+else
+  printf 'ok\n'
+fi
+SH
+chmod +x "$TMPDIR/bin/omarchy-shell"
+
+run_disable() {
+  HOME="$TMPDIR/home" \
+    OMARCHY_PATH="$ROOT" \
+    OMARCHY_TEST_CALLS="$calls" \
+    PATH="$TMPDIR/bin:$ROOT/bin:$PATH" \
+    omarchy-plugin-disable "$@"
+}
+
+output=$(run_disable acme.weather)
+[[ $output == "Disabled acme.weather" ]] || fail "plugin disable did not report success" "$output"
+grep -Fqx 'shell setPluginEnabled acme.weather false' "$calls" ||
+  fail "plugin disable did not call setPluginEnabled with false"
+pass "plugin disable forwards disable mutation to shell"
+
+if output=$(run_disable does.not.exist 2>&1); then
+  fail "plugin disable should fail for unknown plugin id" "$output"
+fi
+[[ $output == *"plugin 'does.not.exist' is not known"* ]] ||
+  fail "plugin disable did not report unknown plugin error" "$output"
+pass "plugin disable fails when plugin is not known"
+
+if output=$(run_disable 2>&1); then
+  fail "plugin disable should fail when plugin id is omitted" "$output"
+fi
+[[ $output == *"plugin id is required"* ]] ||
+  fail "plugin disable did not report missing id error" "$output"
+pass "plugin disable requires a plugin id"
+
+output=$(run_disable --help)
+[[ $output == *"Usage: omarchy plugin disable <id>"* ]] ||
+  fail "plugin disable --help did not print usage" "$output"
+pass "plugin disable --help prints usage"


### PR DESCRIPTION
## What

Guard `PluginRegistry.setEnabled` against plugin IDs that have neither an installed manifest nor an entry in the active shell configuration when disabling.

## Why

`PluginRegistry.setEnabled` previously only checked for a manifest when enabling (`value == true`). When disabling a plugin ID with a typo or one that does not exist, the function skipped the guard, made no modifications in `shellConfigMutator`, but still incremented `registryRevision`, emitted `pluginsChanged`, and returned `true`.

As a result, `shell.qml`'s `setPluginEnabled` returned `"ok"` instead of `"unknown"`, and `omarchy plugin disable <id>` falsely reported success.

With this check, disabling an ID with neither a manifest on disk nor a location in `shell.json` returns `false`, while disabling an uninstalled ghost plugin that is still listed in `shell.json` continues to clean up the configuration entry.

## Testing

- Added `test/shell.d/plugin-disable-test.sh` covering `omarchy plugin disable` success, unknown plugin failure, omitted argument, and `--help`.
- Added contract assertions to `test/shell.d/fixtures/plugin-registry/shell.qml` for unknown plugin disable refusal and uninstalled ghost entry cleanup. Verified that reverting the fix causes contract test failure (sabotage check).
- Validated with `qmllint shell/services/PluginRegistry.qml` and `bash -n test/shell.d/plugin-disable-test.sh`.
- Ran related test suites: `plugin-registry-contract-test.sh`, `plugin-enable-test.sh`, `plugin-clone-test.sh`, `plugins-test.sh`, `plugin-add-test.sh`, `plugin-validate-test.sh`, `menu-plugin-test.sh`, `bar-test.sh`, and `./test/cli`.
- Verified in the Omarchy-in-Omarchy development environment (`omavm`):
  - Reproduced the original bug on a clean boot from snapshot `fresh`: `omarchy plugin disable totally.made.up` exited 0 and printed `Disabled totally.made.up`, and `omarchy-shell shell setPluginEnabled totally.made.up false` answered `ok`.
  - Pushed the candidate branch code to `/usr/share/omarchy/shell/services/PluginRegistry.qml` and restarted the shell.
  - Verified that `omarchy plugin disable totally.made.up` now exits 1 with `plugin 'totally.made.up' is not known; run: omarchy-shell shell rescanPlugins`, and raw IPC returns `unknown`.
  - Verified normal disable and re-enable of real installed plugins (`omarchy.agents`).
  - Verified ghost plugin cleanup: injecting an uninstalled plugin into `shell.json` is cleaned up on the first disable call, and subsequent calls correctly fail with `plugin is not known`.

## Related issue

Fixes #11119