### PR TITLE
Treat Recordly's recording toolbar as a HUD

### DIFF
--- a/default/hypr/apps/recordly.lua
+++ b/default/hypr/apps/recordly.lua
@@ -1,0 +1,20 @@
+-- Recordly's recording toolbar is a HUD: a transparent Electron surface with a small
+-- opaque pill painted inside it. Two defaults work against that shape. The
+-- default-opacity tag compounds with the app's own alpha until the desktop reads
+-- through the controls, and the standard border is drawn around the whole transparent
+-- surface, outlining a large empty rectangle around a small toolbar.
+--
+-- Matched on title rather than class alone: Recordly's editor is an ordinary window
+-- that should tile and keep its border, and it shares the class with the toolbar.
+o.window({ class = "^recordly$", title = "^Recordly$" }, {
+  tag = "-default-opacity",
+  float = true,
+  -- The stop button has to stay reachable from whatever workspace you switch to while
+  -- recording, and a toolbar that appears mid-sentence must not take the keystrokes.
+  pin = true,
+  no_initial_focus = true,
+  no_dim = true,
+  border_size = 0,
+  no_shadow = true,
+  opacity = "1 1",
+})


### PR DESCRIPTION
Recordly (https://recordly.dev, AUR `recordly-bin`) is an Electron screen recorder whose recording toolbar is a HUD: a small opaque pill painted inside a much larger transparent surface. Two Omarchy defaults work against that shape.

`windows.lua` tags every window `default-opacity` (`"0.985 0.96"`), which compounds with the app's own alpha until the desktop reads straight through the controls. And the standard border is drawn around the whole transparent surface, so a large empty rectangle is outlined around a small toolbar — which is what people notice first.

This gives it the same treatment `webcam-overlay.lua` and `hermes.lua` already get for the same class of window.

### Matched on title, not class alone

Recordly's editor is an ordinary window that should keep tiling and keep its border, and it shares the class `recordly` with the toolbar:

```
class="recordly"  title="Recordly"         860x160   <- the HUD
class="recordly"  title="Recordly Editor"  1600x1000 <- an ordinary window
```

A class-only rule floats and de-borders the editor too. Scoping to `title = "^Recordly$"` leaves the editor alone.

### Why pin and no_initial_focus

Both match `webcam-overlay.lua`, and both matter for a recording toolbar specifically: the stop button has to stay reachable from whatever workspace you switch to mid-recording, and a toolbar that appears while you are typing must not take the keystrokes. Happy to drop either if you would rather keep the change minimal.

### Testing

Verified live on Hyprland 0.56.2 with `recordly-bin` 1.4.0:

- Toolbar no longer has a border rectangle around the transparent surface.
- Pill is opaque. Measuring pixel variance in a patch inside the pill (flat = opaque, textured = desktop showing through): **stddev 45.0 before, 32.8 after dropping the opacity tag**.
- `pinned=true`, `floating=true` confirmed via `hyprctl clients`.
- No focus theft: focused window was unchanged across the app launch.
- Editor window still tiles and keeps its border.

Note window rules apply at map time, so `hyprctl reload` does not retrofit them onto an already-open window — the app has to be restarted to see the effect.

### Not covered

Recordly shows a third surface when the webcam is enabled (a ~200x200 bubble, same class). I only saw it briefly and did not capture its title, so I have deliberately not shipped a guessed selector for it. If it needs the same treatment, it is a one-line addition once someone reads the real title.