### PR TITLE
Add Axon as a default coding agent

### DIFF
--- a/bin/omarchy-agent
+++ b/bin/omarchy-agent
@@ -53,7 +53,12 @@ fi
 
 # Agents launched from the keybinding or menu run unattended, so each one starts
 # with its own spelling of "don't stop to ask". Pi and Ori have none to skip.
+# Axon uses its shipped agent's own permission policy.
 case "$agent" in
+axon)
+  command=(axon @axon/zeno)
+  [[ -n ${prompt:-} ]] && command+=(-p "$prompt")
+  ;;
 opencode)
   command=(opencode --auto)
   [[ -n ${prompt:-} ]] && command+=(--prompt "$prompt")

--- a/bin/omarchy-default-agent
+++ b/bin/omarchy-default-agent
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # omarchy:summary=Set and launch the default coding agent
-# omarchy:args=[pi|omp|opencode|ori|claude|codex|grok|openclaw|agy|hermes|copilot|crush|cursor-agent|muse]
+# omarchy:args=[pi|omp|opencode|ori|claude|codex|grok|openclaw|agy|hermes|copilot|crush|cursor-agent|muse|axon]
 # omarchy:examples=omarchy default agent | omarchy default agent codex | omarchy default agent claude
 
 installing=false
@@ -29,6 +29,7 @@ omp | oh-my-pi) agent="omp"; name="Oh My Pi"; agent_package="github:can1357/oh-m
 opencode | open-code) agent="opencode"; name="OpenCode" ;;
 ori | openrouter) agent="ori"; name="Ori"; agent_package="github:OpenRouterLabs/ori-releases" ;;
 claude | claude-code) agent="claude"; name="Claude Code" ;;
+axon) agent="axon"; name="Axon"; agent_installer="omarchy-install-axon-cli" ;;
 codex) agent="codex"; name="Codex" ;;
 crush) agent="crush"; name="Crush" ;;
 grok) agent="grok"; name="Grok"; agent_package="npm:@xai-official/grok" ;;
@@ -43,7 +44,7 @@ muse | muse-code | musecode)
   ;;
 cursor | cursor-agent) agent="cursor-agent"; name="Cursor CLI" ;;
 *)
-  echo "Usage: omarchy-default-agent <pi|omp|opencode|ori|claude|codex|grok|openclaw|agy|hermes|copilot|crush|cursor-agent|muse>"
+  echo "Usage: omarchy-default-agent <pi|omp|opencode|ori|claude|codex|grok|openclaw|agy|hermes|copilot|crush|cursor-agent|muse|axon>"
   exit 1
   ;;
 esac

--- a/bin/omarchy-install-axon-cli
+++ b/bin/omarchy-install-axon-cli
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+# omarchy:summary=Ensure the Axon CLI is installed for the default agent
+# omarchy:args=[--check|--now]
+
+set -euo pipefail
+
+if (( $# > 1 )) || [[ ${1---now} != "--check" && ${1---now} != "--now" ]]; then
+  echo "Usage: omarchy-install-axon-cli [--check|--now]" >&2
+  exit 1
+fi
+
+# Disable implicit installs in mise shims, including probes. Third-party
+# commands can still have their own side effects when asked for --version.
+export MISE_AUTO_INSTALL=0 MISE_EXEC_AUTO_INSTALL=0 MISE_NOT_FOUND_AUTO_INSTALL=0
+
+cold_wrapper() {
+  # omarchy-mise-install writes a shell script. Mise shims are compiled
+  # executables, so searching their binary contents can produce false matches.
+  [[ $(head -c 2 -- "$1" 2>/dev/null) == '#!' ]] &&
+    grep -q '^mise use -g' "$1" 2>/dev/null
+}
+
+mise_shim() {
+  [[ $1 == "${XDG_DATA_HOME:-$HOME/.local/share}/mise/shims/"* ]]
+}
+
+working() {
+  ! cold_wrapper "$1" && timeout 15 "$1" --version >/dev/null 2>&1
+}
+
+refuse() {
+  echo "$*" >&2
+  exit 1
+}
+
+axon_path=$(omarchy-cmd-present axon && type -P axon || true)
+if [[ -n $axon_path ]]; then
+  if working "$axon_path"; then
+    exit 0
+  fi
+  # A mise shim is just the dispatcher: a missing/failed target is repaired
+  # through mise below. Anything else is user-owned and must not be shadowed.
+  mise_shim "$axon_path" ||
+    refuse "Existing Axon command is not runnable (or is a cold mise wrapper); repair it before installing: $axon_path"
+fi
+
+[[ ${1---now} == "--check" ]] && exit 1
+
+bun_path=$(omarchy-cmd-present bun && type -P bun || true)
+if [[ -n $bun_path ]]; then
+  if ! working "$bun_path" && ! mise_shim "$bun_path"; then
+    refuse "Existing Bun command is not runnable (or is a cold mise wrapper); repair it before installing: $bun_path"
+  fi
+fi
+if [[ -z $bun_path ]] || ! working "$bun_path"; then
+  # ls includes uninstalled configured versions and unselected cached versions.
+  # Only records with a source represent a selection. Fail closed on errors.
+  selections=$(mise ls --global --json) || refuse "Could not inspect mise selections."
+  bun_selected=$(jq -er '
+    if type != "object" then error("Unexpected mise ls shape")
+    else (.bun // []) |
+      if type != "array" then error("Unexpected Bun records")
+      else any(.[]; .source != null) end
+    end | tostring
+  ' <<<"$selections") || refuse "Could not inspect configured Bun."
+  [[ $bun_selected == "false" ]] ||
+    refuse "Bun is configured in mise but is not on PATH; install/activate that selection before installing Axon."
+  mise use -g --fuzzy bun@latest
+  bun_path=$(omarchy-cmd-present bun && type -P bun || true)
+  if [[ -z $bun_path ]] || ! working "$bun_path"; then
+    refuse "Bun installed but is not runnable on PATH."
+  fi
+fi
+
+# Match Omarchy's lazy installers and updater: use current releases rather
+# than falling back to an older package during mise's release cooldown.
+export MISE_MINIMUM_RELEASE_AGE=0
+
+# The default npm backend does not require a globally selected Node/npm.
+# Never change a user's runtime selection to satisfy Axon's requirements.
+mise use -g --fuzzy npm:@arcforge/axon@latest
+axon_path=$(omarchy-cmd-present axon && type -P axon || true)
+if [[ -z $axon_path ]] || ! working "$axon_path"; then
+  refuse "Axon installed but is not runnable on PATH; check runtime compatibility."
+fi

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -136,6 +136,7 @@
   "setup.default": {"icon":"","label":"Defaults","aliases":["default","defaults"]},
   "setup.default.agent": {"icon":"󰚩","label":"Agent","title":"Default Agent"},
   "setup.default.agent.agy": {"icon":"󰫢","label":"Antigravity","checked":"[[ \"$(omarchy-default-agent)\" == \"agy\" ]]","action":"omarchy-default-agent agy"},
+  "setup.default.agent.axon": {"icon":"»","label":"Axon","checked":"[[ \"$(omarchy-default-agent)\" == \"axon\" ]]","action":"omarchy-default-agent axon"},
   "setup.default.agent.claude": {"icon":"󰛄","label":"Claude","checked":"[[ \"$(omarchy-default-agent)\" == \"claude\" ]]","action":"omarchy-default-agent claude"},
   "setup.default.agent.codex": {"icon":"","iconFont":"omarchy","label":"Codex","checked":"[[ \"$(omarchy-default-agent)\" == \"codex\" ]]","action":"omarchy-default-agent codex"},
   "setup.default.agent.copilot": {"icon":"","label":"Copilot","checked":"[[ \"$(omarchy-default-agent)\" == \"copilot\" ]]","action":"omarchy-default-agent copilot"},

--- a/manual/17-ai.md
+++ b/manual/17-ai.md
@@ -1,6 +1,6 @@
 # AI
 
-Omarchy treats AI coding agents as first-class citizens, but it doesn't pick a favorite for you. Instead, every major coding-agent CLI comes pre-wired as a lazy-loaded launcher. The launchers are tiny [mise](https://mise.jdx.dev/)-managed stubs in `~/.local/bin/`, so nothing is downloaded until the first time you actually run one. Invoke any of these and authenticate when prompted:
+Omarchy treats AI coding agents as first-class citizens, but it doesn't pick a favorite for you. Most major coding-agent CLIs come pre-wired as lazy-loaded launchers. The launchers are tiny [mise](https://mise.jdx.dev/)-managed stubs in `~/.local/bin/`, so nothing is downloaded until the first time you actually run one. Invoke any of these and authenticate when prompted:
 
 | Command    | Agent                                                            |
 |------------|------------------------------------------------------------------|
@@ -8,6 +8,7 @@ Omarchy treats AI coding agents as first-class citizens, but it doesn't pick a f
 | `codex`    | [OpenAI Codex](https://github.com/openai/codex)                  |
 | `opencode` | [OpenCode](https://opencode.ai/)                                 |
 | `agy`      | [Google Antigravity CLI](https://github.com/google-antigravity/antigravity-cli) |
+| `axon`     | [Axon](https://axon.arclabs.it)                                 |
 | `copilot`  | [GitHub Copilot CLI](https://github.com/github/copilot-cli)      |
 | `crush`    | [Crush](https://github.com/charmbracelet/crush)                  |
 | `grok`     | Grok CLI from xAI                                                |
@@ -26,9 +27,11 @@ To wrap an additional CLI the same way, run `omarchy-mise-install <package> [com
 
 Pick your default agent with `omarchy default agent <name>` or under _Setup > Defaults > Agent_ in the Omarchy Menu (`Super + Space`). If the agent isn't installed yet, picking it installs it first. A fresh Omarchy will invite you to make this choice with a one-time notification.
 
+Axon is available as an optional default agent. Selecting it installs the CLI through mise when needed and launches its shipped Zeno agent (`axon @axon/zeno`). An existing working Axon installation is preserved. Axon uses its own permission policy.
+
 [Muse Code](https://dev.meta.ai) — Meta's `muse` — uses a preinstalled mise stub like the other agents. Picking it as the default installs Meta's official launcher through mise's HTTP backend. The launcher verifies and updates the native binary for your machine.
 
-Once you've chosen, `Super + Shift + Ctrl + A` launches the default agent in a dedicated terminal window (or brings up the picker if you haven't chosen yet). You can also launch it straight into a task with `omarchy agent prompt "Review this project"`. Agents launched this way run unattended in their respective don't-stop-to-ask modes, so be ready for them to actually do things! And since agents refuse to remember trust for your home directory, launches from `$HOME` start in `~/Work` instead.
+Once you've chosen, `Super + Shift + Ctrl + A` launches the default agent in a dedicated terminal window (or brings up the picker if you haven't chosen yet). You can also launch it straight into a task with `omarchy agent prompt "Review this project"`. Agents launched this way use their respective permission policies, so be ready for them to actually do things! And since agents refuse to remember trust for your home directory, launches from `$HOME` start in `~/Work` instead.
 
 There are terminal shortcuts too: `a` runs the default agent inline in the current terminal, while `c`, `cx`, and `cy` start OpenCode, Claude Code, and Codex directly (again in their auto-approving modes). Theme changes sync to the agents as well: Claude Code, Pi, OpenCode, and Hermes (once Hermes Desktop is installed) all follow along when you switch the Omarchy theme.
 

--- a/test/shell.d/axon-cli-test.sh
+++ b/test/shell.d/axon-cli-test.sh
@@ -1,0 +1,193 @@
+#!/bin/bash
+
+set -euo pipefail
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+export HOME="$test_tmp/home" OMARCHY_PATH="$ROOT"
+export AXON_TEST="$test_tmp"
+mkdir -p "$HOME" "$test_tmp/bin" "$HOME/.local/share/mise/shims"
+# An allowlist PATH prevents real runtimes, shims, or installers leaking in.
+for tool in grep head timeout jq cp chmod cat rm mkdir touch; do
+  ln -s "$(command -v "$tool")" "$test_tmp/bin/$tool"
+done
+ln -s "$ROOT/bin/omarchy-cmd-present" "$test_tmp/bin/omarchy-cmd-present"
+export PATH="$test_tmp/bin"
+installer="$ROOT/bin/omarchy-install-axon-cli"
+
+cat >"$test_tmp/runtime" <<'SH'
+#!/bin/bash
+[[ $# == 1 && $1 == "--version" ]] || exit 9
+[[ ${MISE_AUTO_INSTALL:-} == 0 && ${MISE_EXEC_AUTO_INSTALL:-} == 0 && ${MISE_NOT_FOUND_AUTO_INSTALL:-} == 0 ]] || exit 8
+printf '%s\n' "${0##*/}" >>"$AXON_TEST/probes"
+[[ ! -f "$AXON_TEST/broken-${0##*/}" ]]
+SH
+cat >"$test_tmp/bin/mise" <<'SH'
+#!/bin/bash
+[[ ${MISE_AUTO_INSTALL:-} == 0 && ${MISE_EXEC_AUTO_INSTALL:-} == 0 && ${MISE_NOT_FOUND_AUTO_INSTALL:-} == 0 ]] || exit 8
+printf '%s\0' "$@" >>"$AXON_TEST/argv"
+printf '\n' >>"$AXON_TEST/argv"
+if [[ $# == 3 && $1 == ls && $2 == --global && $3 == --json ]]; then
+  printf '%s\n' "$AXON_SELECTIONS"
+elif [[ $# == 4 && $1 == use && $2 == -g && $3 == --fuzzy ]]; then
+  [[ ! -f "$AXON_TEST/install-fail" ]] || exit 1
+  case "$4" in
+  bun@latest) tool=bun ;;
+  npm:@arcforge/axon@latest)
+    [[ ${MISE_MINIMUM_RELEASE_AGE:-} == 0 ]] || exit 8
+    tool=axon
+    ;;
+  *) exit 9 ;;
+  esac
+  if [[ $tool == "axon" ]] && [[ -f $AXON_TEST/shim-mode ]]; then
+    cp "$AXON_TEST/runtime" "$AXON_TEST/installed-axon"
+  else
+    cp "$AXON_TEST/runtime" "$AXON_TEST/bin/$tool"
+  fi
+  chmod +x "$AXON_TEST/bin/$tool" "$AXON_TEST/installed-axon" 2>/dev/null || true
+else
+  exit 9
+fi
+SH
+chmod +x "$test_tmp/bin/mise" "$test_tmp/runtime"
+export AXON_SELECTIONS='{"node":[{"version":"22","source":{"path":"config.toml"}}]}'
+
+reset_case() {
+  /bin/rm -f "$test_tmp/bin/axon" "$test_tmp/bin/bun" "$test_tmp"/broken-* "$test_tmp/install-fail" "$test_tmp/installed-axon" "$test_tmp/shim-mode"
+  : >"$test_tmp/argv"
+  : >"$test_tmp/probes"
+}
+runtime() { cp "$test_tmp/runtime" "$test_tmp/bin/$1"; }
+reject() {
+  if "$installer" "$@" >"$test_tmp/output" 2>&1; then
+    fail "expected rejection: $*"
+  fi
+}
+no_mise() { [[ ! -s $test_tmp/argv ]] || fail "unexpected mise call"; }
+expect_calls() {
+  printf '%s\0' "$@" >"$test_tmp/expected"
+  # Each expected argument list is separated by a newline in the actual log.
+  /usr/bin/tr -d '\n' <"$test_tmp/argv" >"$test_tmp/actual"
+  /usr/bin/cmp "$test_tmp/expected" "$test_tmp/actual" || fail "exact mise argv"
+}
+
+reset_case
+reject --check
+no_mise
+[[ ! -s $test_tmp/probes ]] || fail "absent means no command probe"
+for arg in "" --invalid; do reject "$arg"; done
+reject --now extra
+reject --check extra
+no_mise
+pass "absence and invalid/empty/excess arguments do not install"
+
+for tool in axon bun; do
+  reset_case
+  runtime "$tool"
+  : >"$test_tmp/broken-$tool"
+  reject --check
+  reject --now
+  no_mise
+  pass "broken foreign $tool is not shadowed"
+
+  reset_case
+  # Generate the actual known wrapper, but only inside the disposable HOME.
+  /bin/bash "$ROOT/bin/omarchy-mise-install" "$tool" "$tool"
+  /bin/mv "$HOME/.local/bin/$tool" "$test_tmp/bin/$tool"
+  reject --check
+  reject --now
+  no_mise
+  [[ ! -s $test_tmp/probes ]] || fail "cold wrapper executed"
+  pass "cold $tool wrapper never executes"
+done
+
+reset_case
+runtime axon
+"$installer" --check
+"$installer" --now
+"$installer"
+no_mise
+pass "working Axon (including shim probes with auto-install disabled) is preserved"
+
+reset_case
+runtime bun
+"$installer" --now
+expect_calls use -g --fuzzy npm:@arcforge/axon@latest
+pass "working Bun is reused without changing Node or Bun"
+
+reset_case
+"$installer" --now
+expect_calls ls --global --json use -g --fuzzy bun@latest use -g --fuzzy npm:@arcforge/axon@latest
+pass "genuinely absent runtimes add only fuzzy Bun and Axon"
+
+for installed in true false; do
+  reset_case
+  export AXON_SELECTIONS='{"bun":[{"version":"1.4.0","requested_version":"1.4","installed":'"$installed"',"source":{"path":"config.toml"}}]}'
+  reject --now
+  expect_calls ls --global --json
+  pass "configured Bun is preserved, installed=$installed"
+done
+
+reset_case
+export AXON_SELECTIONS='{"bun":[{"version":"1.4.0","source":null}]}'
+"$installer" --now
+expect_calls ls --global --json use -g --fuzzy bun@latest use -g --fuzzy npm:@arcforge/axon@latest
+pass "unselected cached Bun is not mistaken for a configured selection"
+
+reset_case
+export AXON_SELECTIONS='[]'
+reject --now
+expect_calls ls --global --json
+pass "unexpected selection format fails closed"
+
+reset_case
+runtime bun
+: >"$test_tmp/install-fail"
+reject --now
+expect_calls use -g --fuzzy npm:@arcforge/axon@latest
+pass "install failure propagates"
+
+reset_case
+runtime bun
+: >"$test_tmp/broken-axon"
+reject --now
+expect_calls use -g --fuzzy npm:@arcforge/axon@latest
+pass "runtime incompatibility fails without overwriting Bun"
+
+# Mise shims are compiled executables, not shell wrappers. They must never
+# be scanned for wrapper text: arbitrary bytes in an ELF file can match it.
+reset_case
+cp /usr/bin/true "$test_tmp/bin/axon"
+printf 'mise use -g\n' >>"$test_tmp/bin/axon"
+"$installer" --check
+no_mise
+pass "a compiled mise shim is probed rather than mistaken for a cold wrapper"
+
+# Model a mise shim separately from a foreign executable: dispatch to an
+# installed target, and record any attempt to auto-install a missing target.
+reset_case
+shim_dir="$HOME/.local/share/mise/shims"
+cat >"$shim_dir/axon" <<'SH'
+#!/bin/bash
+if [[ ${MISE_AUTO_INSTALL:-} != 0 || ${MISE_EXEC_AUTO_INSTALL:-} != 0 || ${MISE_NOT_FOUND_AUTO_INSTALL:-} != 0 ]]; then
+  : >"$AXON_TEST/implicit-install"
+  exit 8
+fi
+[[ -f "$AXON_TEST/installed-axon" ]] || exit 1
+exec "$AXON_TEST/installed-axon" "$@"
+SH
+chmod +x "$shim_dir/axon"
+export PATH="$shim_dir:$PATH"
+touch "$test_tmp/shim-mode"
+cp "$test_tmp/runtime" "$test_tmp/installed-axon"
+"$installer" --check
+"$installer" --now
+no_mise
+/bin/rm "$test_tmp/installed-axon"
+reject --check
+export AXON_SELECTIONS='{}'
+"$installer" --now
+expect_calls ls --global --json use -g --fuzzy bun@latest use -g --fuzzy npm:@arcforge/axon@latest
+[[ ! -e $test_tmp/implicit-install ]] || fail "shim tried implicit installation"
+pass "installed and missing mise shim targets probe without implicit installs"

--- a/test/shell.d/default-agent-test.sh
+++ b/test/shell.d/default-agent-test.sh
@@ -801,3 +801,119 @@ mapfile -d '' -t launch_args <"$launch_log"
   ${launch_args[4]} == "Review this project" ]] ||
   fail "OpenClaw receives prompts through --message" "argv: ${launch_args[*]}"
 pass "OpenClaw receives prompts through --message"
+
+# Axon uses the real installer against stubbed executables.
+(
+  # Keep absence genuine, without inheriting developer-installed Axon/Bun.
+  export PATH="$mock_bin:$ROOT/bin:/usr/bin:/bin"
+  cat >"$test_tmp/axon-template" <<'SH'
+#!/bin/bash
+if [[ ${1:-} == "--version" ]]; then
+  [[ -f $OMARCHY_TEST_AXON_READY ]]
+else
+  printf '%s\0' axon "$@" >"$OMARCHY_TEST_AGENT_INLINE_LOG"
+fi
+SH
+  cat >"$mock_bin/omarchy-cmd-present" <<'SH'
+#!/bin/bash
+command -v "$1" >/dev/null 2>&1
+SH
+  cat >"$mock_bin/mise" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$OMARCHY_TEST_MISE_HISTORY"
+printf '%s\0' "$@" >"$OMARCHY_TEST_MISE_LOG"
+expected=(use -g --fuzzy npm:@arcforge/axon@latest)
+(( $# == ${#expected[@]} )) || exit 2
+for arg in "${expected[@]}"; do
+  [[ $1 == "$arg" ]] || exit 2
+  shift
+done
+[[ ${OMARCHY_TEST_MISE_FAIL:-false} != "true" ]] || exit 1
+cp "$OMARCHY_TEST_AXON_TEMPLATE" "$OMARCHY_TEST_AXON_BIN"
+chmod +x "$OMARCHY_TEST_AXON_BIN"
+if [[ ${OMARCHY_TEST_AXON_BROKEN:-false} != "true" ]]; then
+  touch "$OMARCHY_TEST_AXON_READY"
+fi
+SH
+  printf '#!/bin/bash\nexit 0\n' >"$mock_bin/bun"
+  chmod +x "$mock_bin/bun" "$mock_bin/omarchy-cmd-present" "$mock_bin/mise"
+  export OMARCHY_TEST_AXON_TEMPLATE="$test_tmp/axon-template"
+  export OMARCHY_TEST_AXON_BIN="$mock_bin/axon"
+  export OMARCHY_TEST_AXON_READY="$test_tmp/axon-ready"
+  unset OMARCHY_TEST_MISSING_COMMAND
+  hash -r
+
+  : >"$mise_history"
+  if omarchy-install-axon-cli --check; then
+    fail "Axon check rejects an unavailable CLI"
+  fi
+  [[ ! -s $mise_history ]] || fail "Axon check does not install anything"
+  if omarchy-install-axon-cli --invalid >"$test_tmp/axon-invalid" 2>&1; then
+    fail "Axon installer rejects unknown options"
+  fi
+
+  if omarchy-install-axon-cli "" >"$test_tmp/axon-empty" 2>&1; then
+    fail "Axon installer rejects an empty argument"
+  fi
+
+  for mode in --check --now; do
+    if omarchy-install-axon-cli "$mode" unexpected >"$test_tmp/axon-extra" 2>&1; then
+      fail "Axon installer rejects extra arguments for $mode"
+    fi
+  done
+  [[ ! -s $mise_history ]] || fail "invalid Axon arguments cause no installation"
+
+  printf '%s\n' pi >"$agent_file"
+  : >"$terminal_log"
+  : >"$launch_log"
+  : >"$inline_log"
+  omarchy-default-agent axon
+  mapfile -d '' -t terminal_args <"$terminal_log"
+  [[ ${terminal_args[*]} == "omarchy-default-agent --install axon" ]] ||
+    fail "missing Axon opens the installation terminal"
+  [[ $(omarchy-default-agent) == "pi" && ! -s $launch_log && ! -s $inline_log ]] ||
+    fail "missing Axon waits before selecting or launching"
+
+  : >"$inline_log"
+  : >"$terminal_log"
+  if OMARCHY_TEST_MISE_FAIL=true omarchy-default-agent --install axon >"$test_tmp/axon-failure" 2>&1; then
+    fail "Axon installation propagates mise failure"
+  fi
+  [[ $(omarchy-default-agent) == "pi" && ! -s $launch_log && ! -s $inline_log ]] ||
+    fail "failed Axon installation preserves the default and skips launch"
+  [[ ! -s $terminal_log ]] || fail "failed Axon installation does not open another terminal"
+
+  if OMARCHY_TEST_AXON_BROKEN=true omarchy-default-agent --install axon >"$test_tmp/axon-broken" 2>&1; then
+    fail "Axon installation rejects an unusable CLI after mise succeeds"
+  fi
+  [[ $(omarchy-default-agent) == "pi" && ! -s $launch_log && ! -s $inline_log ]] ||
+    fail "broken Axon preserves the default and skips every launch"
+  [[ ! -s $terminal_log ]] || fail "broken Axon does not open another terminal"
+
+  rm -f "$mock_bin/axon"
+  : >"$mise_history"
+  omarchy-default-agent --install axon >"$test_tmp/axon-installed"
+  [[ $(omarchy-default-agent) == "axon" ]] || fail "Axon selection is stored"
+  [[ $(cat "$mise_history") == "use -g --fuzzy npm:@arcforge/axon@latest" ]] ||
+    fail "Axon installs only its fuzzy npm selection"
+  mapfile -d '' -t inline_args <"$inline_log"
+  [[ ${#inline_args[@]} == 2 && ${inline_args[0]} == "axon" && ${inline_args[1]} == "@axon/zeno" ]] ||
+    fail "new Axon launches Zeno inline"
+
+  : >"$mise_history"
+  omarchy-install-axon-cli --check
+  omarchy-default-agent axon
+  omarchy-install-axon-cli
+  [[ ! -s $mise_history ]] || fail "working Axon is preserved without mise changes"
+  assert_launched axon "starts Zeno" axon @axon/zeno
+
+  assert_launch axon axon @axon/zeno -p "Review this project"
+  # Shell syntax is intentionally literal test data, not an expansion.
+  # shellcheck disable=SC2016
+  literal_axon_prompt='--help $(touch "'$test_tmp'/axon-must-not-run"); $HOME'
+  literal_axon_prompt+=$'\nquotes " and trailing\\ '
+  omarchy-agent-prompt "$literal_axon_prompt"
+  assert_launched axon "preserves literal prompt text" axon @axon/zeno -p "$literal_axon_prompt"
+  [[ ! -e $test_tmp/axon-must-not-run ]] || fail "Axon prompt is never evaluated"
+  pass "Axon installs through mise, preserves working installs, and launches literal Zeno prompts"
+)

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -216,6 +216,7 @@ assertEqual(
   'menu lists Reset Computer last under Setup'
 )
 const expectedAgents = {
+  axon: { icon: '»', label: 'Axon' },
   agy: { icon: '󰫢', label: 'Antigravity' },
   pi: { icon: '\ue901', iconFont: 'omarchy', label: 'Pi' },
   omp: { icon: '\ue903', iconFont: 'omarchy', label: 'omp' },
@@ -249,7 +250,7 @@ assertDeepEqual(
   defaultItems
     .filter(item => item.parent === 'setup.default.agent')
     .map(item => item.label),
-  ['Antigravity', 'Claude', 'Codex', 'Copilot', 'Crush', 'Cursor CLI', 'Grok', 'Hermes', 'Muse Code', 'omp', 'OpenClaw', 'OpenCode', 'Ori', 'Pi'],
+  ['Antigravity', 'Axon', 'Claude', 'Codex', 'Copilot', 'Crush', 'Cursor CLI', 'Grok', 'Hermes', 'Muse Code', 'omp', 'OpenClaw', 'OpenCode', 'Ori', 'Pi'],
   'menu sorts coding agents alphabetically'
 )
 const expectedDefaults = {


### PR DESCRIPTION
## Summary
    
    Add Axon as an optional default coding agent.
    
    - Installs the public Axon CLI through mise when needed.
    - Launches Axon's shipped Zeno agent with `axon @axon/zeno`.
    - Forwards prompted launches as one literal `-p` argument.
    - Preserves an existing working Axon installation and avoids changing an existing Node or Bun selection.
    - Adds focused installer, default-agent, and menu coverage.
    
    ## Testing
    
    - `bash test/shell.d/axon-cli-test.sh`
    - `bash test/shell.d/default-agent-test.sh`
    - `bash test/shell.d/menu-test.sh`
    - `bash test/shell.d/bin-style-test.sh`
    - `./test/cli`
    - ShellCheck for `bin/omarchy-install-axon-cli`
    - Manual verification:
      - `» Axon` renders in Setup → Defaults → Agent.
      - Selecting Axon from the live menu completes mise's visible confirmation flow and launches Zeno through the real default-agent path.
    
    `./test/all` was also run. The Axon-related suites passed. Remaining local failures are outside this change: four reproduce on `upstream/quattro`; two are checkout/environment-sensitive.
    
