### PR TITLE
Overlay only the fields a menu extension declares

### DIFF
--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -10,6 +10,10 @@ function normalizeAliases(value) {
   return []
 }
 
+function kindFor(value) {
+  return value.action ? "action" : (value.target ? "link" : "menu")
+}
+
 function normalizeItem(id, raw) {
   var value = raw || {}
   var aliases = normalizeAliases(value.aliases)
@@ -18,9 +22,15 @@ function normalizeItem(id, raw) {
     parent = id.indexOf(".") >= 0 ? id.split(".").slice(0, -1).join(".") : "root"
   if (id === "root") parent = ""
 
-  var kind = value.action ? "action" : (value.target ? "link" : "menu")
+  var kind = kindFor(value)
+
+  // Every field below is materialized with a default, so an overlay onto a
+  // shipped row has to know which of them the author actually wrote. Without
+  // that, a one-field override carries the other thirteen defaults with it.
+  var declared = Object.keys(value)
 
   return {
+    declared: declared,
     id: id,
     parent: parent,
     kind: kind,
@@ -73,11 +83,23 @@ function mergeMenuSources(defaultItems, userItems) {
     for (var i = 0; i < src.length; i++) {
       var entry = src[i]
       if (!entry || !entry.id) continue
-      if (!nextItems[entry.id]) nextOrder.push(entry.id)
-      var prior = nextItems[entry.id] || {}
+      var prior = nextItems[entry.id]
+      if (!prior) {
+        nextOrder.push(entry.id)
+        nextItems[entry.id] = entry
+        continue
+      }
+
+      // Reusing a shipped id overlays only the fields the author declared, so
+      // retitling a row keeps its action and icon. kind is derived, so it is
+      // recomputed from whatever action or target survived the overlay.
       var merged = {}
       for (var k in prior) merged[k] = prior[k]
-      for (var k2 in entry) merged[k2] = entry[k2]
+      var declared = entry.declared || []
+      for (var d = 0; d < declared.length; d++) {
+        if (declared[d] in entry) merged[declared[d]] = entry[declared[d]]
+      }
+      merged.kind = kindFor(merged)
       merged.id = entry.id
       nextItems[entry.id] = merged
     }
@@ -496,6 +518,7 @@ if (typeof module !== "undefined") {
     guardScript: guardScript,
     stripJsonc: stripJsonc,
     normalizeAliases: normalizeAliases,
+    kindFor: kindFor,
     normalizeItem: normalizeItem,
     parseMenuJsonc: parseMenuJsonc,
     mergeMenuSources: mergeMenuSources,

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -30,6 +30,7 @@ assertEqual(parsed.length, 3, 'menu parses JSONC with comments and trailing comm
 assertDeepEqual(
   parsed.find(item => item.id === 'style.theme'),
   {
+    declared: ['label', 'aliases', 'description', 'action'],
     id: 'style.theme',
     parent: 'style',
     kind: 'action',
@@ -57,6 +58,19 @@ const merged = menu.mergeMenuSources(parsed, user)
 assertEqual(merged.items['style.theme'].label, 'Theme picker', 'menu user entries override default entries')
 assertEqual(merged.items['style.theme'].order, 2, 'menu preserves original order on override')
 assert(merged.items.root, 'menu injects root when merging sources')
+
+// The override above declares every field it asserts. An extension that
+// retitles or re-icons a shipped row declares one, and the rest of that row
+// has to survive — docs/menu.md and the shipped sample extension both say so.
+const partial = menu.mergeMenuSources(parsed, [menu.normalizeItem('style.theme', { label: 'Just the label' })])
+assertEqual(partial.items['style.theme'].label, 'Just the label', 'menu applies a one-field override')
+assertEqual(partial.items['style.theme'].action, 'omarchy-theme-set', 'menu keeps the shipped action under a one-field override')
+assertEqual(partial.items['style.theme'].kind, 'action', 'menu keeps a one-field override actionable')
+assertDeepEqual(partial.items['style.theme'].aliases, ['theme'], 'menu keeps shipped aliases under a one-field override')
+
+// kind is derived, so it has to follow whatever action survived the overlay.
+const unactioned = menu.mergeMenuSources(parsed, [menu.normalizeItem('style.theme', { action: '' })])
+assertEqual(unactioned.items['style.theme'].kind, 'menu', 'menu re-derives kind when an override clears the action')
 
 assertEqual(menu.slugify('Power Saver!'), 'power-saver', 'menu slugifies provider rows')
 assertEqual(menu.pathFor(merged.items, 'style.theme'), 'Style › Theme picker', 'menu builds item paths')


### PR DESCRIPTION
`docs/menu.md` and the shipped sample extension both promise that reusing a shipped id replaces only the fields you declare, so an extension can retitle or re-icon a row without re-declaring its action. `normalizeItem` materializes every field with a default before `mergeMenuSources` overlays the entry, so a one-field override carried the other thirteen defaults with it.

The documented example is enough to reproduce it. With `~/.config/omarchy/extensions/omarchy-menu.jsonc` containing `{"items": {"about": {"icon": "X"}}}`:

```
shipped   label="About" kind=action action="omarchy-launch-about" icon=""   visible=true
before    label="about" kind=menu   action=""                     icon="X"  visible=false
after     label="About" kind=action action="omarchy-launch-about" icon="X"  visible=true
```

The row lost its action, its label fell back to the bare id, it became a childless submenu, and `isVisible` then dropped it from the menu entirely.

`normalizeItem` now records which keys the author wrote and `mergeMenuSources` overlays only those, re-deriving `kind` from whatever `action` or `target` survived. A new id declared only in the extension is still taken whole, and merging with no extension leaves the shipped tree identical.

`mergeAppRows` and `swapProviderRows` replace whole rows rather than overlaying fields, so they were not affected.

The existing `menu normalizes parsed items` assertion pins the whole normalized item, so it gains the new key. The added assertions fail on `quattro` and pass with the change; `./test/shell` and `./test/cli` show no other difference from the branch point.
