### PR TITLE
Place bar widgets on the bar when listed in plugins[]

### DIFF
--- a/shell/services/PluginRegistry.qml
+++ b/shell/services/PluginRegistry.qml
@@ -188,7 +188,7 @@ QtObject {
   // cannot be locked out of the shell by taking its button off the bar.
   function inBar(id) {
     var config = shellConfigProvider ? shellConfigProvider() : null
-    return findEntryLocation(config, id).kind === "bar"
+    return findBarLocation(config, id, "").found
   }
 
   function defaultBarWidgetSection(manifest) {
@@ -411,6 +411,15 @@ QtObject {
     config.disabledPlugins.push(id)
   }
 
+  function removePluginEntry(config, id) {
+    if (!Util.isPlainObject(config) || !Array.isArray(config.plugins)) return
+    var key = Util.canonicalWidgetId(String(id))
+    for (var j = config.plugins.length - 1; j >= 0; j--) {
+      if (config.plugins[j] && Util.canonicalWidgetId(config.plugins[j].id) === key)
+        config.plugins.splice(j, 1)
+    }
+  }
+
   function cloneShouldRestoreSource(config, id) {
     return Array.isArray(config.cloneSourceRestores) && config.cloneSourceRestores.indexOf(id) !== -1
   }
@@ -520,23 +529,27 @@ QtObject {
 
       var isFirstParty = manifest && manifest.__isFirstParty
       var location = findEntryLocation(config, key)
+      var barLocation = isBarWidget ? findBarLocation(config, key, "") : { found: false }
 
       if (value) {
         removeDisabled(config, key)
         var entry = { id: key }
         var insertedWithPlacement = false
-        if (!location.found && isBarWidget) {
-          var sourceLocation = clonedFrom ? findEntryLocation(config, clonedFrom) : { found: false }
-          if (sourceLocation.kind === "bar") {
-            var sourceEntry = config.bar.layout[sourceLocation.section][sourceLocation.index]
-            var replacement = Util.isPlainObject(sourceEntry) ? Util.cloneJson(sourceEntry) : entry
-            replacement.id = key
-            config.bar.layout[sourceLocation.section][sourceLocation.index] = replacement
-          } else {
-            var section = defaultBarWidgetSection(manifest)
-            var target = barTarget(config, placement || {}, section)
-            config.bar.layout[target.section].splice(target.index, 0, entry)
-            insertedWithPlacement = true
+        if (isBarWidget) {
+          removePluginEntry(config, key)
+          if (!barLocation.found) {
+            var sourceLocation = clonedFrom ? findBarLocation(config, clonedFrom, "") : { found: false }
+            if (sourceLocation.found) {
+              var sourceEntry = config.bar.layout[sourceLocation.section][sourceLocation.index]
+              var replacement = Util.isPlainObject(sourceEntry) ? Util.cloneJson(sourceEntry) : entry
+              replacement.id = key
+              config.bar.layout[sourceLocation.section][sourceLocation.index] = replacement
+            } else {
+              var section = defaultBarWidgetSection(manifest)
+              var target = barTarget(config, placement || {}, section)
+              config.bar.layout[target.section].splice(target.index, 0, entry)
+              insertedWithPlacement = true
+            }
           }
         } else if (!location.found && !isFirstParty) {
           config.plugins.push(entry)
@@ -555,6 +568,7 @@ QtObject {
       if (clonedFrom) restoreCloneSource(config, key, clonedFrom)
       else if (location.kind === "bar") config.bar.layout[location.section].splice(location.index, 1)
       else if (location.kind === "plugin") config.plugins.splice(location.index, 1)
+      if (isBarWidget) removePluginEntry(config, key)
 
       // Dropping the layout entry is the whole story for a widget. Anything
       // else built-in loads by default, so switching it off has to be stated.

--- a/test/shell.d/fixtures/plugin-registry/shell.qml
+++ b/test/shell.d/fixtures/plugin-registry/shell.qml
@@ -185,6 +185,38 @@ ShellRoot {
 
     root.config = {
       version: 1,
+      bar: { layout: { left: [], center: [], right: [] } },
+      plugins: [{ id: "third.widget" }]
+    }
+    registry.setEnabled("third.widget", true)
+    root.assertDeepEqual(root.config.bar.layout.left, [{ id: "third.widget" }], "enabling a bar widget listed in plugins[] places it in the bar")
+    root.assertDeepEqual(root.config.plugins, [], "enabling a bar widget listed in plugins[] prunes it from plugins array")
+    root.assertTrue(registry.inBar("third.widget"), "enabled bar widget listed in plugins[] is reported inBar")
+    root.assertTrue(registry.isEnabled("third.widget"), "enabled bar widget listed in plugins[] is reported isEnabled")
+
+    root.config = {
+      version: 1,
+      bar: { layout: { left: [], center: [], right: [] } },
+      plugins: [{ id: "third.right-widget" }]
+    }
+    root.assertEqual(registry.putBarWidget("third.right-widget", {}), "", "put accepts a bar widget listed in plugins[]")
+    root.assertDeepEqual(root.config.bar.layout.right, [{ id: "third.right-widget" }], "put places a bar widget listed in plugins[]")
+    root.assertDeepEqual(root.config.plugins, [], "put prunes a placed bar widget from plugins array")
+    root.assertTrue(registry.inBar("third.right-widget"), "put bar widget listed in plugins[] is reported inBar")
+
+    root.config = {
+      version: 1,
+      bar: { layout: { left: [{ id: "third.widget" }], center: [], right: [] } },
+      plugins: [{ id: "third.widget" }]
+    }
+    registry.setEnabled("third.widget", false)
+    root.assertDeepEqual(root.config.bar.layout.left, [], "disabling a bar widget removes it from layout")
+    root.assertDeepEqual(root.config.plugins, [], "disabling a bar widget prunes any stray entry from plugins array")
+    root.assertTrue(!registry.inBar("third.widget"), "disabled bar widget is not inBar")
+    root.assertTrue(!registry.isEnabled("third.widget"), "disabled bar widget is not isEnabled")
+
+    root.config = {
+      version: 1,
       bar: {
         layout: {
           left: [{ id: "omarchy.workspaces" }, { id: "omarchy.menu" }],


### PR DESCRIPTION
## What

Place bar widgets on the bar when enabling or putting them, even if their ID is already listed in `plugins[]` in `shell.json`, and prune redundant/stray entries from `plugins[]`. Also check `findBarLocation` directly in `PluginRegistry.inBar()`.

## Why

In `PluginRegistry.setEnabled()`, whether to place a bar widget into `config.bar.layout` was guarded by `!location.found && isBarWidget`, where `location` came from `findEntryLocation(config, key)`.

Because `findEntryLocation` searches both `bar.layout` and `plugins[]`, any bar widget whose ID was already present in `plugins[]` (e.g., third-party plugins with `kinds: ["service", "bar-widget"]`, or manual config edits) reported `location.found === true`. As a result:
- The bar placement branch was skipped entirely.
- Neither `bar.layout` nor `plugins[]` was updated.
- `setEnabled` returned `true`, causing `omarchy plugin enable <id>` and `omarchy bar put <id>` to report success.
- `shell.qml`'s `listPlugins` checks `inBar(id)` for bar widgets, which evaluates `findEntryLocation(config, id).kind === "bar"`. Because the widget was not in `bar.layout`, `inBar(id)` returned `false`.
- The CLI reported success, but the widget was never placed on the bar, `shell.json` remained unchanged, and `listPlugins` continued reporting the plugin as disabled.

By testing `findBarLocation(config, key, "").found` for bar widgets in `setEnabled`, bar widgets are placed onto the bar regardless of whether a stray entry exists in `plugins[]`. Any stray entry in `plugins[]` is pruned upon placement or disable to keep configuration clean. In addition, `inBar()` now consults `findBarLocation(config, id, "").found` directly instead of running a compound entry lookup.

## Testing

- Added contract test cases in `test/shell.d/fixtures/plugin-registry/shell.qml` covering:
  - Enabling a bar widget listed in `plugins[]` (places it in `bar.layout.left`, prunes from `plugins[]`, reports `inBar: true` and `isEnabled: true`).
  - Putting a bar widget listed in `plugins[]` via `putBarWidget` (places it in `bar.layout.right`, prunes from `plugins[]`, reports `inBar: true`).
  - Disabling a bar widget present in both `bar.layout` and `plugins[]` (removes from layout and prunes stray `plugins[]` entry, reports `inBar: false` and `isEnabled: false`).
- Executed sabotage verification: confirmed test failure prior to fix implementation, and clean pass (`ok - plugin registry contract checks pass`) with fix applied.
- Validated with `qmllint shell/services/PluginRegistry.qml` (clean, 0 warnings/errors).
- Ran full test suites:
  - `bash test/shell.d/plugin-registry-contract-test.sh`
  - `bash test/shell.d/plugin-enable-test.sh`
  - `bash test/shell.d/plugin-validate-test.sh`
  - `bash test/shell.d/plugin-clone-test.sh`
  - `bash test/shell.d/plugin-add-test.sh`
  - `bash test/shell.d/plugin-auth-boundary-test.sh`
  - `bash test/shell.d/plugins-test.sh`
  - `bash test/shell.d/menu-plugin-test.sh`
  - `bash test/shell.d/bar-test.sh`
  - `bash test/shell.d/bar-widget-contract-test.sh`
  - `./test/cli`
- Tested in the Omarchy-in-Omarchy disposable VM (`omavm`):
  - Reproduced the exact issue on a clean boot from `fresh`: with `agx.screen-time` in `plugins[]`, `omarchy plugin enable` and `omarchy bar put` printed success, but the widget was omitted from `bar.layout`, `shell.json` was unedited, and `listPlugins` reported `enabled: false`.
  - Pushed updated `PluginRegistry.qml` to `/usr/share/omarchy/shell/services/PluginRegistry.qml` and restarted the shell.
  - Verified `omarchy plugin enable agx.screen-time` placed the widget into `bar.layout.right`, pruned `plugins[]`, and `listPlugins` reported `enabled: true`.
  - Verified `omarchy bar put omaconnect --section right` placed the widget into `bar.layout.right` and pruned `plugins[]`.
  - Verified disabling pruned the widget cleanly from `bar.layout` and `plugins[]`.
  - Captured and inspected VM screen (`omavm shot`) verifying UI stability.

## Related issue

Fixes #11062