### PR TITLE
Fall back when reboot has no session D-Bus

### DIFF
--- a/bin/omarchy-system-reboot
+++ b/bin/omarchy-system-reboot
@@ -4,9 +4,21 @@
 # omarchy:examples=omarchy reboot | omarchy system reboot
 # omarchy:aliases=omarchy reboot
 
-# Schedule the reboot in the user manager so closing the terminal's systemd
-# scope cannot terminate it before it runs.
-systemd-run --user --collect --quiet --on-active="2s" --timer-property=AccuracySec=100ms systemctl reboot --no-wall || exit 1
+# tmux/SSH/bare TTY often drop the session bus even when a graphical session exists.
+if [[ -z ${XDG_RUNTIME_DIR:-} ]]; then
+  export XDG_RUNTIME_DIR=/run/user/$(id -u)
+fi
+if [[ -z ${DBUS_SESSION_BUS_ADDRESS:-} && -S $XDG_RUNTIME_DIR/bus ]]; then
+  export DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"
+fi
+
+# Schedule in the user manager so closing the terminal's systemd scope cannot
+# terminate it. Fall back to the system manager when no user bus is available.
+if ! systemd-run --user --collect --quiet --on-active="2s" --timer-property=AccuracySec=100ms systemctl reboot --no-wall; then
+  if ! systemd-run --system --collect --quiet --on-active="2s" --timer-property=AccuracySec=100ms systemctl reboot --no-wall; then
+    exit 1
+  fi
+fi
 
 omarchy-osd -i reboot -m "Rebooting" -d 5000
 

--- a/bin/omarchy-system-shutdown
+++ b/bin/omarchy-system-shutdown
@@ -4,9 +4,21 @@
 # omarchy:examples=omarchy shutdown | omarchy system shutdown
 # omarchy:aliases=omarchy shutdown
 
-# Schedule the shutdown in the user manager so closing the terminal's systemd
-# scope cannot terminate it before it runs.
-systemd-run --user --collect --quiet --on-active="2s" --timer-property=AccuracySec=100ms systemctl poweroff --no-wall || exit 1
+# tmux/SSH/bare TTY often drop the session bus even when a graphical session exists.
+if [[ -z ${XDG_RUNTIME_DIR:-} ]]; then
+  export XDG_RUNTIME_DIR=/run/user/$(id -u)
+fi
+if [[ -z ${DBUS_SESSION_BUS_ADDRESS:-} && -S $XDG_RUNTIME_DIR/bus ]]; then
+  export DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"
+fi
+
+# Schedule in the user manager so closing the terminal's systemd scope cannot
+# terminate it. Fall back to the system manager when no user bus is available.
+if ! systemd-run --user --collect --quiet --on-active="2s" --timer-property=AccuracySec=100ms systemctl poweroff --no-wall; then
+  if ! systemd-run --system --collect --quiet --on-active="2s" --timer-property=AccuracySec=100ms systemctl poweroff --no-wall; then
+    exit 1
+  fi
+fi
 
 omarchy-osd -i shutdown -m "Shutting down" -d 5000
 

--- a/test/shell.d/system-power-test.sh
+++ b/test/shell.d/system-power-test.sh
@@ -14,6 +14,10 @@ cat >"$mock_bin/systemd-run" <<'SH'
 
 printf 'systemd-run %s\n' "$*" >>"$CALL_LOG"
 [[ ${FAIL_SYSTEMD_RUN:-false} == "true" ]] && exit 1
+if [[ ${1:-} == "--user" ]]; then
+  [[ ${FAIL_USER_BUS:-false} == "true" ]] && exit 1
+  [[ -n ${DBUS_SESSION_BUS_ADDRESS:-} && -n ${XDG_RUNTIME_DIR:-} ]] || exit 1
+fi
 exit 0
 SH
 
@@ -30,7 +34,10 @@ run_power_command() {
   local action="$1"
 
   : >"$call_log"
-  PATH="$mock_bin:$PATH" CALL_LOG="$call_log" "$ROOT/bin/omarchy-system-$action"
+  PATH="$mock_bin:$PATH" CALL_LOG="$call_log" \
+    XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-$test_tmp/runtime}" \
+    DBUS_SESSION_BUS_ADDRESS="${DBUS_SESSION_BUS_ADDRESS:-unix:path=$test_tmp/runtime/bus}" \
+    "$ROOT/bin/omarchy-system-$action"
 }
 
 assert_power_calls() {
@@ -57,12 +64,59 @@ assert_power_calls shutdown poweroff
 
 for action in reboot shutdown; do
   : >"$call_log"
-  if PATH="$mock_bin:$PATH" CALL_LOG="$call_log" FAIL_SYSTEMD_RUN=true "$ROOT/bin/omarchy-system-$action"; then
+  if PATH="$mock_bin:$PATH" CALL_LOG="$call_log" FAIL_SYSTEMD_RUN=true \
+    XDG_RUNTIME_DIR="$test_tmp/runtime" \
+    DBUS_SESSION_BUS_ADDRESS="unix:path=$test_tmp/runtime/bus" \
+    "$ROOT/bin/omarchy-system-$action"; then
     fail "$action aborts when scheduling fails"
   fi
 
-  if (( $(wc -l <"$call_log") != 1 )); then
-    fail "$action leaves state and windows alone when scheduling fails"
+  if (( $(wc -l <"$call_log") != 2 )); then
+    fail "$action leaves state and windows alone when scheduling fails" "$(cat "$call_log")"
   fi
   pass "$action leaves state and windows alone when scheduling fails"
 done
+
+empty_runtime="$test_tmp/empty-runtime"
+mkdir -p "$empty_runtime"
+
+for action in reboot shutdown; do
+  unit=reboot
+  [[ $action == shutdown ]] && unit=poweroff
+
+  : >"$call_log"
+  PATH="$mock_bin:$PATH" CALL_LOG="$call_log" FAIL_USER_BUS=true \
+    XDG_RUNTIME_DIR="$empty_runtime" \
+    env -u DBUS_SESSION_BUS_ADDRESS \
+    "$ROOT/bin/omarchy-system-$action"
+
+  grep -Fq "systemd-run --user --collect --quiet --on-active=2s --timer-property=AccuracySec=100ms systemctl $unit --no-wall" "$call_log" ||
+    fail "$action still tries the user manager first" "$(cat "$call_log")"
+  grep -Fq "systemd-run --system --collect --quiet --on-active=2s --timer-property=AccuracySec=100ms systemctl $unit --no-wall" "$call_log" ||
+    fail "$action falls back to the system manager without a user bus" "$(cat "$call_log")"
+  grep -Fq "omarchy-hyprland-window-close-all" "$call_log" ||
+    fail "$action still closes windows after the system-manager fallback"
+  pass "$action falls back to the system manager without a user bus"
+done
+
+bus_runtime="$test_tmp/session-runtime"
+mkdir -p "$bus_runtime"
+python3 -c 'import os, socket, sys
+path = sys.argv[1]
+if os.path.exists(path):
+    os.unlink(path)
+sock = socket.socket(socket.AF_UNIX)
+sock.bind(path)
+' "$bus_runtime/bus"
+
+: >"$call_log"
+PATH="$mock_bin:$PATH" CALL_LOG="$call_log" \
+  XDG_RUNTIME_DIR="$bus_runtime" \
+  env -u DBUS_SESSION_BUS_ADDRESS \
+  "$ROOT/bin/omarchy-system-reboot"
+
+grep -Fq 'systemd-run --user --collect --quiet --on-active=2s --timer-property=AccuracySec=100ms systemctl reboot --no-wall' "$call_log" ||
+  fail "reboot reconstructs the session bus from XDG_RUNTIME_DIR/bus" "$(cat "$call_log")"
+grep -Fq 'systemd-run --system' "$call_log" &&
+  fail "reboot does not use the system manager when the session bus socket exists" "$(cat "$call_log")"
+pass "reboot reconstructs the session bus from XDG_RUNTIME_DIR/bus"


### PR DESCRIPTION
`omarchy update` → reboot fails from tmux, SSH, or a bare TTY with:

```
Failed to connect to user scope bus via local transport: $DBUS_SESSION_BUS_ADDRESS and $XDG_RUNTIME_DIR not defined
```

`omarchy-system-reboot` (and shutdown) always called `systemd-run --user`. Restore the session bus from `$XDG_RUNTIME_DIR/bus` when that socket exists, and fall back to `systemd-run --system` when it does not, so the 2s delayed reboot still schedules before windows close.

Fixes #11108