### PR TITLE
Warn on low battery even when line power is online

### DIFF
--- a/shell/plugins/services/battery/BatteryModel.js
+++ b/shell/plugins/services/battery/BatteryModel.js
@@ -4,7 +4,7 @@ function batteryPercentage(device) {
 }
 
 function isDischarging(device, onBattery, dischargingState) {
-  return !!(device && device.isPresent && onBattery && device.state === dischargingState)
+  return !!(device && device.isPresent && device.state === dischargingState)
 }
 
 function shouldWarnLowBattery(device, onBattery, dischargingState, threshold, alreadyNotified) {

--- a/test/shell.d/battery-test.sh
+++ b/test/shell.d/battery-test.sh
@@ -11,8 +11,14 @@ const discharging = 1
 assertEqual(battery.batteryPercentage({ isPresent: true, percentage: 0.126 }), 13, 'battery rounds display percentage')
 assertEqual(battery.batteryPercentage({ isPresent: false, percentage: 0.5 }), -1, 'battery reports missing battery')
 assert(battery.isDischarging({ isPresent: true, state: discharging }, true, discharging), 'battery detects discharging state')
-assert(!battery.isDischarging({ isPresent: true, state: discharging }, false, discharging), 'battery requires on-battery state')
+assert(battery.isDischarging({ isPresent: true, state: discharging }, false, discharging), 'battery detects discharging state even when line power is online (docked)')
+assert(!battery.isDischarging({ isPresent: true, state: 2 }, false, discharging), 'battery ignores non-discharging state')
 
+assertDeepEqual(
+  battery.shouldWarnLowBattery({ isPresent: true, percentage: 0.08, state: discharging }, false, discharging, 10, false),
+  { level: 8, notify: true, notifiedLowBattery: true },
+  'battery warns under threshold when line power is online (docked)'
+)
 assertDeepEqual(
   battery.shouldWarnLowBattery({ isPresent: true, percentage: 0.08, state: discharging }, true, discharging, 10, false),
   { level: 8, notify: true, notifiedLowBattery: true },


### PR DESCRIPTION
## What

Detect battery discharge directly via `device.state === dischargingState` in `BatteryModel.isDischarging`, removing the requirement that UPower's global `onBattery` property be true.

## Why

When a laptop is connected to a dock, hub, or under-wattage charger where system power consumption exceeds the power delivered by the power supply:
- `UPower.onBattery` is `false` (because a line-power device is online).
- `UPower.displayDevice.state` is `Discharging` (the battery percentage is actively dropping).

Because `isDischarging` previously required `onBattery && device.state === dischargingState`, it returned `false` while docked. As a result, `shouldWarnLowBattery` suppressed the low-battery notification across the entire discharge, leaving the user with zero warning before the system drained to 2% and was force-suspended by `upowerd`.

Checking `device.state === dischargingState` ensures that any time the battery is genuinely discharging past the low threshold, the warning is sent. The `onBattery` argument is preserved in the function signature for compatibility with existing callers.

Note that `Service.qml`'s `applyPowerProfile()` legitimately continues to use `UPower.onBattery` for profile switching between AC and battery.

## Testing

- Updated `test/shell.d/battery-test.sh`:
  - Sabotage check: Replaced the outdated assertion expecting `!isDischarging` when `onBattery` is false with an assertion verifying `isDischarging` returns true even when line power is online (`onBattery: false`). Confirmed this fails on unmodified baseline and passes with the fix.
  - Added unit test asserting `shouldWarnLowBattery` triggers notification when `onBattery: false` and `state: discharging` under threshold.
  - Added assertion verifying non-discharging states (e.g. charging) return false.
  - All 9 unit test assertions pass.
- Verified in the Omarchy disposable VM (`omavm`):
  - Booted clean `fresh` snapshot.
  - Deployed updated `BatteryModel.js` and verified unit assertions inside the guest session.
  - Restarted the Omarchy shell and confirmed clean desktop/bar loading with no QML or service warnings.

Fixes #10939