### PR TITLE
Recognize Ecosia as a Chromium-family browser in omarchy-launch-webapp

### DIFF
--- a/bin/omarchy-launch-webapp
+++ b/bin/omarchy-launch-webapp
@@ -6,7 +6,7 @@
 browser=$(xdg-settings get default-web-browser)
 
 case $browser in
-google-chrome* | brave* | microsoft-edge* | opera* | vivaldi* | helium*) ;;
+google-chrome* | brave* | microsoft-edge* | opera* | vivaldi* | helium* | org.ecosia.Browser* | ecosia*) ;;
 *) browser="chromium.desktop" ;;
 esac
 

--- a/test/shell.d/launch-webapp-browser-test.sh
+++ b/test/shell.d/launch-webapp-browser-test.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+mkdir -p "$tmp_dir/bin" "$tmp_dir/home/.local/share/applications"
+
+write_desktop() {
+  local name="$1" exec_line="$2"
+
+  cat >"$tmp_dir/home/.local/share/applications/$name" <<EOF
+[Desktop Entry]
+Exec=$exec_line
+EOF
+}
+
+# Ecosia is Chromium-based (AUR: ecosia-browser-bin) and supports --app like
+# the other browsers already recognized here, so it should launch under its
+# own profile rather than silently falling back to chromium.desktop.
+write_desktop "org.ecosia.Browser.desktop" "ecosiabrowser %U"
+write_desktop "chromium.desktop" "chromium %U"
+
+cat >"$tmp_dir/bin/xdg-settings" <<'SH'
+#!/bin/bash
+printf '%s\n' "$OMARCHY_TEST_BROWSER"
+SH
+
+cat >"$tmp_dir/bin/setsid" <<'SH'
+#!/bin/bash
+exec "$@"
+SH
+
+cat >"$tmp_dir/bin/uwsm-app" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >"$OMARCHY_TEST_LAUNCH"
+SH
+
+chmod +x "$tmp_dir/bin"/*
+
+launch_webapp() {
+  local browser="$1" url="$2"
+
+  : >"$tmp_dir/launch"
+  OMARCHY_TEST_BROWSER="$browser" OMARCHY_TEST_LAUNCH="$tmp_dir/launch" \
+    HOME="$tmp_dir/home" PATH="$tmp_dir/bin:$PATH" \
+    "$ROOT/bin/omarchy-launch-webapp" "$url"
+}
+
+launch_webapp "org.ecosia.Browser.desktop" "https://app.zoom.us/wc/home"
+grep -Fq "ecosiabrowser --app=https://app.zoom.us/wc/home" "$tmp_dir/launch" ||
+  fail "webapp launch uses the Ecosia binary when Ecosia is the default browser" \
+    "launch: $(cat "$tmp_dir/launch")"
+pass "webapp launch recognizes org.ecosia.Browser.desktop instead of falling back to chromium"
+
+launch_webapp "some-unknown-browser.desktop" "https://example.com"
+grep -Fq "chromium --app=https://example.com" "$tmp_dir/launch" ||
+  fail "webapp launch still falls back to chromium.desktop for an unrecognized browser" \
+    "launch: $(cat "$tmp_dir/launch")"
+pass "webapp launch keeps the chromium.desktop fallback for browsers outside the recognized list"


### PR DESCRIPTION
## Problem

`omarchy-launch-webapp` whitelists a fixed set of Chromium-family default-browser desktop ids and falls back to a hardcoded `chromium.desktop` for anything not on the list:

```bash
case $browser in
google-chrome* | brave* | microsoft-edge* | opera* | vivaldi* | helium*) ;;
*) browser="chromium.desktop" ;;
esac
```

Ecosia's default-browser id (`org.ecosia.Browser.desktop`) isn't on that list, so it silently falls into the `chromium.desktop` branch. Every web app launch — including protocol-handler launches like Zoom's `omarchy-webapp-handler-zoom` — then opens in a separate, unauthenticated Chromium profile instead of the user's real, signed-in Ecosia profile. From the user's perspective, the web app "forgets" who they are and any state (e.g. a partially-typed meeting number) on every single launch, because it isn't actually their browser.

Ecosia is Chromium-based (packaged in the AUR as `ecosia-browser-bin`, currently tracking Chromium 152.x) and supports `--app` mode exactly like the browsers already on this list, so it belongs in the same bucket as e.g. Helium (#3225).

## Fix

Add `org.ecosia.Browser* | ecosia*` to the recognized case, matching both the desktop id `xdg-settings` reports and the raw exec name, the same pattern already used for the other entries.

## Testing

- Added `test/shell.d/launch-webapp-browser-test.sh`, covering:
  - Ecosia as the default browser resolves to the Ecosia binary with `--app=<url>` instead of falling back to `chromium.desktop`.
  - An unrecognized browser id still falls back to `chromium.desktop` (existing behavior preserved).
- `./test/cli` passes fully.
- `./test/shell`: 52-53 files fail identically with and without this change on this sandbox (no compositor/hardware available), confirming they're pre-existing environment-dependent failures unrelated to this diff.