### PR TITLE
Flash the lock screen fingerprint icon when a read is rejected

### DIFF
--- a/shell/plugins/lock/LockView.qml
+++ b/shell/plugins/lock/LockView.qml
@@ -10,6 +10,10 @@ Item {
   property int backgroundVersion: 0
   property bool fingerprintConfigured: false
   property bool authenticatingPassword: false
+  // Bumped by the service on every rejected fingerprint read; the view turns
+  // it into a brief flash of the hint icon.
+  property int fingerprintFailureTick: 0
+  property bool fingerprintError: false
   property string failureMessage: ""
   property int failedAttempts: 0
   property bool inputEnabled: true
@@ -67,6 +71,11 @@ Item {
   onInputEnabledChanged: {
     if (inputEnabled) Qt.callLater(forcePasswordFocus)
   }
+  onFingerprintFailureTickChanged: {
+    if (fingerprintFailureTick <= 0) return
+    fingerprintError = true
+    fingerprintErrorTimer.restart()
+  }
   Component.onCompleted: {
     syncPasswordText()
     if (inputEnabled) Qt.callLater(forcePasswordFocus)
@@ -80,6 +89,12 @@ Item {
     font.pixelSize: root.passwordDotFontSize
     font.letterSpacing: root.passwordDotLetterSpacing
     text: "●".repeat(passwordInput.text.length)
+  }
+
+  Timer {
+    id: fingerprintErrorTimer
+    interval: 1000
+    onTriggered: root.fingerprintError = false
   }
 
   Rectangle {
@@ -210,7 +225,7 @@ Item {
         anchors.verticalCenter: parent.verticalCenter
         visible: root.fingerprintConfigured
         text: "󰈷"
-        color: Color.lock.placeholder
+        color: root.fingerprintError ? Color.lock.textError : Color.lock.placeholder
         font.family: Style.font.family
         font.pixelSize: Math.round(root.fieldFontSize * 1.1)
         horizontalAlignment: Text.AlignHCenter

--- a/shell/plugins/lock/LockView.qml
+++ b/shell/plugins/lock/LockView.qml
@@ -226,6 +226,9 @@ Item {
         visible: root.fingerprintConfigured
         text: "󰈷"
         color: root.fingerprintError ? Color.lock.textError : Color.lock.placeholder
+        // Dim as well as recolor, so a rejected read stays noticeable on
+        // themes where the error color is close to the normal one.
+        opacity: root.fingerprintError ? 0.2 : 1.0
         font.family: Style.font.family
         font.pixelSize: Math.round(root.fieldFontSize * 1.1)
         horizontalAlignment: Text.AlignHCenter

--- a/shell/plugins/lock/Service.qml
+++ b/shell/plugins/lock/Service.qml
@@ -20,6 +20,7 @@ Item {
   property bool pendingSessionLock: false
   property bool authenticatingPassword: false
   property bool fingerprintAuthenticating: false
+  property int fingerprintFailureTick: 0
   property bool passwordPamConfigured: false
   property bool fingerprintConfigured: false
   property bool previewVisible: false
@@ -130,6 +131,7 @@ Item {
     failedAttempts = 0
     authenticatingPassword = false
     fingerprintAuthenticating = false
+    fingerprintFailureTick = 0
     fingerprintRetryTimer.stop()
     if (passwordPam.active) passwordPam.abort()
     if (fingerprintPam.active) fingerprintPam.abort()
@@ -310,6 +312,7 @@ Item {
         backgroundVersion: root.backgroundVersion
         fingerprintConfigured: root.fingerprintConfigured
         authenticatingPassword: root.authenticatingPassword
+        fingerprintFailureTick: root.fingerprintFailureTick
         failureMessage: root.failureMessage
         failedAttempts: root.failedAttempts
         inputEnabled: root.lockRequested
@@ -383,6 +386,12 @@ Item {
     id: fingerprintPam
     config: "omarchy-lock-fingerprint"
     user: root.userName
+
+    // pam_fprintd sends a rejected read as an error message while the PAM
+    // conversation keeps running, so surface each one as a flash.
+    onPamMessage: {
+      if (fingerprintPam.messageIsError) root.fingerprintFailureTick += 1
+    }
 
     onCompleted: function(result) {
       root.handleFingerprintFinished(result)

--- a/test/shell.d/fixtures/lock-fingerprint-indicator/shell.qml
+++ b/test/shell.d/fixtures/lock-fingerprint-indicator/shell.qml
@@ -86,12 +86,14 @@ ShellRoot {
           root.assertTrue(view.fingerprintReserve === 0, "no space is reserved when no sensor is configured")
 
           // A rejected read bumps the failure tick; the icon flips to the
-          // error color until the view's own timer clears it.
+          // error color and dims until the view's own timer clears it.
           view.fingerprintConfigured = true
           view.fingerprintFailureTick = 1
           root.assertTrue(view.fingerprintError, "a rejected read puts the fingerprint icon into its error state")
           root.assertTrue(String(indicator.color).toLowerCase() === String(Color.lock.textError).toLowerCase(),
             "the fingerprint icon flashes the error color on a rejected read")
+          root.assertTrue(indicator.opacity < 1,
+            "the fingerprint icon dims on a rejected read, got opacity " + indicator.opacity)
         }
 
         view.destroy()

--- a/test/shell.d/fixtures/lock-fingerprint-indicator/shell.qml
+++ b/test/shell.d/fixtures/lock-fingerprint-indicator/shell.qml
@@ -84,6 +84,14 @@ ShellRoot {
 
           view.fingerprintConfigured = false
           root.assertTrue(view.fingerprintReserve === 0, "no space is reserved when no sensor is configured")
+
+          // A rejected read bumps the failure tick; the icon flips to the
+          // error color until the view's own timer clears it.
+          view.fingerprintConfigured = true
+          view.fingerprintFailureTick = 1
+          root.assertTrue(view.fingerprintError, "a rejected read puts the fingerprint icon into its error state")
+          root.assertTrue(String(indicator.color).toLowerCase() === String(Color.lock.textError).toLowerCase(),
+            "the fingerprint icon flashes the error color on a rejected read")
         }
 
         view.destroy()

--- a/test/shell.d/lock-fingerprint-feedback-test.sh
+++ b/test/shell.d/lock-fingerprint-feedback-test.sh
@@ -41,4 +41,9 @@ assert(
   /color: root\.fingerprintError \? Color\.lock\.textError : Color\.lock\.placeholder/.test(lockViewQml),
   'the hint icon uses the error color while the flash is active'
 )
+
+assert(
+  /opacity: root\.fingerprintError \? 0\.2 : 1\.0/.test(lockViewQml),
+  'the hint icon dims as well as recolors so the flash survives low-contrast themes'
+)
 JS

--- a/test/shell.d/lock-fingerprint-feedback-test.sh
+++ b/test/shell.d/lock-fingerprint-feedback-test.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const serviceQml = fs.readFileSync(path.join(root, 'shell/plugins/lock/Service.qml'), 'utf8')
+const lockViewQml = fs.readFileSync(path.join(root, 'shell/plugins/lock/LockView.qml'), 'utf8')
+
+// pam_fprintd reports a rejected read as a PAM error message while the PAM
+// conversation keeps running, so the lock must turn each one into a flash
+// instead of leaving the user staring at a static icon.
+assert(
+  /onPamMessage: \{\s*if \(fingerprintPam\.messageIsError\) root\.fingerprintFailureTick \+= 1\s*\}/.test(serviceQml),
+  'a rejected fingerprint read bumps the failure tick'
+)
+
+assert(
+  /fingerprintFailureTick: root\.fingerprintFailureTick/.test(serviceQml),
+  'the lock surface passes the failure tick to the view'
+)
+
+assert(
+  /fingerprintFailureTick = 0/.test(serviceQml),
+  'the failure tick resets with the rest of the authentication state'
+)
+
+assert(
+  /fingerprintError = true\s*fingerprintErrorTimer\.restart\(\)/.test(lockViewQml),
+  'the view flashes the hint icon when the failure tick changes'
+)
+
+assert(
+  /id: fingerprintErrorTimer[\s\S]*?onTriggered: root\.fingerprintError = false/.test(lockViewQml),
+  'the hint icon returns to its normal color once the flash timer elapses'
+)
+
+assert(
+  /color: root\.fingerprintError \? Color\.lock\.textError : Color\.lock\.placeholder/.test(lockViewQml),
+  'the hint icon uses the error color while the flash is active'
+)
+JS

--- a/test/shell.d/lock-fingerprint-indicator-test.sh
+++ b/test/shell.d/lock-fingerprint-indicator-test.sh
@@ -70,4 +70,4 @@ if ! jq -e '.ok == true' "$result" >/dev/null; then
   fail "fingerprint indicator tracks the configured sensor"
 fi
 
-pass "fingerprint indicator tracks the configured sensor"
+pass "fingerprint indicator tracks the configured sensor and flashes on rejected reads"


### PR DESCRIPTION
### Problem

The lock screen gives no feedback when a fingerprint read is rejected. The hint icon sits static while pam_fprintd relays `Failed to match fingerprint` and the PAM conversation keeps running, so a rejected touch looks the same as a sensor that isn't reading at all.

### Fix

Give the fingerprint hint icon a brief rejection flash:

- `Service.qml` bumps `fingerprintFailureTick` whenever the fingerprint `PamContext` relays a message with `messageIsError`, and passes the counter to the view.
- `LockView.qml` flips the icon to `Color.lock.textError` and dims it to `0.2` opacity for a second, then a timer returns it to the hint color.

Only rejected reads flash: silent verify timeouts and PAM service errors relay no error message, so the icon is left alone.

The opacity dim matters because the flash must not rely on the theme's error color being distinct. A survey of the 22 stock themes (generating each `shell.toml` with `omarchy-theme-set-templates`) found two where a color-only flash is invisible:

- `tokyo-night` ships `themes/tokyo-night/shell.lock.toml` with every `[lock]` color — including `text-error` and `border-active` — set to the foreground (`#a9b1d6`), so error and idle states are identical. That also means failed-password error coloring never shows on tokyo-night.
- `vantablack` has `text-error = #a4a4a4` against `placeholder = #a8a8a8`, which is imperceptible.

The remaining 20 stock themes get distinct error colors from `default/themed/shell.toml.tpl`. Dimming in addition to recoloring keeps the feedback visible regardless of the theme palette.

Deliberately scoped to the visual feedback. The display blank/wake behavior during a fingerprint verify is separate work (see #10653), and the "reader unavailable" state belongs to #7158.

### Tests

- New `test/shell.d/lock-fingerprint-feedback-test.sh` covers the service wiring: an error message bumps the tick, the tick reaches the view, the flash clears on its timer, and the icon binds to the error color and dims.
- `test/shell.d/lock-fingerprint-indicator-test.sh` now also asserts the icon enters its error state, uses the error color, and dims on a rejected read.
- All lock shell tests pass: `apply-lock`, `lock-blank-fingerprint`, `lock-fingerprint-feedback`, `lock-fingerprint-indicator`, `lock-password-overflow`, `lock-stranded-recovery`, `sleep-lock`, `system-lock`, `update-lock`, `hyprland-session-locked`.

### Verification on hardware

With a Broadcom sensor and fprintd, a rejected read flashes the icon in the error color and dims it, then it returns to the hint color a second later; a valid read still unlocks unchanged. Also verified live on the tokyo-night theme.
