### PR TITLE
Probe network latency over TCP before ICMP

### DIFF
--- a/bin/omarchy-network-status
+++ b/bin/omarchy-network-status
@@ -48,10 +48,43 @@ print_status() {
   printf 'wifi\t%s\t%s\t%s\n' "${ssid:-$device}" "$signal" "$freq"
 }
 
-ping_latency_ms() {
+# ICMP is often filtered on enterprise/captive networks while TCP still works.
+# A refused TCP connect is still a round trip; a 1s timeout is not.
+tcp_connect_ms() {
+  local host=$1
+  local port=$2
+  local start end status ms
+
+  [[ $host == *:* ]] && return 1
+  [[ $host =~ ^[0-9A-Za-z.-]+$ && $port =~ ^[0-9]+$ ]] || return 1
+
+  start=${EPOCHREALTIME}
+  timeout 1 bash -c "exec 3<>/dev/tcp/${host}/${port}" >/dev/null 2>&1
+  status=$?
+  end=${EPOCHREALTIME}
+
+  (( status == 0 || status == 1 )) || return 1
+  ms=$(awk -v s="$start" -v e="$end" 'BEGIN { printf "%.1f", (e - s) * 1000 }')
+  awk -v ms="$ms" 'BEGIN { exit !(ms + 0 > 0 && ms + 0 < 900) }' || return 1
+  printf '%s\n' "$ms"
+}
+
+icmp_ping_ms() {
   local host=$1
 
+  omarchy-cmd-present ping || return 1
   LC_ALL=C ping -n -c 1 -W 1 "$host" 2>/dev/null | awk -F'time[=<]' '/time[=<]/ { split($2, parts, " "); print parts[1]; exit }'
+}
+
+ping_latency_ms() {
+  local host=$1
+  local port=${2:-}
+
+  if [[ -n $port ]]; then
+    tcp_connect_ms "$host" "$port" && return
+  fi
+
+  icmp_ping_ms "$host"
 }
 
 print_ping_samples() {
@@ -59,17 +92,16 @@ print_ping_samples() {
   local tmpdir router_file internet_file
   local router_pid="" internet_pid=""
 
-  omarchy-cmd-present ping || return
   tmpdir=$(mktemp -d) || return
   router_file="$tmpdir/router"
   internet_file="$tmpdir/internet"
 
   if [[ -n $gateway ]]; then
-    ping_latency_ms "$gateway" >"$router_file" &
+    ping_latency_ms "$gateway" 80 >"$router_file" &
     router_pid=$!
   fi
 
-  ping_latency_ms "$internet_probe" >"$internet_file" &
+  ping_latency_ms "$internet_probe" 443 >"$internet_file" &
   internet_pid=$!
 
   if [[ -n $router_pid ]]; then
@@ -130,8 +162,10 @@ print_verbose() {
   print_ping_samples "$gw"
 }
 
-if [[ $verbose == "true" ]]; then
-  print_verbose
-else
-  print_status
+if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
+  if [[ $verbose == "true" ]]; then
+    print_verbose
+  else
+    print_status
+  fi
 fi

--- a/test/shell.d/network-status-test.sh
+++ b/test/shell.d/network-status-test.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+stub_bin="$tmp_dir/bin"
+mkdir -p "$stub_bin"
+
+cat >"$stub_bin/timeout" <<'SH'
+#!/bin/bash
+
+printf '%s\n' "$*" >>"$TIMEOUT_LOG"
+exit "${TCP_STATUS:-0}"
+SH
+
+cat >"$stub_bin/ping" <<'SH'
+#!/bin/bash
+
+printf '%s\n' "$*" >>"$PING_LOG"
+printf '64 bytes from %s: icmp_seq=1 ttl=54 time=17.4 ms\n' "$2"
+SH
+
+chmod +x "$stub_bin"/*
+
+PATH="$stub_bin:$ROOT/bin:$PATH"
+# shellcheck disable=SC1091
+source "$ROOT/bin/omarchy-network-status"
+
+: >"$tmp_dir/timeout.log"
+: >"$tmp_dir/ping.log"
+ms=$(TCP_STATUS=0 TIMEOUT_LOG="$tmp_dir/timeout.log" PING_LOG="$tmp_dir/ping.log" ping_latency_ms 1.1.1.1 443)
+[[ $ms =~ ^[0-9]+(\.[0-9]+)?$ ]] || fail "TCP connect reports latency in ms" "$ms"
+awk -v ms="$ms" 'BEGIN { exit !(ms + 0 > 0 && ms + 0 < 900) }' || fail "TCP connect latency is a short round trip" "$ms"
+[[ ! -s $tmp_dir/ping.log ]] || fail "TCP success does not fall back to ICMP" "$(cat "$tmp_dir/ping.log")"
+grep -Fq '/dev/tcp/1.1.1.1/443' "$tmp_dir/timeout.log" || fail "TCP connect targets the requested host and port" "$(cat "$tmp_dir/timeout.log")"
+pass "TCP connect reports latency without ICMP"
+
+: >"$tmp_dir/timeout.log"
+: >"$tmp_dir/ping.log"
+ms=$(TCP_STATUS=124 TIMEOUT_LOG="$tmp_dir/timeout.log" PING_LOG="$tmp_dir/ping.log" ping_latency_ms 1.1.1.1 443)
+[[ $ms == "17.4" ]] || fail "a TCP timeout falls back to ICMP" "$ms"
+pass "a TCP timeout falls back to ICMP"
+
+: >"$tmp_dir/timeout.log"
+: >"$tmp_dir/ping.log"
+ms=$(TCP_STATUS=1 TIMEOUT_LOG="$tmp_dir/timeout.log" PING_LOG="$tmp_dir/ping.log" ping_latency_ms 10.0.0.1 80)
+[[ $ms =~ ^[0-9]+(\.[0-9]+)?$ ]] || fail "a refused TCP connect still counts as a round trip" "$ms"
+[[ ! -s $tmp_dir/ping.log ]] || fail "a refused TCP connect does not fall back to ICMP" "$(cat "$tmp_dir/ping.log")"
+pass "a refused TCP connect still counts as a round trip"
+
+: >"$tmp_dir/timeout.log"
+: >"$tmp_dir/ping.log"
+ms=$(TIMEOUT_LOG="$tmp_dir/timeout.log" PING_LOG="$tmp_dir/ping.log" ping_latency_ms fe80::1 80)
+[[ $ms == "17.4" ]] || fail "IPv6 targets skip /dev/tcp and use ICMP" "$ms"
+[[ ! -s $tmp_dir/timeout.log ]] || fail "IPv6 targets do not use /dev/tcp" "$(cat "$tmp_dir/timeout.log")"
+pass "IPv6 targets skip /dev/tcp and use ICMP"


### PR DESCRIPTION
The network widget reports **Ping: Timeout** and **Packet Loss: 100%** on networks that drop ICMP, even when TCP/HTTPS is fine. `omarchy-network-status` sampled latency with `ping`, and empty samples are counted as loss.

Measure TCP connect time first (gateway port 80, `1.1.1.1:443`). A refused connect is still a round trip; a 1s timeout is not, and those fall back to ICMP so home routers that do not listen on TCP still get a reading.

Fixes #10950