### PR TITLE
Decode double-escaped notification entities

### DIFF
--- a/shell/plugins/notifications/NotificationLogic.js
+++ b/shell/plugins/notifications/NotificationLogic.js
@@ -89,8 +89,29 @@ function styledBody(body, app, appIcon) {
   return stripImageTags(sanitizeBody(body, app, appIcon).replace(/\r\n|\r|\n/g, "<br/>"))
 }
 
+// KDE Connect HTML-escapes notification text, and some paths encode that a
+// second time (`&quot;` → `&amp;quot;`). StyledText decodes one layer, so the
+// extra `&amp;` is what the user sees. Undo only that extra layer, and never
+// for lt/gt: turning `&amp;lt;img …&amp;gt;` into `&lt;img …&gt;` would let
+// StyledText materialise a tag the input did not contain.
+function isMarkupEntityName(name) {
+  var key = String(name || "").toLowerCase()
+  if (key === "lt" || key === "gt") return true
+  if (key.charAt(0) !== "#") return false
+
+  var code = key.charAt(1) === "x" ? parseInt(key.slice(2), 16) : parseInt(key.slice(1), 10)
+  return code === 60 || code === 62
+}
+
+function decodeDoubleEscapedEntities(text) {
+  return String(text || "").replace(/&amp;(#x[0-9a-fA-F]+|#\d+|[a-zA-Z][a-zA-Z0-9]*);/g, function(match, name) {
+    if (isMarkupEntityName(name)) return match
+    return "&" + name + ";"
+  })
+}
+
 function sanitizeBody(body, app, appIcon) {
-  var text = stripImageTags(String(body || ""))
+  var text = decodeDoubleEscapedEntities(stripImageTags(String(body || "")))
   if (!isChromiumDerived(app, appIcon)) return text
 
   return text

--- a/test/shell.d/notifications-test.sh
+++ b/test/shell.d/notifications-test.sh
@@ -164,6 +164,35 @@ assertEqual(
 )
 
 assertEqual(
+  notifications.styledBody('Someone: Reacted 🤓 to &amp;quot;🤗&amp;quot;', 'KDE Connect', ''),
+  'Someone: Reacted 🤓 to &quot;🤗&quot;',
+  'notifications undo a second HTML-escape layer so StyledText can show quotes'
+)
+
+assertEqual(
+  notifications.sanitizeBody('a &amp;amp; b', 'KDE Connect', ''),
+  'a &amp; b',
+  'notifications undo a double-escaped ampersand into one StyledText entity'
+)
+
+assertEqual(
+  notifications.sanitizeBody('keep &quot;quotes&quot;', 'KDE Connect', ''),
+  'keep &quot;quotes&quot;',
+  'notifications leave a single-escaped quote for StyledText to decode'
+)
+
+assertEqual(
+  notifications.sanitizeBody('&amp;lt;img src="http://host/x.png"&amp;gt;', 'KDE Connect', ''),
+  '&amp;lt;img src="http://host/x.png"&amp;gt;',
+  'notifications do not turn double-escaped lt/gt into markup StyledText would parse'
+)
+
+assertNoImageSurvives(
+  '&amp;lt;img src="http://host/entity.png"&amp;gt;',
+  'notifications leave no image tag when lt/gt are double-escaped'
+)
+
+assertEqual(
   notifications.sanitizeBody('<a href="https://example.com">example.com</a> Message body', 'Chromium', ''),
   'Message body',
   'notifications strip chromium leading origin links'


### PR DESCRIPTION
KDE Connect HTML-escapes notification title/body, and the body that reaches Omarchy is sometimes encoded twice (`&quot;` → `&amp;quot;`). The card renders as StyledText, which decodes one layer, so the user sees literal `&quot;` around WhatsApp reactions.

Undo that extra `&amp;` layer in `NotificationLogic.sanitizeBody` for entities that cannot introduce markup. `&amp;lt;` / `&amp;gt;` (and numeric equivalents) are left encoded so StyledText cannot materialise an `<img>` the input never contained.

Fixes #11059