### PR TITLE
Stop screensaver busy-loop when branding text is missing

### DIFF
--- a/bin/omarchy-screensaver
+++ b/bin/omarchy-screensaver
@@ -13,14 +13,28 @@ exit_screensaver() {
   exit 0
 }
 
+screensaver_text() {
+  local user_file="$HOME/.config/omarchy/branding/screensaver.txt"
+  local fallback="$OMARCHY_PATH/logo.txt"
+
+  if [[ -f $user_file ]]; then
+    printf '%s\n' "$user_file"
+  elif [[ -f $fallback ]]; then
+    printf '%s\n' "$fallback"
+  fi
+}
+
 # Exit the screensaver on signals and input from keyboard and mouse
 trap exit_screensaver SIGINT SIGTERM SIGHUP SIGQUIT
+
+input=$(screensaver_text)
+if [[ -z $input ]]; then
+  exit 0
+fi
 
 printf '\033]11;rgb:00/00/00\007'  # Set background color to black
 
 hyprctl eval 'hl.config({ cursor = { invisible = true } })' &>/dev/null || hyprctl keyword cursor:invisible true &>/dev/null
-
-tty=$(tty 2>/dev/null)
 
 # Terminals allocate the pty at the default 80x24 and only resize it once the
 # compositor has told the window how big it is. ttfx measures the terminal once,
@@ -36,13 +50,20 @@ wait_for_terminal_resize() {
 wait_for_terminal_resize
 
 while true; do
-  ttfx -i ~/.config/omarchy/branding/screensaver.txt \
+  ttfx -i "$input" \
     --frame-rate 120 --canvas-width 0 --canvas-height 0 --reuse-canvas --anchor-canvas c --anchor-text c\
     --random-effect --no-eol --no-restore-cursor &
+  ttfx_pid=$!
 
-  while pgrep -t "${tty#/dev/}" -x ttfx >/dev/null; do
+  while kill -0 "$ttfx_pid" 2>/dev/null; do
     if read -n1 -t 1 || ! screensaver_in_focus; then
       exit_screensaver
     fi
   done
+
+  if wait "$ttfx_pid"; then
+    continue
+  else
+    exit_screensaver
+  fi
 done

--- a/test/shell.d/screensaver-test.sh
+++ b/test/shell.d/screensaver-test.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+stub_bin="$tmp_dir/bin"
+mkdir -p "$stub_bin" "$tmp_dir/home/.config/omarchy/branding" "$tmp_dir/omarchy"
+
+printf 'fallback-logo\n' >"$tmp_dir/omarchy/logo.txt"
+printf 'user-branding\n' >"$tmp_dir/home/.config/omarchy/branding/screensaver.txt"
+
+cat >"$stub_bin/hyprctl" <<'SH'
+#!/bin/bash
+if [[ ${1:-} == activewindow ]]; then
+  printf '%s\n' '{"class":"org.omarchy.screensaver"}'
+fi
+exit 0
+SH
+
+cat >"$stub_bin/stty" <<'SH'
+#!/bin/bash
+printf '%s\n' "60 200"
+SH
+
+cat >"$stub_bin/pkill" <<'SH'
+#!/bin/bash
+exit 0
+SH
+
+cat >"$stub_bin/ttfx" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$TTFX_LOG"
+count=0
+[[ -f $TTFX_COUNT ]] && count=$(<"$TTFX_COUNT")
+count=$((count + 1))
+printf '%s\n' "$count" >"$TTFX_COUNT"
+if (( count <= ${TTFX_SUCCESSES:-0} )); then
+  exit 0
+fi
+exit "${TTFX_EXIT:-1}"
+SH
+
+chmod +x "$stub_bin"/*
+
+run_screensaver() {
+  : >"$tmp_dir/ttfx.log"
+  : >"$tmp_dir/ttfx.count"
+  PATH="$stub_bin:$PATH" \
+    HOME="$tmp_dir/home" \
+    OMARCHY_PATH="$tmp_dir/omarchy" \
+    TTFX_LOG="$tmp_dir/ttfx.log" \
+    TTFX_COUNT="$tmp_dir/ttfx.count" \
+    TTFX_SUCCESSES="${TTFX_SUCCESSES:-0}" \
+    TTFX_EXIT="${TTFX_EXIT:-1}" \
+    timeout --kill-after=1s 3s bash "$ROOT/bin/omarchy-screensaver" </dev/null >/dev/null
+}
+
+status=0
+run_screensaver || status=$?
+(( status != 124 )) || fail "a missing-file screensaver does not busy-loop" "timeout after a failed ttfx"
+[[ $(<"$tmp_dir/ttfx.count") == 1 ]] || fail "ttfx is launched once when the user branding file exists" "$(<"$tmp_dir/ttfx.count")"
+[[ $(<"$tmp_dir/ttfx.log") == *"$tmp_dir/home/.config/omarchy/branding/screensaver.txt"* ]] ||
+  fail "the user branding file is preferred when it exists" "$(<"$tmp_dir/ttfx.log")"
+pass "the user branding file is preferred when it exists"
+
+rm -f "$tmp_dir/home/.config/omarchy/branding/screensaver.txt"
+status=0
+run_screensaver || status=$?
+(( status != 124 )) || fail "a missing branding file does not busy-loop" "timeout after a failed ttfx"
+[[ $(<"$tmp_dir/ttfx.count") == 1 ]] || fail "ttfx is launched once when falling back to logo.txt" "$(<"$tmp_dir/ttfx.count")"
+[[ $(<"$tmp_dir/ttfx.log") == *"$tmp_dir/omarchy/logo.txt"* ]] ||
+  fail "a missing branding file falls back to logo.txt" "$(<"$tmp_dir/ttfx.log")"
+pass "a missing branding file falls back to logo.txt"
+
+rm -f "$tmp_dir/omarchy/logo.txt"
+status=0
+run_screensaver || status=$?
+(( status != 124 )) || fail "a screensaver with no input file does not busy-loop" "timeout with no branding"
+[[ ! -s $tmp_dir/ttfx.log ]] || fail "ttfx is not launched when no input file exists" "$(<"$tmp_dir/ttfx.log")"
+(( status == 0 )) || fail "a screensaver with no input file exits cleanly" "exit $status"
+pass "a screensaver with no input file exits instead of looping"
+
+printf 'fallback-logo\n' >"$tmp_dir/omarchy/logo.txt"
+TTFX_SUCCESSES=2
+status=0
+run_screensaver || status=$?
+(( status != 124 )) || fail "a successful effect cycle does not hang" "timeout after successful ttfx runs"
+[[ $(<"$tmp_dir/ttfx.count") == 3 ]] || fail "a finished effect is relaunched until ttfx fails" "$(<"$tmp_dir/ttfx.count")"
+pass "a finished effect is relaunched until ttfx fails"


### PR DESCRIPTION
If `~/.config/omarchy/branding/screensaver.txt` is missing, `ttfx` exits immediately and `omarchy-screensaver` relaunches it in a tight loop. The keyboard poll lives inside `while pgrep`, so Escape never dismisses it — only Ctrl+C works. To the user this looks like a crashed fullscreen terminal flooding `Error reading input file`.

- Prefer the user branding file when it exists, otherwise `$OMARCHY_PATH/logo.txt` (the same file `omarchy branding screensaver reset` already copies).
- If neither file exists, exit instead of starting the loop.
- Track the `ttfx` child and exit when it fails, so a missing/unreadable file cannot spin the CPU. A clean effect completion still relaunches the next random effect.

Fixes #11090