### PR TITLE
Skip togglesplit on non-dwindle workspace layouts

### DIFF
--- a/bin/omarchy-hyprland-window-togglesplit
+++ b/bin/omarchy-hyprland-window-togglesplit
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# omarchy:summary=Toggle the dwindle split of the focused window; no-op on other layouts
+
+set -euo pipefail
+
+layout=$(hyprctl activeworkspace -j | jq -r '.tiledLayout')
+if [[ $layout != "dwindle" ]]; then
+  exit 0
+fi
+
+hyprctl dispatch 'hl.dsp.layout("togglesplit")' >/dev/null 2>&1 ||
+  hyprctl dispatch layoutmsg togglesplit >/dev/null

--- a/default/hypr/bindings/tiling.lua
+++ b/default/hypr/bindings/tiling.lua
@@ -2,7 +2,7 @@ o.bind("SUPER + W", "Close window", hl.dsp.window.close())
 o.bind("SUPER + Q", "Close window", hl.dsp.window.close())
 o.bind("CTRL + ALT + DELETE", "Close all windows", "omarchy-hyprland-window-close-all")
 
-o.bind("SUPER + J", "Toggle window split", hl.dsp.layout("togglesplit"))
+o.bind("SUPER + J", "Toggle window split", "omarchy-hyprland-window-togglesplit")
 o.bind("SUPER + P", "Pseudo window", hl.dsp.window.pseudo())
 o.bind("SUPER + T", "Toggle window floating/tiling", hl.dsp.window.float({ action = "toggle" }))
 o.bind("SUPER + F", "Full screen", hl.dsp.window.fullscreen({ mode = "fullscreen" }))

--- a/test/shell.d/hyprland-window-togglesplit-test.sh
+++ b/test/shell.d/hyprland-window-togglesplit-test.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+source "$(dirname "$0")/base-test.sh"
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+cat >"$tmpdir/hyprctl" <<'BASH'
+#!/bin/bash
+
+if [[ $1 == "activeworkspace" && $2 == "-j" ]]; then
+  printf '{"id":3,"tiledLayout":"%s"}\n' "${HYPR_LAYOUT:-dwindle}"
+  exit 0
+fi
+
+if [[ $1 == "dispatch" ]]; then
+  printf '%s\n' "$*" >>"$HYPRCTL_LOG"
+  exit 0
+fi
+
+exit 1
+BASH
+chmod +x "$tmpdir/hyprctl"
+
+log="$tmpdir/hyprctl.log"
+
+PATH="$tmpdir:$PATH" HYPRCTL_LOG="$log" HYPR_LAYOUT=dwindle \
+  "$ROOT/bin/omarchy-hyprland-window-togglesplit"
+
+grep -Fq 'hl.dsp.layout("togglesplit")' "$log" ||
+  fail "togglesplit is dispatched on dwindle" "$(cat "$log")"
+pass "togglesplit is dispatched on dwindle"
+
+>"$log"
+PATH="$tmpdir:$PATH" HYPRCTL_LOG="$log" HYPR_LAYOUT=scrolling \
+  "$ROOT/bin/omarchy-hyprland-window-togglesplit"
+
+[[ ! -s $log ]] || fail "togglesplit is not dispatched on scrolling" "$(cat "$log")"
+pass "togglesplit is not dispatched on scrolling"
+
+>"$log"
+PATH="$tmpdir:$PATH" HYPRCTL_LOG="$log" HYPR_LAYOUT=master \
+  "$ROOT/bin/omarchy-hyprland-window-togglesplit"
+
+[[ ! -s $log ]] || fail "togglesplit is not dispatched on master" "$(cat "$log")"
+pass "togglesplit is not dispatched on other layouts"
+
+grep -Fq 'omarchy-hyprland-window-togglesplit' "$ROOT/default/hypr/bindings/tiling.lua" ||
+  fail "SUPER + J uses the layout-aware togglesplit command"
+grep -F 'SUPER + J' "$ROOT/default/hypr/bindings/tiling.lua" | grep -Fq 'hl.dsp.layout("togglesplit")' &&
+  fail "SUPER + J no longer dispatches togglesplit unconditionally"
+pass "SUPER + J uses the layout-aware togglesplit command"


### PR DESCRIPTION
`Super+J` always dispatched `togglesplit`, which only exists on dwindle. After `Super+L` switches a workspace to scrolling, that bind logs `no such layoutmsg for scrolling`.

Route the bind through `omarchy-hyprland-window-togglesplit`, which checks `.tiledLayout` and only dispatches on dwindle. Scrolling (and any other layout) is a no-op.

Fixes #11078