### PR TITLE
Add OpenCode Go agent usage provider

### DIFF
--- a/bin/omarchy-agent-usage-opencode-go
+++ b/bin/omarchy-agent-usage-opencode-go
@@ -6,10 +6,20 @@
 
 OpenCode Go (the opencode.ai Go plan) exposes no usage API; the web console
 scrapes its own pages. This collector reads the rolling 5-hour / weekly /
-monthly meters from the workspace page and the recent per-request token
-records from the usage page, using the auth session cookie Firefox or Zen
-Browser stores for opencode.ai. The panel only ever reads the JSON this
-prints; it never talks to disk formats or endpoints.
+monthly meters from the workspace page and the per-request token records
+from the usage list, using the auth session cookie Firefox or Zen Browser
+stores for opencode.ai. The console renders only the newest page of that
+list in HTML, so the collector pages the rest through the SPA's usage-list
+server function and keeps the trailing 7 local days — a refresh that never
+paged would permanently lose every day that scrolled past the newest page.
+The panel only ever reads the JSON this prints; it never talks to disk
+formats or endpoints.
+
+Metrics scoped in code:
+- limits: account truth from the workspace meters (rolling / weekly / monthly).
+- per-request stats (today*, recentDays, modelUsage): the trailing 7 local
+  days, window-bounded so the "tokens by day" and "tokens by model"
+  sections describe the same period.
 """
 
 from __future__ import annotations
@@ -38,6 +48,21 @@ SITE = "https://opencode.ai"
 # opencode.ai changes the SPA, this constant must be refreshed from the
 # workspace-*.js asset referenced by any /workspace/<id> page.
 WORKSPACES_SERVER_FN_ID = "def39973159c7f0483d8793a822b8dbb10d067e12c65455fcb4608459ba0234f"
+# SolidStart server-function id backing the SPA's usage-list pagination
+# (getUsageInfo in the workspace route chunk). The usage page SSR renders only
+# the newest page of per-request records; the client fetches older pages by
+# POSTing its (workspace, page) arguments to /_server. Refreshed the same way
+# as WORKSPACES_SERVER_FN_ID when the SPA changes.
+USAGE_SERVER_FN_ID = "bfd684bfc2e4eed05cd0b518f5e4eafd3f3376e3938abb9e536e7c03df831e5c"
+USAGE_PAGE_SIZE = 50
+# The usage walk pages newest-first and stops once the trailing window is
+# covered; per-request stats are bounded by this window so the panel's
+# "tokens by day" chart and "tokens by model" section describe the same
+# period. Pages older than the window are never requested.
+STATS_WINDOW_DAYS = 7
+# Safety valve: a week of very heavy usage at USAGE_PAGE_SIZE records a page
+# must not turn a refresh into an unbounded crawl.
+MAX_USAGE_PAGES = 40
 FETCH_TIMEOUT_SECONDS = 15
 USER_AGENT = "omarchy-agent-usage-opencode-go/1.0"
 
@@ -266,6 +291,100 @@ def fetch_page(cookie_header: str, path: str, retries: int = 1) -> str:
         continue
       raise
   raise last_error or RuntimeError("fetch_page exhausted retries")
+
+
+def seroval_args(args: list[Any]) -> dict[str, Any]:
+  """Serialize plain arguments the way the SPA's SolidStart client does.
+
+  The client POSTs its server-function arguments to /_server as a
+  seroval-encoded tree; the shape below was captured from the bundled client
+  (node types: 9 array, 1 string, 0 number). Only the string/int arguments
+  this collector sends are supported; anything else raises."""
+  def node(value: Any) -> dict[str, Any]:
+    if isinstance(value, str):
+      return {"t": 1, "s": value}
+    if isinstance(value, int):
+      return {"t": 0, "s": value}
+    raise TypeError(f"unsupported seroval argument: {value!r}")
+  return {
+    "t": {"t": 9, "i": 0, "l": len(args), "a": [node(a) for a in args], "o": 0},
+    "f": 31,
+    "m": [],
+  }
+
+
+def fetch_usage_chunk(cookie_header: str, workspace: str, page: int, instance: str, retries: int = 1) -> str:
+  """POST the usage-list server function for one page of per-request records.
+
+  Mirrors fetch_page's retry policy: no retry on 4xx, one retry on transport
+  failures and 5xx. The response body carries the same serialized records the
+  usage page SSR embeds, so parse_usage_records reads it unchanged."""
+  body = json.dumps(seroval_args([workspace, page]), separators=(",", ":")).encode("utf-8")
+  request = urllib.request.Request(
+    SITE + "/_server",
+    method="POST",
+    data=body,
+    headers={
+      "Cookie": cookie_header,
+      "User-Agent": USER_AGENT,
+      "Accept": "*/*",
+      "Content-Type": "application/json",
+      "X-Server-Id": USAGE_SERVER_FN_ID,
+      "X-Server-Instance": instance,
+    },
+  )
+  last_error: Exception | None = None
+  for attempt in range(retries + 1):
+    try:
+      with urllib.request.urlopen(request, timeout=FETCH_TIMEOUT_SECONDS) as response:
+        return response.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as error:
+      last_error = error
+      if 500 <= error.code < 600 and attempt < retries:
+        time.sleep(1)
+        continue
+      raise FetchError(error.code) from error
+    except urllib.error.URLError:
+      last_error = sys.exc_info()[1]
+      if attempt < retries:
+        time.sleep(1)
+        continue
+      raise
+  raise last_error or RuntimeError("fetch_usage_chunk exhausted retries")
+
+
+def fetch_usage_records(cookie_header: str, workspace: str) -> list[dict[str, Any]]:
+  """Page the workspace usage list back through the trailing week.
+
+  The console's usage page renders only the newest page of per-request
+  records and fetches the rest by page index; a collector that stopped at
+  that page would permanently lose every day that scrolled past it. The
+  pages are contiguous newest-first, so the walk ends when a page comes back
+  empty (the list's oldest page) or when a full page's oldest record
+  predates the trailing window — everything older is out of window and never
+  requested. Page size is not a stop signal: new records land while the walk
+  runs, so an interior page can come back short without being the last, and
+  ending on ``len < 50`` dropped entire days.
+
+  A page that fails mid-walk keeps the pages already parsed (the most
+  recent days stay complete); failing the very first page degrades to the
+  empty-records shape, exactly like the old single-page read."""
+  records: list[dict[str, Any]] = []
+  window_start = (dt.date.today() - dt.timedelta(days=STATS_WINDOW_DAYS - 1)).strftime("%Y-%m-%d")
+  for page in range(MAX_USAGE_PAGES):
+    try:
+      html = fetch_usage_chunk(cookie_header, workspace, page, f"server-fn:{page + 20}")
+    except Exception:
+      break
+    chunk = parse_usage_records(html)
+    if not chunk:
+      # An empty page is the list's last page: the account history ends.
+      break
+    records.extend(chunk)
+    if min(record["day"] for record in chunk) < window_start:
+      # The trailing window is covered; every further page is older.
+      break
+  return [record for record in records if record["day"] >= window_start]
 
 
 # ------------------------------------------------------------------- parse
@@ -582,15 +701,13 @@ def main() -> int:
     return 0
 
   # Meters parsed — this is the healthy answer of record, so the cache is
-  # refreshed before the (optional) usage page fetch.
+  # refreshed before the (optional) usage list walk.
   write_limits_cache(build_limits(meters))
 
-  records: list[dict[str, Any]] = []
   try:
-    usage_html = fetch_page(cookie, f"/workspace/{workspace}/usage")
-    records = parse_usage_records(usage_html)
+    # Limits are the point; a usage walk that fails entirely still shows them.
+    records = fetch_usage_records(cookie, workspace)
   except Exception:
-    # Limits are the point; a missing usage page still shows them.
     records = []
 
   print_record(build_record(meters, plan, records))

--- a/bin/omarchy-agent-usage-opencode-go
+++ b/bin/omarchy-agent-usage-opencode-go
@@ -1,0 +1,403 @@
+#!/usr/bin/python3
+# omarchy:summary=Print the OpenCode Go usage record as JSON
+# omarchy:args=[--force] [--limits-only]
+# omarchy:hidden=true
+"""Collect OpenCode Go usage into one display-ready JSON record.
+
+OpenCode Go (the opencode.ai Go plan) exposes no usage API; the web console
+scrapes its own pages. This collector reads the rolling 5-hour / weekly /
+monthly meters from the workspace page and the recent per-request token
+records from the usage page, using the auth session cookie Firefox or Zen
+Browser stores for opencode.ai. The panel only ever reads the JSON this
+prints; it never talks to disk formats or endpoints.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import shutil
+import sqlite3
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+AGENT_ID = "opencode-go"
+AGENT_NAME = "OpenCode Go"
+AUTH_HELP = "Sign in to opencode.ai in a browser (Firefox or Zen) so its session cookie is available."
+WORKSPACE_HELP = 'Set "workspaceId" in ~/.config/omarchy/agents/opencode-go.json or OPENCODE_WORKSPACE.'
+SITE = "https://opencode.ai"
+# SolidStart server-function id backing the SPA's workspace picker query. If
+# opencode.ai changes the SPA, this constant must be refreshed from the
+# workspace-*.js asset referenced by any /workspace/<id> page.
+WORKSPACES_SERVER_FN_ID = "def39973159c7f0483d8793a822b8dbb10d067e12c65455fcb4608459ba0234f"
+FETCH_TIMEOUT_SECONDS = 15
+USER_AGENT = "omarchy-agent-usage-opencode-go/1.0"
+
+METER_RE = re.compile(
+    r'(rollingUsage|weeklyUsage|monthlyUsage):\$R\[\d+\]=\{status:"([^"]+)",resetInSec:(\d+),usagePercent:([\d.]+)\}'
+)
+PLAN_RE = re.compile(r'liteSubscriptionID:"[^"]+"')
+WORKSPACE_RE = re.compile(r'\{id:"(wrk_[A-Za-z0-9]{26})"[^}]*\}')
+# One serialized usage record from the workspace usage page. Field order is
+# stable in the observed SSR payload; a markup change here needs a regex retune.
+USAGE_RECORD_RE = re.compile(
+    r'\{id:"usg_[^"]+",workspaceID:"wrk_[^"]+",timeCreated:\$R\[\d+\]=new Date\("([^"]+)"\),'
+    r'timeUpdated:\$R\[\d+\]=new Date\("[^"]+"\),timeDeleted:[^,]+,'
+    r'model:"([^"]+)",provider:"([^"]+)",'
+    r'inputTokens:(\d+),outputTokens:(\d+),reasoningTokens:(\d+),cacheReadTokens:(\d+),'
+    r'cacheWrite5mTokens:([^,]+),cacheWrite1hTokens:([^,]+),cost:(\d+)'
+)
+
+
+def expand_path(value: str) -> Path:
+  return Path(os.path.expandvars(os.path.expanduser(value))).resolve()
+
+
+def agent_config() -> dict[str, Any]:
+  root = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config")) / "omarchy" / "agents"
+  try:
+    data = json.loads((root / "opencode-go.json").read_text(encoding="utf-8"))
+    return data if isinstance(data, dict) else {}
+  except Exception:
+    return {}
+
+
+def number(value: Any) -> int:
+  try:
+    n = float(value or 0)
+    return round(n) if n == n else 0
+  except Exception:
+    return 0
+
+
+def local_date_string() -> str:
+  return dt.date.today().strftime("%Y-%m-%d")
+
+
+# ---------------------------------------------------------------- session
+
+
+def find_cookie_dbs() -> list[Path]:
+  home = Path.home()
+  roots = [
+    home / ".mozilla" / "firefox",
+    home / ".config" / "mozilla" / "firefox",
+    home / ".zen",
+    home / ".var" / "app" / "org.mozilla.firefox" / ".mozilla" / "firefox",
+    home / ".var" / "app" / "io.github.zen_browser.zen" / ".zen",
+  ]
+  found: list[Path] = []
+  for root in roots:
+    if not root.is_dir():
+      continue
+    for entry in sorted(root.iterdir()):
+      candidate = entry / "cookies.sqlite"
+      if candidate.is_file():
+        found.append(candidate)
+  return found
+
+
+def extract_auth_cookie(cookie_db: Path) -> str:
+  """Read the opencode.ai auth cookie from a Firefox-style cookies.sqlite.
+
+  The database is copied to a temp dir first so a running browser's WAL (and
+  the file locks that come with it) does not interfere; the copy is a snapshot.
+  """
+  tmpdir = Path(tempfile.mkdtemp())
+  try:
+    db = tmpdir / "cookies.sqlite"
+    for suffix in ("", "-wal", "-shm"):
+      source = Path(str(cookie_db) + suffix)
+      if source.is_file():
+        shutil.copy2(source, Path(str(db) + suffix))
+    try:
+      conn = sqlite3.connect(f"file:{db}?mode=ro", uri=True)
+      try:
+        row = conn.execute(
+          "SELECT value FROM moz_cookies WHERE host IN ('.opencode.ai','opencode.ai') "
+          "AND name='auth' ORDER BY expiry DESC LIMIT 1"
+        ).fetchone()
+        return str(row[0]) if row else ""
+      finally:
+        conn.close()
+    except sqlite3.Error:
+      return ""
+  finally:
+    shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def resolve_session(cfg: dict[str, Any]) -> str:
+  cookie_file = str(cfg.get("cookieFile") or "").strip()
+  if cookie_file:
+    try:
+      value = expand_path(cookie_file).read_text(encoding="utf-8").strip()
+      if value:
+        return value
+    except Exception:
+      pass
+  for db in find_cookie_dbs():
+    cookie = extract_auth_cookie(db)
+    if cookie:
+      return cookie
+  return ""
+
+
+# --------------------------------------------------------------- workspace
+
+
+def list_workspaces(cookie: str) -> list[str]:
+  request = urllib.request.Request(
+    SITE + "/_server",
+    method="POST",
+    headers={
+      "Cookie": f"auth={cookie}",
+      "User-Agent": USER_AGENT,
+      "Accept": "text/html",
+      "X-Server-Id": WORKSPACES_SERVER_FN_ID,
+      "X-Server-Instance": "server-fn:1",
+    },
+  )
+  with urllib.request.urlopen(request, timeout=FETCH_TIMEOUT_SECONDS) as response:
+    body = response.read().decode("utf-8", errors="replace")
+  seen: dict[str, bool] = {}
+  for match in WORKSPACE_RE.finditer(body):
+    seen[match.group(1)] = True
+  return sorted(seen)
+
+
+def resolve_workspace(cfg: dict[str, Any], cookie: str) -> str:
+  explicit = str(cfg.get("workspaceId") or "").strip()
+  if explicit:
+    return explicit
+  env = os.environ.get("OPENCODE_WORKSPACE", "").strip()
+  if env:
+    return env
+  try:
+    workspaces = list_workspaces(cookie)
+  except Exception:
+    return ""
+  if len(workspaces) == 1:
+    return workspaces[0]
+  return ""
+
+
+# ------------------------------------------------------------------- fetch
+
+
+def fetch_page(cookie: str, path: str) -> str:
+  """GET a workspace page. HTTP status errors become RuntimeError; transport
+  failures raise urllib.error.URLError unchanged."""
+  request = urllib.request.Request(
+    SITE + path,
+    headers={
+      "Cookie": f"auth={cookie}",
+      "User-Agent": USER_AGENT,
+      "Accept": "text/html",
+    },
+  )
+  try:
+    with urllib.request.urlopen(request, timeout=FETCH_TIMEOUT_SECONDS) as response:
+      return response.read().decode("utf-8", errors="replace")
+  except urllib.error.HTTPError as error:
+    # HTTPError subclasses URLError; convert it so main() can tell a server
+    # answer from a transport failure (no route, no DNS, timeout).
+    raise RuntimeError(f"opencode.ai returned status {error.code}") from error
+
+
+# ------------------------------------------------------------------- parse
+
+
+def parse_meters(html: str) -> tuple[dict[str, dict[str, Any]], str]:
+  meters: dict[str, dict[str, Any]] = {}
+  for match in METER_RE.finditer(html):
+    name, status, reset_in_sec, percent = match.groups()
+    meters[name] = {"status": status, "resetInSec": int(reset_in_sec), "usagePercent": float(percent)}
+  plan = "Go" if PLAN_RE.search(html) else ""
+  return meters, plan
+
+
+def parse_usage_records(html: str) -> list[dict[str, Any]]:
+  records: list[dict[str, Any]] = []
+  for match in USAGE_RECORD_RE.finditer(html):
+    created, model, provider, inp, out, reasoning, cache_read, write_5m, write_1h, cost = match.groups()
+    records.append({
+      "day": str(created)[:10],
+      "model": model,
+      "input": number(inp),
+      "output": number(out),
+      "reasoning": number(reasoning),
+      "cacheRead": number(cache_read),
+      "cacheWrite5m": number(write_5m),
+      "cacheWrite1h": number(write_1h),
+    })
+  return records
+
+
+# ------------------------------------------------------------------- stats
+
+
+def build_stats(records: list[dict[str, Any]]) -> dict[str, Any]:
+  today = local_date_string()
+  recent_dates = [(dt.date.today() - dt.timedelta(days=offset)).strftime("%Y-%m-%d") for offset in range(6, -1, -1)]
+  recent = {day: {"date": day, "messageCount": 0} for day in recent_dates}
+  usage_by_model: dict[str, dict[str, int]] = {}
+  active_dates: set[str] = set()
+  today_tokens: dict[str, int] = {}
+  today_prompts = 0
+
+  for record in records:
+    total = (
+      record["input"] + record["output"] + record["reasoning"]
+      + record["cacheRead"] + record["cacheWrite5m"] + record["cacheWrite1h"]
+    )
+    bucket = usage_by_model.setdefault(record["model"], {
+      "inputTokens": 0,
+      "outputTokens": 0,
+      "cacheReadInputTokens": 0,
+      "cacheCreationInputTokens": 0,
+    })
+    bucket["inputTokens"] += record["input"]
+    # OpenCode Go keeps thinking tokens out of output; both are generated.
+    bucket["outputTokens"] += record["output"] + record["reasoning"]
+    bucket["cacheReadInputTokens"] += record["cacheRead"]
+    bucket["cacheCreationInputTokens"] += record["cacheWrite5m"] + record["cacheWrite1h"]
+
+    active_dates.add(record["day"])
+    if record["day"] in recent:
+      recent[record["day"]]["messageCount"] += total
+    if record["day"] == today:
+      today_prompts += 1
+      today_tokens[record["model"]] = today_tokens.get(record["model"], 0) + total
+
+  return {
+    "todayPrompts": today_prompts,
+    "todaySessions": 0,
+    "todayTotalTokens": sum(today_tokens.values()),
+    "todayTokensByModel": today_tokens,
+    "recentDays": [recent[day] for day in recent_dates],
+    "modelUsage": usage_by_model,
+    "totalPrompts": len(records),
+    "totalSessions": 0,
+    "activeDays": len(active_dates),
+    "activeDates": sorted(active_dates),
+  }
+
+
+# ------------------------------------------------------------------- record
+
+
+def resets_at(reset_in_sec: int) -> str:
+  return (dt.datetime.now(dt.timezone.utc) + dt.timedelta(seconds=reset_in_sec)).isoformat()
+
+
+def build_limits(meters: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
+  order = [("rollingUsage", "Rolling (5-hour)"), ("weeklyUsage", "Weekly"), ("monthlyUsage", "Monthly")]
+  limits: list[dict[str, Any]] = []
+  for key, label in order:
+    meter = meters.get(key)
+    if not meter or meter.get("status") != "ok":
+      continue
+    percent = float(meter.get("usagePercent") or 0) / 100.0
+    if not (percent >= 0):
+      continue
+    limits.append({
+      "label": label,
+      "percent": min(1.0, percent),
+      "resetsAt": resets_at(int(meter.get("resetInSec") or 0)),
+    })
+  return limits
+
+
+def base_record(**overrides: Any) -> dict[str, Any]:
+  record = {
+    "schemaVersion": 1,
+    "id": AGENT_ID,
+    "name": AGENT_NAME,
+    "updatedAt": dt.datetime.now(dt.timezone.utc).isoformat(),
+    "ready": False,
+    "hasLocalStats": True,
+    "hasPromptStats": False,
+    "tierLabel": "",
+    "usageStatusText": "",
+    "authHelpText": "",
+    "limits": [],
+  }
+  record.update(overrides)
+  return record
+
+
+def build_record(meters: dict[str, dict[str, Any]], plan: str, records: list[dict[str, Any]]) -> dict[str, Any]:
+  limits = build_limits(meters)
+  record = base_record(
+    ready=bool(limits),
+    tierLabel=plan or "Go",
+    limits=limits,
+  )
+  if records:
+    record.update(build_stats(records))
+  return record
+
+
+def print_record(record: dict[str, Any]) -> None:
+  print(json.dumps(record, separators=(",", ":"), sort_keys=True))
+
+
+def main() -> int:
+  parser = argparse.ArgumentParser()
+  parser.add_argument("--force", action="store_true", help="re-fetch everything, ignoring caches")
+  parser.add_argument("--limits-only", action="store_true", help="reuse recent stats; only limits must be fresh")
+  parser.parse_args()
+
+  cfg = agent_config()
+  cookie = resolve_session(cfg)
+
+  if not cookie:
+    print_record(base_record(authHelpText=AUTH_HELP))
+    return 0
+
+  workspace = resolve_workspace(cfg, cookie)
+  if not workspace:
+    print_record(base_record(usageStatusText="Workspace not configured", authHelpText=WORKSPACE_HELP))
+    return 0
+
+  try:
+    go_html = fetch_page(cookie, f"/workspace/{workspace}/go")
+  except urllib.error.URLError:
+    # A transport failure reached no server at all — no route, no DNS. Ask the
+    # shell to try again sooner than its regular interval.
+    print_record(base_record(retryAdvised=True, authHelpText="Couldn't reach opencode.ai. Retrying shortly."))
+    return 0
+  except RuntimeError as error:
+    print_record(base_record(authHelpText=f"{error}. Sign in again in a browser."))
+    return 0
+
+  meters, plan = parse_meters(go_html)
+  if not meters:
+    # The console redirects signed-out sessions to /signin; the page then
+    # carries no meter data.
+    print_record(base_record(
+      authHelpText="The opencode.ai session cookie is invalid or expired. Sign in again in a browser."
+    ))
+    return 0
+
+  records: list[dict[str, Any]] = []
+  try:
+    usage_html = fetch_page(cookie, f"/workspace/{workspace}/usage")
+    records = parse_usage_records(usage_html)
+  except Exception:
+    # Limits are the point; a missing usage page still shows them.
+    records = []
+
+  print_record(build_record(meters, plan, records))
+  return 0
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())

--- a/bin/omarchy-agent-usage-opencode-go
+++ b/bin/omarchy-agent-usage-opencode-go
@@ -172,20 +172,23 @@ def list_workspaces(cookie: str) -> list[str]:
   return sorted(seen)
 
 
-def resolve_workspace(cfg: dict[str, Any], cookie: str) -> str:
+def resolve_workspace(cfg: dict[str, Any], cookie: str) -> tuple[str, str]:
+  """Return (workspace, status); status is "" on success, "transport" when the
+  workspace RPC could not reach the network, and "unknown" when zero or
+  several workspaces came back."""
   explicit = str(cfg.get("workspaceId") or "").strip()
   if explicit:
-    return explicit
+    return explicit, ""
   env = os.environ.get("OPENCODE_WORKSPACE", "").strip()
   if env:
-    return env
+    return env, ""
   try:
     workspaces = list_workspaces(cookie)
   except Exception:
-    return ""
+    return "", "transport"
   if len(workspaces) == 1:
-    return workspaces[0]
-  return ""
+    return workspaces[0], ""
+  return "", "unknown"
 
 
 # ------------------------------------------------------------------- fetch
@@ -227,8 +230,12 @@ def parse_usage_records(html: str) -> list[dict[str, Any]]:
   records: list[dict[str, Any]] = []
   for match in USAGE_RECORD_RE.finditer(html):
     created, model, provider, inp, out, reasoning, cache_read, write_5m, write_1h, cost = match.groups()
+    # The panel's "today" is the local calendar date; the record timestamp is
+    # UTC, so convert before slicing or evening requests in non-UTC zones land
+    # on tomorrow's date and drop out of todayPrompts/todayTotalTokens.
+    local_created = dt.datetime.fromisoformat(created.replace("Z", "+00:00")).astimezone()
     records.append({
-      "day": str(created)[:10],
+      "day": local_created.strftime("%Y-%m-%d"),
       "model": model,
       "input": number(inp),
       "output": number(out),
@@ -362,8 +369,13 @@ def main() -> int:
     print_record(base_record(authHelpText=AUTH_HELP))
     return 0
 
-  workspace = resolve_workspace(cfg, cookie)
+  workspace, workspace_status = resolve_workspace(cfg, cookie)
   if not workspace:
+    if workspace_status == "transport":
+      # The workspace RPC never reached the network; retry sooner than the
+      # regular interval instead of blaming the configuration.
+      print_record(base_record(retryAdvised=True, authHelpText="Couldn't reach opencode.ai. Retrying shortly."))
+      return 0
     print_record(base_record(usageStatusText="Workspace not configured", authHelpText=WORKSPACE_HELP))
     return 0
 
@@ -376,6 +388,12 @@ def main() -> int:
     return 0
   except RuntimeError as error:
     print_record(base_record(authHelpText=f"{error}. Sign in again in a browser."))
+    return 0
+  except Exception:
+    # http.client.HTTPException subclasses (BadStatusLine, IncompleteRead) and
+    # anything else must still yield a valid record, never a crash with no
+    # JSON on stdout.
+    print_record(base_record(authHelpText="Couldn't read the opencode.ai response. Retrying shortly."))
     return 0
 
   meters, plan = parse_meters(go_html)

--- a/bin/omarchy-agent-usage-opencode-go
+++ b/bin/omarchy-agent-usage-opencode-go
@@ -7,8 +7,11 @@
 OpenCode Go (the opencode.ai Go plan) exposes no usage API; the web console
 scrapes its own pages. This collector reads the rolling 5-hour / weekly /
 monthly meters from the workspace page and the per-request token records
-from the usage list, using the auth session cookie Firefox or Zen Browser
-stores for opencode.ai. The console renders only the newest page of that
+from the usage list, using the auth session cookie any browser on the
+machine stores for opencode.ai — Firefox and Zen keep it plaintext in
+sqlite; Chrome-family stores (Chrome, Chromium, Brave, Edge, Vivaldi,
+Opera) encrypt it with their SafeStorage password, which the collector
+deciphers from the same Secret Service item the browser reads. The console renders only the newest page of that
 list in HTML, so the collector pages the rest through the SPA's usage-list
 server function and keeps the trailing 7 local days — a refresh that never
 paged would permanently lose every day that scrolled past the newest page.
@@ -31,12 +34,14 @@ from __future__ import annotations
 
 import argparse
 import datetime as dt
+import hashlib
 import json
 import math
 import os
 import re
 import shutil
 import sqlite3
+import subprocess
 import sys
 import tempfile
 import time
@@ -44,6 +49,16 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 from typing import Any
+
+# Chrome-family stores encrypt their cookie values; deciphering them needs
+# PBKDF2 + AES from the cryptography wheel. The collector is fully functional
+# without it (Firefox/Zen cookies are plaintext in sqlite); Chrome rows are
+# only skipped when the wheel is absent, never fatal.
+try:
+  import cryptography  # noqa: F401  (presence probe)
+  _HAS_CRYPTO = True
+except Exception:
+  _HAS_CRYPTO = False
 
 AGENT_ID = "opencode-go"
 AGENT_NAME = "OpenCode Go"
@@ -76,6 +91,30 @@ MAX_USAGE_PAGES = 40
 USAGE_WALK_SECONDS = 60
 FETCH_TIMEOUT_SECONDS = 15
 USER_AGENT = "omarchy-agent-usage-opencode-go/1.0"
+# Chrome-family config dir -> the browser's SafeStorage "application" name
+# (the attribute secret-tool searches for the keyring password it uses).
+CHROME_CONFIG_DIRS = {
+  "google-chrome": "chrome",
+  "google-chrome-beta": "chrome",
+  "google-chrome-unstable": "chrome",
+  "chromium": "chromium",
+  "brave-browser": "brave",
+  "microsoft-edge": "microsoft-edge",
+  "vivaldi": "vivaldi",
+  "opera": "opera",
+  "ungoogled-chromium": "ungoogled-chromium",
+}
+# Flatpak package ids map onto a config dir under their data root.
+CHROME_FLATPAK_ROOTS = {
+  "com.google.Chrome": "google-chrome",
+  "org.chromium.Chromium": "chromium",
+  "com.brave.Browser": "brave-browser",
+  "com.microsoft.Edge": "microsoft-edge",
+}
+# Chrome timestamps (last_access_utc, …) count microseconds since 1601-01-01
+# (FILETIME), Firefox's since 1970-01-01; the drift keeps cross-browser
+# freshness comparisons honest.
+FILETIME_EPOCH_UNIX_US = 11644473600000000
 
 METER_RE = re.compile(
     r'(rollingUsage|weeklyUsage|monthlyUsage):\$R\[\d+\]=\{status:"([^"]+)",resetInSec:(\d+),usagePercent:([\d.]+)[^}]*\}'
@@ -188,6 +227,219 @@ def extract_all_cookies(cookie_db: Path) -> list[tuple[str, str, int]]:
     shutil.rmtree(tmpdir, ignore_errors=True)
 
 
+# ---------------------------------------------------------------- chrome
+
+
+def chrome_roots() -> dict[Path, str]:
+  """Config roots for every Chrome-family browser on the machine.
+
+  Maps a profile root to the application name the browser's SafeStorage
+  password lives under in the Secret Service. Covers the classic ~/.config
+  layout, Flatpak data dirs, and the snap chromium profile root."""
+  home = Path.home()
+  roots: dict[Path, str] = {}
+  for config_dir, application in CHROME_CONFIG_DIRS.items():
+    roots[home / ".config" / config_dir] = application
+  for pkg, config_dir in CHROME_FLATPAK_ROOTS.items():
+    roots[home / ".var/app" / pkg / "config" / config_dir] = CHROME_CONFIG_DIRS[config_dir]
+  snap = home / "snap/chromium/common/chromium"
+  if snap.is_dir():
+    roots[snap] = "chromium"
+  return roots
+
+
+def find_chrome_cookie_dbs() -> list[tuple[Path, str]]:
+  """Discover (Cookies db, application) pairs for every profile.
+
+  Each profile dir carries either a top-level `Cookies` or a
+  `Network/Cookies` (newer Chrome layouts). One database wins per profile."""
+  found: list[tuple[Path, str]] = []
+  for root, application in chrome_roots().items():
+    if not root.is_dir():
+      continue
+    for profile in sorted(root.iterdir()):
+      for candidate in (profile / "Cookies", profile / "Network" / "Cookies"):
+        if candidate.is_file():
+          found.append((candidate, application))
+          break
+  return found
+
+
+_chrome_secret_cache: dict[str, str] = {}
+
+
+def chrome_secret(application: str) -> str | None:
+  """The SafeStorage password for one browser, from the Secret Service.
+
+  This is the same item the browser itself reads ("Chromium Safe Storage",
+  schema chrome_libsecret_os_crypt_password_v2, keyed by the application
+  attribute). None when the service is unreachable, the item is missing, or
+  the keyring is locked — callers then leave that browser's cookie rows
+  undecrypted instead of failing. Cached per process because every profile
+  of one browser shares the password."""
+  if application in _chrome_secret_cache:
+    return _chrome_secret_cache[application] or None
+  secret = ""
+  secret_tool = shutil.which("secret-tool")
+  if secret_tool:
+    try:
+      result = subprocess.run(
+        [secret_tool, "lookup", "application", application],
+        capture_output=True, text=True, timeout=5,
+      )
+      if result.returncode == 0:
+        secret = result.stdout.strip()
+    except Exception:
+      secret = ""
+  _chrome_secret_cache[application] = secret
+  return secret or None
+
+
+def chrome_derived_key(secret: str) -> bytes | None:
+  """AES-128 key the browser derives from its SafeStorage password:
+  PBKDF2-HMAC-SHA1(password, salt="saltysalt", 1 iteration, 16 bytes)."""
+  if not _HAS_CRYPTO:
+    return None
+  try:
+    from cryptography.hazmat.primitives import hashes
+    from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+    return PBKDF2HMAC(
+      algorithm=hashes.SHA1(), length=16, salt=b"saltysalt", iterations=1
+    ).derive(secret.encode("utf-8"))
+  except Exception:
+    return None
+
+
+def chrome_decryption_keys(application: str) -> list[bytes]:
+  """Candidate AES keys for one browser, strongest first."""
+  keys: list[bytes] = []
+  secret = chrome_secret(application)
+  derived = chrome_derived_key(secret) if secret else None
+  if derived:
+    keys.append(derived)
+  # Keyringless legacy builds fell back to the constant "peanuts" passphrase
+  # (and briefly the empty one, crbug.com/40055416). Try both so old Chrome
+  # v10 stores still decrypt on a machine without a keyring item.
+  for fallback in (b"peanuts", b""):
+    key = chrome_derived_key(fallback.decode("latin-1"))
+    if key:
+      keys.append(key)
+  return keys
+
+
+def _aes_cbc_decrypt(key: bytes, iv: bytes, ciphertext: bytes) -> bytes | None:
+  try:
+    from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+    decryptor = Cipher(algorithms.AES(key), modes.CBC(iv)).decryptor()
+    plain = decryptor.update(ciphertext) + decryptor.finalize()
+  except Exception:
+    return None
+  if not plain:
+    return plain
+  pad = plain[-1]
+  if pad < 1 or pad > 16 or plain[-pad:] != bytes([pad]) * pad:
+    return None
+  return plain[:-pad]
+
+
+def chrome_decrypt_value(encrypted_value: bytes, host_key: str, keys: list[bytes]) -> str | None:
+  """One Chrome-family cookie cell's value, or None when unreadable.
+
+  Current Chromium wraps values as b"v11" + AES-128-CBC ciphertext with a
+  fixed all-space IV (async os_crypt, key = PBKDF2 of the SafeStorage
+  password); older stores use b"v10" + random IV + ciphertext. The store
+  prepends SHA256(host_key) to the plaintext when encrypting, as a wrong-key
+  check, and strips it on load; we do the same. Unknown or app-bound
+  (v20+) schemes, and every wrong key, come back None."""
+  if encrypted_value[:3] == b"v10":
+    iv, ciphertext = encrypted_value[3:19], encrypted_value[19:]
+  elif encrypted_value[:3] == b"v11":
+    iv, ciphertext = b" " * 16, encrypted_value[3:]
+  else:
+    return None
+  digest = hashlib.sha256(host_key.encode("utf-8")).digest()[:32]
+  for key in keys:
+    plain = _aes_cbc_decrypt(key, iv, ciphertext)
+    if plain is None:
+      continue
+    candidate = plain[32:] if plain.startswith(digest) else plain
+    try:
+      return candidate.decode("utf-8")
+    except UnicodeDecodeError:
+      return candidate.decode("latin-1")
+  return None
+
+
+def _chrome_plaintext_value(raw: object) -> str:
+  if isinstance(raw, bytes):
+    try:
+      return raw.decode("utf-8")
+    except UnicodeDecodeError:
+      return raw.decode("latin-1")
+  return str(raw or "")
+
+
+def extract_chrome_cookies(cookie_db: Path, application: str) -> list[tuple[str, str, int]]:
+  """Read every opencode.ai cookie from a Chrome-family cookies database.
+
+  Mirrors extract_all_cookies: the database is copied to a temp dir first
+  (WAL and file locks), host scoping matches only the main opencode.ai
+  domain, and entries come back as (name, value, lastAccessed) tuples with
+  lastAccessed in Unix microseconds so the cross-browser freshness sort and
+  de-duplication behave. Rows the browser itself would drop — both a
+  plaintext and an encrypted value, or an encrypted row no candidate key
+  decodes — are skipped, never fatal. The SafeStorage password is only
+  fetched when a row actually needs deciphering, so a store without
+  opencode.ai cookies (or with everything in plaintext) never touches the
+  Secret Service."""
+  tmpdir = Path(tempfile.mkdtemp())
+  try:
+    db = tmpdir / "Cookies"
+    for suffix in ("", "-wal", "-shm"):
+      source = Path(str(cookie_db) + suffix)
+      if source.is_file():
+        shutil.copy2(source, Path(str(db) + suffix))
+    try:
+      conn = sqlite3.connect(f"file:{db}?mode=ro", uri=True)
+      try:
+        rows = conn.execute(
+          "SELECT host_key, name, value, encrypted_value, last_access_utc "
+          "FROM cookies WHERE host_key IN ('.opencode.ai','opencode.ai')"
+        ).fetchall()
+      finally:
+        conn.close()
+    except sqlite3.Error:
+      return []
+    needs_keys = any(
+      encrypted_value if isinstance(encrypted_value, (bytes, bytearray)) else b""
+      for _, _, _, encrypted_value, _ in rows
+    )
+    keys = chrome_decryption_keys(application) if needs_keys else []
+    out: list[tuple[str, str, int]] = []
+    for host_key, name, plain_value, encrypted_value, last_access_utc in rows:
+      encrypted = encrypted_value if isinstance(encrypted_value, (bytes, bytearray)) else b""
+      if plain_value and encrypted:
+        # Chrome treats a row carrying both as corrupt and drops the cookie.
+        continue
+      if plain_value:
+        value = _chrome_plaintext_value(plain_value)
+      elif encrypted:
+        value = chrome_decrypt_value(bytes(encrypted), str(host_key), keys)
+      else:
+        continue
+      if not value:
+        continue
+      accessed = int(last_access_utc or 0)
+      if accessed > 0:
+        accessed -= FILETIME_EPOCH_UNIX_US
+      out.append((str(name), value, accessed))
+    return out
+  except (OSError, PermissionError):
+    return []
+  finally:
+    shutil.rmtree(tmpdir, ignore_errors=True)
+
+
 def build_cookie_header(cookies: list[tuple[str, str, int]]) -> str:
   """Format cookies as a `Cookie` header value, de-duplicating by name so
   the most recently accessed value wins (browser behavior)."""
@@ -213,6 +465,8 @@ def resolve_session(cfg: dict[str, Any]) -> str:
   all_cookies: list[tuple[str, str, int]] = []
   for db in find_cookie_dbs():
     all_cookies.extend(extract_all_cookies(db))
+  for db, application in find_chrome_cookie_dbs():
+    all_cookies.extend(extract_chrome_cookies(db, application))
   if not all_cookies:
     return ""
   # Send every opencode.ai cookie, just like the browser does.

--- a/bin/omarchy-agent-usage-opencode-go
+++ b/bin/omarchy-agent-usage-opencode-go
@@ -525,6 +525,40 @@ def build_stats(records: list[dict[str, Any]]) -> dict[str, Any]:
   }
 
 
+# The field names build_stats emits; previous_stats reuses exactly this set
+# so a limits-only record never loses or fabricates a stat the panel reads.
+STATS_FIELDS = [
+  "todayPrompts", "todaySessions", "todayTotalTokens", "todayTokensByModel",
+  "recentDays", "modelUsage", "totalPrompts", "totalSessions",
+  "activeDays", "activeDates",
+]
+
+
+def previous_stats() -> dict[str, Any]:
+  """Stats from the record the last run left for the panel.
+
+  A limits-only refresh (the panel opening) has no walk to tally stats from,
+  but it must not blank the chart that the last full run drew: Claude and
+  Codex reuse their recent scans in this mode, and the state record is the
+  only recent scan this collector has. When there is no previous record —
+  or one without the full stats shape — the zero-shape stands in, exactly as
+  if no run had written yet.
+  """
+  root = Path(os.environ.get("XDG_STATE_HOME", Path.home() / ".local" / "state")) / "omarchy" / "agents" / "usage"
+  try:
+    data = json.loads((root / f"{AGENT_ID}.json").read_text(encoding="utf-8"))
+  except Exception:
+    return build_stats([])
+  if not isinstance(data, dict) or data.get("id") != AGENT_ID:
+    return build_stats([])
+  stats = {key: data[key] for key in STATS_FIELDS if key in data}
+  if len(stats) != len(STATS_FIELDS):
+    # A partial (e.g. older) record would leave the panel without the
+    # sections it keys off; a full zero-shape is safer than a partial one.
+    return build_stats([])
+  return stats
+
+
 # ------------------------------------------------------------ limits cache
 #
 # The meters scraped on a healthy run are cached so a later refresh failure
@@ -707,6 +741,7 @@ def build_record(
   plan: str,
   records: list[dict[str, Any]],
   go_config: dict[str, Any] | None = None,
+  stats: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
   go_config = go_config or {}
   limits = build_limits(meters)
@@ -718,10 +753,11 @@ def build_record(
     usageStatusText=status_text,
     authHelpText=auth_help,
   )
-  # Stats always ride along, zero-shaped when no usage records parsed: the
-  # panel keys off their presence for the today/total lines and merges them
-  # across providers.
-  record.update(build_stats(records))
+  # Stats always ride along: freshly tallied from the usage walk, or reused
+  # from the previous record when a limits-only refresh had no walk to tally
+  # from. The panel keys off their presence for the today/total lines and
+  # merges them across providers.
+  record.update(stats if stats is not None else build_stats(records))
   return record
 
 
@@ -811,15 +847,20 @@ def main() -> int:
   write_limits_cache(build_limits(meters))
 
   # Limits are the point; a usage walk that fails entirely still shows them.
-  # A limits-only refresh (the panel opening) skips the walk altogether.
+  # A limits-only refresh (the panel opening) skips the walk and keeps the
+  # last record's stats — the chart must not blank out every time the panel
+  # opens, pending the next full refresh.
   records = []
-  if not args.limits_only:
+  stats = None
+  if args.limits_only:
+    stats = previous_stats()
+  else:
     try:
       records = fetch_usage_records(cookie, workspace)
     except Exception:
       records = []
 
-  print_record(build_record(meters, plan, records, go_config))
+  print_record(build_record(meters, plan, records, go_config, stats))
   return 0
 
 

--- a/bin/omarchy-agent-usage-opencode-go
+++ b/bin/omarchy-agent-usage-opencode-go
@@ -42,7 +42,7 @@ FETCH_TIMEOUT_SECONDS = 15
 USER_AGENT = "omarchy-agent-usage-opencode-go/1.0"
 
 METER_RE = re.compile(
-    r'(rollingUsage|weeklyUsage|monthlyUsage):\$R\[\d+\]=\{status:"([^"]+)",resetInSec:(\d+),usagePercent:([\d.]+)\}'
+    r'(rollingUsage|weeklyUsage|monthlyUsage):\$R\[\d+\]=\{status:"([^"]+)",resetInSec:(\d+),usagePercent:([\d.]+)[^}]*\}'
 )
 PLAN_RE = re.compile(r'liteSubscriptionID:"[^"]+"')
 WORKSPACE_RE = re.compile(r'\{id:"(wrk_[A-Za-z0-9]{26})"[^}]*\}')
@@ -105,8 +105,19 @@ def find_cookie_dbs() -> list[Path]:
   return found
 
 
-def extract_auth_cookie(cookie_db: Path) -> str:
-  """Read the opencode.ai auth cookie from a Firefox-style cookies.sqlite.
+def extract_all_cookies(cookie_db: Path) -> list[tuple[str, str, int]]:
+  """Read every opencode.ai cookie scoped for the main opencode.ai domain.
+
+  Returns a list of (name, value, lastAccessed) tuples ordered by
+  lastAccessed descending (most recently sent by the browser first).
+
+  The browser only sends cookies whose domain matches the request host:
+  - host='opencode.ai' → exact match, sent to opencode.ai
+  - host='.opencode.ai' → domain cookie, sent to opencode.ai and subdomains
+  - host='auth.opencode.ai' → subdomain-scoped, NOT sent to opencode.ai
+
+  We mirror that scoping so we do not leak subdomain cookies to the main
+  site or send cookies the server is not expecting.
 
   The database is copied to a temp dir first so a running browser's WAL (and
   the file locks that come with it) does not interfere; the copy is a snapshot.
@@ -121,17 +132,35 @@ def extract_auth_cookie(cookie_db: Path) -> str:
     try:
       conn = sqlite3.connect(f"file:{db}?mode=ro", uri=True)
       try:
-        row = conn.execute(
-          "SELECT value FROM moz_cookies WHERE host IN ('.opencode.ai','opencode.ai') "
-          "AND name='auth' ORDER BY expiry DESC LIMIT 1"
-        ).fetchone()
-        return str(row[0]) if row else ""
+        rows = conn.execute(
+          "SELECT name, value, lastAccessed FROM moz_cookies "
+          "WHERE host IN ('.opencode.ai','opencode.ai') "
+          "ORDER BY lastAccessed DESC"
+        ).fetchall()
+        return [(str(r[0]), str(r[1]), int(r[2])) for r in rows]
       finally:
         conn.close()
     except sqlite3.Error:
-      return ""
+      return []
+  except (OSError, PermissionError):
+    # The copy itself can fail if the profile dir is unreadable or the
+    # temp filesystem is full.  Treat it the same as a missing cookie.
+    return []
   finally:
     shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def build_cookie_header(cookies: list[tuple[str, str, int]]) -> str:
+  """Format cookies as a `Cookie` header value, de-duplicating by name so
+  the most recently accessed value wins (browser behavior)."""
+  seen: dict[str, bool] = {}
+  parts: list[str] = []
+  for name, value, _ in cookies:
+    if name in seen:
+      continue
+    seen[name] = True
+    parts.append(f"{name}={value}")
+  return "; ".join(parts)
 
 
 def resolve_session(cfg: dict[str, Any]) -> str:
@@ -143,22 +172,25 @@ def resolve_session(cfg: dict[str, Any]) -> str:
         return value
     except Exception:
       pass
+  all_cookies: list[tuple[str, str, int]] = []
   for db in find_cookie_dbs():
-    cookie = extract_auth_cookie(db)
-    if cookie:
-      return cookie
-  return ""
+    all_cookies.extend(extract_all_cookies(db))
+  if not all_cookies:
+    return ""
+  # Send every opencode.ai cookie, just like the browser does.
+  # De-duplicate by name so the most recently accessed value wins.
+  return build_cookie_header(all_cookies)
 
 
 # --------------------------------------------------------------- workspace
 
 
-def list_workspaces(cookie: str) -> list[str]:
+def list_workspaces(cookie_header: str) -> list[str]:
   request = urllib.request.Request(
     SITE + "/_server",
     method="POST",
     headers={
-      "Cookie": f"auth={cookie}",
+      "Cookie": cookie_header,
       "User-Agent": USER_AGENT,
       "Accept": "text/html",
       "X-Server-Id": WORKSPACES_SERVER_FN_ID,
@@ -173,7 +205,7 @@ def list_workspaces(cookie: str) -> list[str]:
   return sorted(seen)
 
 
-def resolve_workspace(cfg: dict[str, Any], cookie: str) -> tuple[str, str]:
+def resolve_workspace(cfg: dict[str, Any], cookie_header: str) -> tuple[str, str]:
   """Return (workspace, status); status is "" on success, "transport" when the
   workspace RPC could not reach the network, and "unknown" when zero or
   several workspaces came back."""
@@ -184,7 +216,7 @@ def resolve_workspace(cfg: dict[str, Any], cookie: str) -> tuple[str, str]:
   if env:
     return env, ""
   try:
-    workspaces = list_workspaces(cookie)
+    workspaces = list_workspaces(cookie_header)
   except Exception:
     return "", "transport"
   if len(workspaces) == 1:
@@ -195,24 +227,45 @@ def resolve_workspace(cfg: dict[str, Any], cookie: str) -> tuple[str, str]:
 # ------------------------------------------------------------------- fetch
 
 
-def fetch_page(cookie: str, path: str) -> str:
-  """GET a workspace page. HTTP status errors become RuntimeError; transport
-  failures raise urllib.error.URLError unchanged."""
+class FetchError(Exception):
+  def __init__(self, status_code: int):
+    self.status_code = status_code
+    super().__init__(f"opencode.ai returned status {status_code}")
+
+
+def fetch_page(cookie_header: str, path: str, retries: int = 1) -> str:
+  """GET a workspace page. HTTP status errors become FetchError; transport
+  failures raise urllib.error.URLError unchanged.
+
+  Retries once on transport failures (no route, timeout) and on 5xx server
+  errors, with a 1-second pause between attempts.  4xx errors are not
+  retried — they are client-side and unlikely to change on a second try."""
   request = urllib.request.Request(
     SITE + path,
     headers={
-      "Cookie": f"auth={cookie}",
+      "Cookie": cookie_header,
       "User-Agent": USER_AGENT,
       "Accept": "text/html",
     },
   )
-  try:
-    with urllib.request.urlopen(request, timeout=FETCH_TIMEOUT_SECONDS) as response:
-      return response.read().decode("utf-8", errors="replace")
-  except urllib.error.HTTPError as error:
-    # HTTPError subclasses URLError; convert it so main() can tell a server
-    # answer from a transport failure (no route, no DNS, timeout).
-    raise RuntimeError(f"opencode.ai returned status {error.code}") from error
+  last_error: Exception | None = None
+  for attempt in range(retries + 1):
+    try:
+      with urllib.request.urlopen(request, timeout=FETCH_TIMEOUT_SECONDS) as response:
+        return response.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as error:
+      last_error = error
+      if 500 <= error.code < 600 and attempt < retries:
+        time.sleep(1)
+        continue
+      raise FetchError(error.code) from error
+    except urllib.error.URLError:
+      last_error = sys.exc_info()[1]
+      if attempt < retries:
+        time.sleep(1)
+        continue
+      raise
+  raise last_error or RuntimeError("fetch_page exhausted retries")
 
 
 # ------------------------------------------------------------------- parse
@@ -462,7 +515,9 @@ def main() -> int:
   parser = argparse.ArgumentParser()
   parser.add_argument("--force", action="store_true", help="accepted no-op (update-runner compatibility; no cache reuse to bypass)")
   parser.add_argument("--limits-only", action="store_true", help="accepted no-op (update-runner compatibility; limits are always fresh)")
-  parser.parse_args()
+  parser.add_argument("--debug", action="store_true", help="dump fetched HTML to stderr when meter parsing fails")
+  args = parser.parse_args()
+  debug = args.debug
 
   cfg = agent_config()
   cached = read_limits_cache()
@@ -493,8 +548,11 @@ def main() -> int:
       cached, "Couldn't reach opencode.ai", "Couldn't reach opencode.ai. Retrying shortly.", retry=True
     ))
     return 0
-  except RuntimeError as error:
-    print_record(failure_record(cached, "Sign-in expired", f"{error}. Sign in again in a browser."))
+  except FetchError as error:
+    if error.status_code in (401, 403):
+      print_record(failure_record(cached, "Sign-in expired", f"opencode.ai returned status {error.status_code}. Sign in again in a browser."))
+    else:
+      print_record(failure_record(cached, "Server error", f"opencode.ai returned status {error.status_code}. Retrying shortly.", retry=True))
     return 0
   except Exception:
     # http.client.HTTPException subclasses (BadStatusLine, IncompleteRead) and
@@ -507,11 +565,20 @@ def main() -> int:
 
   meters, plan = parse_meters(go_html)
   if not meters:
-    # The console redirects signed-out sessions to /signin; the page then
-    # carries no meter data.
-    print_record(failure_record(
-      cached, "Sign-in expired", "The opencode.ai session cookie is invalid or expired. Sign in again in a browser."
-    ))
+    if debug:
+      print(f"DEBUG: fetched {len(go_html)} chars from /workspace/{workspace}/go", file=sys.stderr)
+      print(f"DEBUG: first 4000 chars:\n{go_html[:4000]}", file=sys.stderr)
+    # Distinguish an auth redirect (cookie is genuinely stale) from a page
+    # format change (meters moved to a different markup pattern).
+    looks_like_auth = "OpenAuth" in go_html or "/signin" in go_html
+    if looks_like_auth:
+      print_record(failure_record(
+        cached, "Sign-in expired", "The opencode.ai session cookie is invalid or expired. Sign in again in a browser."
+      ))
+    else:
+      print_record(failure_record(
+        cached, "Page format changed", "The opencode.ai console layout changed and meters could not be found. This collector may need an update.", retry=True
+      ))
     return 0
 
   # Meters parsed — this is the healthy answer of record, so the cache is

--- a/bin/omarchy-agent-usage-opencode-go
+++ b/bin/omarchy-agent-usage-opencode-go
@@ -23,6 +23,7 @@ import shutil
 import sqlite3
 import sys
 import tempfile
+import time
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -297,6 +298,78 @@ def build_stats(records: list[dict[str, Any]]) -> dict[str, Any]:
   }
 
 
+# ------------------------------------------------------------ limits cache
+#
+# The meters scraped on a healthy run are cached so a later refresh failure
+# (cookie expired, no route, opencode.ai hiccup) keeps the last known numbers
+# on the panel instead of wiping the provider's tab. Cache reads and writes
+# are best-effort: a cache problem never takes down the record.
+
+
+def cache_root() -> Path:
+  root = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache")) / "omarchy" / "agent-usage"
+  try:
+    root.mkdir(parents=True, exist_ok=True)
+  except OSError:
+    pass
+  return root
+
+
+def read_limits_cache() -> dict[str, Any] | None:
+  try:
+    data = json.loads((cache_root() / "opencode-go-limits.json").read_text(encoding="utf-8"))
+    return data if isinstance(data, dict) else None
+  except Exception:
+    return None
+
+
+def write_limits_cache(limits: list[dict[str, Any]]) -> None:
+  try:
+    payload = {"fetchedAtMs": round(time.time() * 1000), "limits": limits}
+    # A temp name unique to this writer, not derived from the target: several
+    # collectors can run at once and a shared temp path means the second
+    # replace finds the first one's file already moved away.
+    handle_fd, tmp_name = tempfile.mkstemp(dir=cache_root(), prefix="opencode-go-limits.", suffix=".tmp")
+    tmp = Path(tmp_name)
+    try:
+      with os.fdopen(handle_fd, "w", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, separators=(",", ":"), sort_keys=True) + "\n")
+      # mkstemp opens at 0600; the caches the other collectors write are
+      # world-readable before.
+      tmp.chmod(0o644)
+      tmp.replace(cache_root() / "opencode-go-limits.json")
+    except BaseException:
+      tmp.unlink(missing_ok=True)
+  except Exception:
+    pass
+
+
+# A cached percentage outlives the run that measured it, but only until its
+# window rolls over: once a window has reset, the figure describes a period
+# that is over, and a stale 78% would misreport an allowance that is now
+# untouched. A window with no reset time, or one that will not parse, is kept
+# — an unreadable timestamp is no reason to throw away a real number.
+def limit_window_open(entry: dict[str, Any], now: dt.datetime) -> bool:
+  raw = str(entry.get("resetsAt") or "")
+  if raw == "":
+    return True
+  try:
+    resets_at = dt.datetime.fromisoformat(raw.replace("Z", "+00:00"))
+  except Exception:
+    return True
+  if resets_at.tzinfo is None:
+    resets_at = resets_at.replace(tzinfo=dt.timezone.utc)
+  return resets_at > now
+
+
+def usable_cached_limits(cached: dict[str, Any] | None) -> list[dict[str, Any]]:
+  entries = cached.get("limits") if cached else None
+  if not isinstance(entries, list):
+    return []
+  now = dt.datetime.now(dt.timezone.utc)
+  return [entry for entry in entries if isinstance(entry, dict) and limit_window_open(entry, now)]
+
+
 # ------------------------------------------------------------------- record
 
 
@@ -330,6 +403,9 @@ def base_record(**overrides: Any) -> dict[str, Any]:
     "updatedAt": dt.datetime.now(dt.timezone.utc).isoformat(),
     "ready": False,
     "hasLocalStats": True,
+    # The meters and token records are server-side, per-account truth: every
+    # synced device reports the same numbers, so aggregation must not sum them.
+    "scope": "account",
     "hasPromptStats": False,
     "tierLabel": "",
     "usageStatusText": "",
@@ -340,6 +416,26 @@ def base_record(**overrides: Any) -> dict[str, Any]:
   return record
 
 
+def failure_record(
+    cached: dict[str, Any] | None,
+    usage_status: str,
+    auth_help: str,
+    *,
+    retry: bool = False,
+) -> dict[str, Any]:
+  """A failure-path record that keeps the last cached meters visible: the
+  panel hides a provider whose record carries no limits, so a stale sign-in
+  must not make a working meter line vanish. Without usable cached limits the
+  record stays the bare base record."""
+  limits = usable_cached_limits(cached)
+  overrides: dict[str, Any] = {"limits": limits, "ready": bool(limits), "authHelpText": auth_help}
+  if limits:
+    overrides["usageStatusText"] = usage_status
+  if retry:
+    overrides["retryAdvised"] = True
+  return base_record(**overrides)
+
+
 def build_record(meters: dict[str, dict[str, Any]], plan: str, records: list[dict[str, Any]]) -> dict[str, Any]:
   limits = build_limits(meters)
   record = base_record(
@@ -347,8 +443,10 @@ def build_record(meters: dict[str, dict[str, Any]], plan: str, records: list[dic
     tierLabel=plan or "Go",
     limits=limits,
   )
-  if records:
-    record.update(build_stats(records))
+  # Stats always ride along, zero-shaped when no usage records parsed: the
+  # panel keys off their presence for the today/total lines and merges them
+  # across providers.
+  record.update(build_stats(records))
   return record
 
 
@@ -357,16 +455,21 @@ def print_record(record: dict[str, Any]) -> None:
 
 
 def main() -> int:
+  # --force and --limits-only arrive from the update runner, which passes both
+  # to every collector. They are deliberate no-ops here: meters are fetched
+  # fresh on every run, and the limits cache is a failure fallback, not a
+  # freshness shortcut the flags could bypass.
   parser = argparse.ArgumentParser()
-  parser.add_argument("--force", action="store_true", help="re-fetch everything, ignoring caches")
-  parser.add_argument("--limits-only", action="store_true", help="reuse recent stats; only limits must be fresh")
+  parser.add_argument("--force", action="store_true", help="accepted no-op (update-runner compatibility; no cache reuse to bypass)")
+  parser.add_argument("--limits-only", action="store_true", help="accepted no-op (update-runner compatibility; limits are always fresh)")
   parser.parse_args()
 
   cfg = agent_config()
+  cached = read_limits_cache()
   cookie = resolve_session(cfg)
 
   if not cookie:
-    print_record(base_record(authHelpText=AUTH_HELP))
+    print_record(failure_record(cached, "Waiting for sign-in", AUTH_HELP))
     return 0
 
   workspace, workspace_status = resolve_workspace(cfg, cookie)
@@ -374,9 +477,11 @@ def main() -> int:
     if workspace_status == "transport":
       # The workspace RPC never reached the network; retry sooner than the
       # regular interval instead of blaming the configuration.
-      print_record(base_record(retryAdvised=True, authHelpText="Couldn't reach opencode.ai. Retrying shortly."))
+      print_record(failure_record(
+        cached, "Couldn't reach opencode.ai", "Couldn't reach opencode.ai. Retrying shortly.", retry=True
+      ))
       return 0
-    print_record(base_record(usageStatusText="Workspace not configured", authHelpText=WORKSPACE_HELP))
+    print_record(failure_record(cached, "Workspace not configured", WORKSPACE_HELP))
     return 0
 
   try:
@@ -384,26 +489,34 @@ def main() -> int:
   except urllib.error.URLError:
     # A transport failure reached no server at all — no route, no DNS. Ask the
     # shell to try again sooner than its regular interval.
-    print_record(base_record(retryAdvised=True, authHelpText="Couldn't reach opencode.ai. Retrying shortly."))
+    print_record(failure_record(
+      cached, "Couldn't reach opencode.ai", "Couldn't reach opencode.ai. Retrying shortly.", retry=True
+    ))
     return 0
   except RuntimeError as error:
-    print_record(base_record(authHelpText=f"{error}. Sign in again in a browser."))
+    print_record(failure_record(cached, "Sign-in expired", f"{error}. Sign in again in a browser."))
     return 0
   except Exception:
     # http.client.HTTPException subclasses (BadStatusLine, IncompleteRead) and
     # anything else must still yield a valid record, never a crash with no
     # JSON on stdout.
-    print_record(base_record(authHelpText="Couldn't read the opencode.ai response. Retrying shortly."))
+    print_record(failure_record(
+      cached, "Couldn't reach opencode.ai", "Couldn't read the opencode.ai response. Retrying shortly.", retry=True
+    ))
     return 0
 
   meters, plan = parse_meters(go_html)
   if not meters:
     # The console redirects signed-out sessions to /signin; the page then
     # carries no meter data.
-    print_record(base_record(
-      authHelpText="The opencode.ai session cookie is invalid or expired. Sign in again in a browser."
+    print_record(failure_record(
+      cached, "Sign-in expired", "The opencode.ai session cookie is invalid or expired. Sign in again in a browser."
     ))
     return 0
+
+  # Meters parsed — this is the healthy answer of record, so the cache is
+  # refreshed before the (optional) usage page fetch.
+  write_limits_cache(build_limits(meters))
 
   records: list[dict[str, Any]] = []
   try:

--- a/bin/omarchy-agent-usage-opencode-go
+++ b/bin/omarchy-agent-usage-opencode-go
@@ -51,8 +51,8 @@ USAGE_RECORD_RE = re.compile(
     r'\{id:"usg_[^"]+",workspaceID:"wrk_[^"]+",timeCreated:\$R\[\d+\]=new Date\("([^"]+)"\),'
     r'timeUpdated:\$R\[\d+\]=new Date\("[^"]+"\),timeDeleted:[^,]+,'
     r'model:"([^"]+)",provider:"([^"]+)",'
-    r'inputTokens:(\d+),outputTokens:(\d+),reasoningTokens:(\d+),cacheReadTokens:(\d+),'
-    r'cacheWrite5mTokens:([^,]+),cacheWrite1hTokens:([^,]+),cost:(\d+)'
+    r'inputTokens:(\d+),outputTokens:(\d+),reasoningTokens:([^,]+),cacheReadTokens:(\d+),'
+    r'cacheWrite5mTokens:([^,]+),cacheWrite1hTokens:([^,]+),cost:([^,]+)'
 )
 
 

--- a/bin/omarchy-agent-usage-opencode-go
+++ b/bin/omarchy-agent-usage-opencode-go
@@ -32,6 +32,7 @@ from __future__ import annotations
 import argparse
 import datetime as dt
 import json
+import math
 import os
 import re
 import shutil
@@ -68,6 +69,11 @@ STATS_WINDOW_DAYS = 7
 # Safety valve: a week of very heavy usage at USAGE_PAGE_SIZE records a page
 # must not turn a refresh into an unbounded crawl.
 MAX_USAGE_PAGES = 40
+# The walk is best-effort and must never anchor the update runner for
+# minutes: a slow server that keeps every page alive to its timeout would
+# otherwise stretch MAX_USAGE_PAGES pages and their retries into a ~20-minute
+# crawl inside one refresh.
+USAGE_WALK_SECONDS = 60
 FETCH_TIMEOUT_SECONDS = 15
 USER_AGENT = "omarchy-agent-usage-opencode-go/1.0"
 
@@ -103,7 +109,9 @@ def agent_config() -> dict[str, Any]:
 def number(value: Any) -> int:
   try:
     n = float(value or 0)
-    return round(n) if n == n else 0
+    # round(inf) raises OverflowError; a token count the server serializes as
+    # an extreme value must read as zero, never crash the whole parse.
+    return round(n) if math.isfinite(n) else 0
   except Exception:
     return 0
 
@@ -208,7 +216,11 @@ def resolve_session(cfg: dict[str, Any]) -> str:
   if not all_cookies:
     return ""
   # Send every opencode.ai cookie, just like the browser does.
-  # De-duplicate by name so the most recently accessed value wins.
+  # De-duplicate by name so the most recently accessed value wins. Each
+  # database is ordered by lastAccessed internally, but the same cookie name
+  # can exist in several profiles; ordering is only trustworthy once the
+  # lists are merged and re-sorted together.
+  all_cookies.sort(key=lambda cookie: cookie[2], reverse=True)
   return build_cookie_header(all_cookies)
 
 
@@ -263,21 +275,13 @@ class FetchError(Exception):
     super().__init__(f"opencode.ai returned status {status_code}")
 
 
-def fetch_page(cookie_header: str, path: str, retries: int = 1) -> str:
-  """GET a workspace page. HTTP status errors become FetchError; transport
-  failures raise urllib.error.URLError unchanged.
+def _request_with_retries(request: urllib.request.Request, label: str, retries: int = 1) -> str:
+  """Run a request, retrying once on transport failures and 5xx server
+  errors with a 1-second pause between attempts.
 
-  Retries once on transport failures (no route, timeout) and on 5xx server
-  errors, with a 1-second pause between attempts.  4xx errors are not
-  retried — they are client-side and unlikely to change on a second try."""
-  request = urllib.request.Request(
-    SITE + path,
-    headers={
-      "Cookie": cookie_header,
-      "User-Agent": USER_AGENT,
-      "Accept": "text/html",
-    },
-  )
+  HTTP status errors become FetchError; transport failures raise
+  urllib.error.URLError unchanged. 4xx errors are not retried — they are
+  client-side and unlikely to change on a second try."""
   last_error: Exception | None = None
   for attempt in range(retries + 1):
     try:
@@ -295,7 +299,20 @@ def fetch_page(cookie_header: str, path: str, retries: int = 1) -> str:
         time.sleep(1)
         continue
       raise
-  raise last_error or RuntimeError("fetch_page exhausted retries")
+  raise last_error or RuntimeError(f"{label} exhausted retries")
+
+
+def fetch_page(cookie_header: str, path: str, retries: int = 1) -> str:
+  """GET a workspace page; see _request_with_retries for the retry policy."""
+  request = urllib.request.Request(
+    SITE + path,
+    headers={
+      "Cookie": cookie_header,
+      "User-Agent": USER_AGENT,
+      "Accept": "text/html",
+    },
+  )
+  return _request_with_retries(request, "fetch_page", retries)
 
 
 def seroval_args(args: list[Any]) -> dict[str, Any]:
@@ -338,24 +355,7 @@ def fetch_usage_chunk(cookie_header: str, workspace: str, page: int, instance: s
       "X-Server-Instance": instance,
     },
   )
-  last_error: Exception | None = None
-  for attempt in range(retries + 1):
-    try:
-      with urllib.request.urlopen(request, timeout=FETCH_TIMEOUT_SECONDS) as response:
-        return response.read().decode("utf-8", errors="replace")
-    except urllib.error.HTTPError as error:
-      last_error = error
-      if 500 <= error.code < 600 and attempt < retries:
-        time.sleep(1)
-        continue
-      raise FetchError(error.code) from error
-    except urllib.error.URLError:
-      last_error = sys.exc_info()[1]
-      if attempt < retries:
-        time.sleep(1)
-        continue
-      raise
-  raise last_error or RuntimeError("fetch_usage_chunk exhausted retries")
+  return _request_with_retries(request, "fetch_usage_chunk", retries)
 
 
 def fetch_usage_records(cookie_header: str, workspace: str) -> list[dict[str, Any]]:
@@ -376,12 +376,22 @@ def fetch_usage_records(cookie_header: str, workspace: str) -> list[dict[str, An
   empty-records shape, exactly like the old single-page read."""
   records: list[dict[str, Any]] = []
   window_start = (dt.date.today() - dt.timedelta(days=STATS_WINDOW_DAYS - 1)).strftime("%Y-%m-%d")
+  # The walk is best-effort, so give it a wall-clock budget as well as a page
+  # cap, and treat a page that will not parse like a page that fails to
+  # fetch: the pages already read stay, and the walk stops instead of one
+  # bad record discarding everything.
+  deadline = time.time() + USAGE_WALK_SECONDS
   for page in range(MAX_USAGE_PAGES):
+    if time.time() >= deadline:
+      break
     try:
       html = fetch_usage_chunk(cookie_header, workspace, page, f"server-fn:{page + 20}")
     except Exception:
       break
-    chunk = parse_usage_records(html)
+    try:
+      chunk = parse_usage_records(html)
+    except Exception:
+      break
     if not chunk:
       # An empty page is the list's last page: the account history ends.
       break
@@ -419,8 +429,26 @@ def parse_go_config(html: str) -> dict[str, Any]:
   if not match:
     return config
   config["useBalance"] = "useBalance:!0" in match.group(1) or "useBalance:true" in match.group(1)
-  prefix = html[:match.start()]
-  balance = re.findall(r'\bbalance:(\d+)', prefix)
+  # The Zen credits sit in the same enclosing workspace object as lite:, not
+  # scattered across the page. Bound the search to that object: walking
+  # backwards from the lite block, the brace that brings the nesting depth
+  # back to zero is its opening, so an unrelated balance: elsewhere on the
+  # page can never be attributed to this workspace.
+  depth = 0
+  start = -1
+  pos = match.start() - 1
+  while pos >= 0:
+    if html[pos] == "}":
+      depth += 1
+    elif html[pos] == "{":
+      if depth == 0:
+        start = pos
+        break
+      depth -= 1
+    pos -= 1
+  if start < 0:
+    return config
+  balance = re.findall(r'\bbalance:(\d+)', html[start:match.start()])
   if balance:
     config["balance"] = int(balance[-1])
   return config
@@ -537,7 +565,10 @@ def write_limits_cache(limits: list[dict[str, Any]]) -> None:
       # world-readable before.
       tmp.chmod(0o644)
       tmp.replace(cache_root() / "opencode-go-limits.json")
-    except BaseException:
+    finally:
+      # The temp name is ours alone. Clean up on the way out whatever
+      # happened; the outer Exception handler still lets interrupts
+      # propagate rather than swallowing them.
       tmp.unlink(missing_ok=True)
   except Exception:
     pass
@@ -558,7 +589,9 @@ def limit_window_open(entry: dict[str, Any], now: dt.datetime) -> bool:
     return True
   if resets_at.tzinfo is None:
     resets_at = resets_at.replace(tzinfo=dt.timezone.utc)
-  return resets_at > now
+  # Keep the window through its reset instant: dropping it at exactly the
+  # reset time would hide a meter whose refresh landed on the boundary.
+  return resets_at >= now
 
 
 def usable_cached_limits(cached: dict[str, Any] | None) -> list[dict[str, Any]]:
@@ -577,9 +610,17 @@ def resets_at(reset_in_sec: int) -> str:
 
 
 def build_limits(meters: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
-  order = [("rollingUsage", "Rolling (5-hour)"), ("weeklyUsage", "Weekly"), ("monthlyUsage", "Monthly")]
+  # Each window travels with an explicit title as well as its label: the
+  # panel prefers a collector-declared title to reading one back out of the
+  # label, and "Rolling (5-hour)" would otherwise parse as a generic
+  # session window.
+  order = [
+    ("rollingUsage", "Rolling", "Rolling (5-hour)"),
+    ("weeklyUsage", "Weekly", "Weekly"),
+    ("monthlyUsage", "Monthly", "Monthly"),
+  ]
   limits: list[dict[str, Any]] = []
-  for key, label in order:
+  for key, title, label in order:
     meter = meters.get(key)
     if not meter:
       continue
@@ -587,6 +628,7 @@ def build_limits(meters: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
     if not (percent >= 0):
       continue
     limit: dict[str, Any] = {
+      "title": title,
       "label": label,
       "percent": min(1.0, percent),
       "resetsAt": resets_at(int(meter.get("resetInSec") or 0)),
@@ -688,13 +730,15 @@ def print_record(record: dict[str, Any]) -> None:
 
 
 def main() -> int:
-  # --force and --limits-only arrive from the update runner, which passes both
-  # to every collector. They are deliberate no-ops here: meters are fetched
-  # fresh on every run, and the limits cache is a failure fallback, not a
-  # freshness shortcut the flags could bypass.
+  # --force and --limits-only arrive from the update runner. --force is a
+  # deliberate no-op: meters are fetched fresh on every run, and the limits
+  # cache is a failure fallback, not a freshness shortcut the flag could
+  # bypass. --limits-only is honored: the panel opens with a cheap
+  # limits-only refresh, and paging the usage history is exactly the walk
+  # the flag exists to skip.
   parser = argparse.ArgumentParser()
   parser.add_argument("--force", action="store_true", help="accepted no-op (update-runner compatibility; no cache reuse to bypass)")
-  parser.add_argument("--limits-only", action="store_true", help="accepted no-op (update-runner compatibility; limits are always fresh)")
+  parser.add_argument("--limits-only", action="store_true", help="skip the usage walk; report fresh meters only")
   parser.add_argument("--debug", action="store_true", help="dump fetched HTML to stderr when meter parsing fails")
   args = parser.parse_args()
   debug = args.debug
@@ -766,11 +810,14 @@ def main() -> int:
   # refreshed before the (optional) usage list walk.
   write_limits_cache(build_limits(meters))
 
-  try:
-    # Limits are the point; a usage walk that fails entirely still shows them.
-    records = fetch_usage_records(cookie, workspace)
-  except Exception:
-    records = []
+  # Limits are the point; a usage walk that fails entirely still shows them.
+  # A limits-only refresh (the panel opening) skips the walk altogether.
+  records = []
+  if not args.limits_only:
+    try:
+      records = fetch_usage_records(cookie, workspace)
+    except Exception:
+      records = []
 
   print_record(build_record(meters, plan, records, go_config))
   return 0

--- a/bin/omarchy-agent-usage-opencode-go
+++ b/bin/omarchy-agent-usage-opencode-go
@@ -16,7 +16,12 @@ The panel only ever reads the JSON this prints; it never talks to disk
 formats or endpoints.
 
 Metrics scoped in code:
-- limits: account truth from the workspace meters (rolling / weekly / monthly).
+- limits: account truth from the workspace meters (rolling / weekly /
+  monthly), including meters the console has flipped to "rate-limited" —
+  a full window is the binding constraint, not data to hide.
+- fallback state: the workspace's "Use balance" option and the Zen credits
+  left decide whether an exhausted window blocks requests or bills the
+  balance; the record's status card says which.
 - per-request stats (today*, recentDays, modelUsage): the trailing 7 local
   days, window-bounded so the "tokens by day" and "tokens by model"
   sections describe the same period.
@@ -399,6 +404,28 @@ def parse_meters(html: str) -> tuple[dict[str, dict[str, Any]], str]:
   return meters, plan
 
 
+def parse_go_config(html: str) -> dict[str, Any]:
+  """Read the workspace's Go fallback state off the page.
+
+  ``useBalance`` is the console's 'Use balance' option: when true and credits
+  exist, an exhausted window bills the workspace's Zen balance instead of
+  hard blocking. ``balance`` is the credits left, an integer in 1e-8-dollar
+  units (a $10 top-up reads ~1e9; the meter limits use the same unit — $60
+  is 6e9). ``lite:`` carries useBalance; the balance field sits in the same
+  enclosing workspace object, just before it. An absent block parses as
+  defaults (no fallback)."""
+  config: dict[str, Any] = {"useBalance": False, "balance": None}
+  match = re.search(r'\blite:(?:\$R\[\d+\]=)?\{([^}]*)\}', html)
+  if not match:
+    return config
+  config["useBalance"] = "useBalance:!0" in match.group(1) or "useBalance:true" in match.group(1)
+  prefix = html[:match.start()]
+  balance = re.findall(r'\bbalance:(\d+)', prefix)
+  if balance:
+    config["balance"] = int(balance[-1])
+  return config
+
+
 def parse_usage_records(html: str) -> list[dict[str, Any]]:
   records: list[dict[str, Any]] = []
   for match in USAGE_RECORD_RE.finditer(html):
@@ -554,16 +581,24 @@ def build_limits(meters: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
   limits: list[dict[str, Any]] = []
   for key, label in order:
     meter = meters.get(key)
-    if not meter or meter.get("status") != "ok":
+    if not meter:
       continue
     percent = float(meter.get("usagePercent") or 0) / 100.0
     if not (percent >= 0):
       continue
-    limits.append({
+    limit: dict[str, Any] = {
       "label": label,
       "percent": min(1.0, percent),
       "resetsAt": resets_at(int(meter.get("resetInSec") or 0)),
-    })
+    }
+    # A meter that stopped accepting requests is the binding constraint, not
+    # a gap in the data: 'rate-limited' means requests for that window block
+    # (or bill the Zen balance, when useBalance is on). Carrying the status
+    # lets the record tell those apart from a merely full window.
+    status = str(meter.get("status") or "")
+    if status != "ok":
+      limit["status"] = status
+    limits.append(limit)
   return limits
 
 
@@ -608,12 +643,38 @@ def failure_record(
   return base_record(**overrides)
 
 
-def build_record(meters: dict[str, dict[str, Any]], plan: str, records: list[dict[str, Any]]) -> dict[str, Any]:
+def rate_limited_note(limits: list[dict[str, Any]], go_config: dict[str, Any]) -> tuple[str, str]:
+  """(hero, help) texts for an exhausted window, or ("", "") when none is
+  throttled. The hero is the short headline the panel's hero meta shows; the
+  help is the status-card body, which explains whether requests block or bill
+  the Zen balance until the window resets."""
+  throttled = [limit for limit in limits if limit.get("status") == "rate-limited"]
+  if not throttled:
+    return "", ""
+  headline = ", ".join(limit["label"] for limit in throttled) + " limit reached"
+  if go_config.get("useBalance") and go_config.get("balance") is not None:
+    remaining = go_config["balance"] / 1e8
+    return headline, f"Billing the Zen balance (${remaining:,.2f} left) until the window resets"
+  if go_config.get("useBalance"):
+    return headline, "Zen balance is empty — requests blocked until the window resets"
+  return headline, "Requests blocked until the window resets"
+
+
+def build_record(
+  meters: dict[str, dict[str, Any]],
+  plan: str,
+  records: list[dict[str, Any]],
+  go_config: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+  go_config = go_config or {}
   limits = build_limits(meters)
+  status_text, auth_help = rate_limited_note(limits, go_config)
   record = base_record(
     ready=bool(limits),
     tierLabel=plan or "Go",
     limits=limits,
+    usageStatusText=status_text,
+    authHelpText=auth_help,
   )
   # Stats always ride along, zero-shaped when no usage records parsed: the
   # panel keys off their presence for the today/total lines and merges them
@@ -683,6 +744,7 @@ def main() -> int:
     return 0
 
   meters, plan = parse_meters(go_html)
+  go_config = parse_go_config(go_html)
   if not meters:
     if debug:
       print(f"DEBUG: fetched {len(go_html)} chars from /workspace/{workspace}/go", file=sys.stderr)
@@ -710,7 +772,7 @@ def main() -> int:
   except Exception:
     records = []
 
-  print_record(build_record(meters, plan, records))
+  print_record(build_record(meters, plan, records, go_config))
   return 0
 
 

--- a/shell/Ui/PanelHero.qml
+++ b/shell/Ui/PanelHero.qml
@@ -14,6 +14,11 @@ Item {
   property real iconOpacity: 1.0
   property alias metaOpacity: metaText.opacity
 
+  // A detail pill that means trouble — a stale record, a fault — renders
+  // with the urgent border and text instead of the neutral controlSpec.
+  property bool detailAlarming: false
+  property color detailAlarmColor: Color.urgent
+
   // Optional control pinned to the trailing edge of the hero — a ToggleSwitch,
   // a small button. The hero centers it against the labels and reserves the
   // space itself, so callers never do the geometry.
@@ -71,7 +76,9 @@ Item {
         implicitHeight: detailText.implicitHeight + Style.space(4)
         anchors.verticalCenter: parent.verticalCenter
         color: "transparent"
-        borderSpec: Border.controlSpec("normal", root.foreground, Color.accent)
+        borderSpec: root.detailAlarming
+          ? Border.flat(root.detailAlarmColor, 1)
+          : Border.controlSpec("normal", root.foreground, Color.accent)
         radius: Style.cornerRadius
 
         Text {
@@ -79,7 +86,7 @@ Item {
           textFormat: Text.PlainText
           anchors.centerIn: parent
           text: root.detail
-          color: root.dim
+          color: root.detailAlarming ? root.detailAlarmColor : root.dim
           font.family: root.fontFamily
           font.pixelSize: Style.font.body
           font.bold: true

--- a/shell/plugins/agents/Main.qml
+++ b/shell/plugins/agents/Main.qml
@@ -250,6 +250,10 @@ Item {
       ready: record.ready === true || synced,
       usageStatusText: String(record.usageStatusText || ""),
       authHelpText: String(record.authHelpText || ""),
+      // When the collector last wrote this record. The panel flags records
+      // that age past the refresh cadence — a stale record means the
+      // collector is not running, not that the numbers are quiet.
+      updatedAtMs: Number(new Date(String(record.updatedAt || "")).getTime()) || 0,
 
       // Rate limits and balances stay per-account and are never merged
       // across devices.

--- a/shell/plugins/agents/Panel.qml
+++ b/shell/plugins/agents/Panel.qml
@@ -46,6 +46,18 @@ Panel {
     && balance.remaining / balance.funded <= 0.1
   readonly property bool alarming: (!!headline && headline.percent >= 0.9) || balanceAlarming
 
+  // A record that survives a refresh cycle unwritten means its collector did
+  // not run — a missing binary or a failing scrape. Every collector rewrites
+  // updatedAt on each successful run, so an age past two refresh intervals is
+  // a real gap, not cadence jitter. Providers with no local record (synced
+  // only) carry no updatedAt and are never flagged; the sync footer owns
+  // their freshness.
+  readonly property double staleAgeMs: provider && provider.updatedAtMs > 0
+    ? root.nowMs - provider.updatedAtMs
+    : -1
+  readonly property bool stale: root.staleAgeMs > 2 * usage.refreshIntervalSec * 1000
+  readonly property string staleText: root.stale ? "stale · " + root.formatAge(root.staleAgeMs) : ""
+
   function clamp(v, lo, hi) { return Math.max(lo, Math.min(hi, v)) }
   function alpha(c, a) { return Qt.rgba(c.r, c.g, c.b, a) }
 
@@ -145,6 +157,18 @@ Panel {
     var days = Math.floor(hours / 24)
     if (days > 0) return days + "d " + (hours % 24) + "h"
     if (hours > 0) return hours + "h " + (minutes % 60) + "m"
+    return Math.max(1, minutes) + "m"
+  }
+
+  // Compact age for the stale pill, where "12h 0m" would read as noise next
+  // to the provider name. Countdowns keep the minute detail; ages drop it.
+  function formatAge(ms) {
+    if (!(ms > 0)) return ""
+    var minutes = Math.floor(ms / 60000)
+    var hours = Math.floor(minutes / 60)
+    var days = Math.floor(hours / 24)
+    if (days > 0) return days + "d " + (hours % 24) + "h"
+    if (hours > 0) return hours + "h"
     return Math.max(1, minutes) + "m"
   }
 
@@ -401,6 +425,9 @@ Panel {
             width: parent.width
             title: root.provider ? root.provider.providerName : ""
             meta: root.heroMeta(root.provider)
+            detail: root.staleText
+            detailAlarming: root.stale
+            detailAlarmColor: root.urgent
             foreground: root.foreground
             fontFamily: root.fontFamily
 

--- a/shell/plugins/agents/Panel.qml
+++ b/shell/plugins/agents/Panel.qml
@@ -56,7 +56,7 @@ Panel {
     ? root.nowMs - provider.updatedAtMs
     : -1
   readonly property bool stale: root.staleAgeMs > 2 * usage.refreshIntervalSec * 1000
-  readonly property string staleText: root.stale ? "stale · " + root.formatAge(root.staleAgeMs) : ""
+  readonly property string staleText: root.stale ? "stale · " + root.formatDuration(root.staleAgeMs, true) : ""
 
   function clamp(v, lo, hi) { return Math.max(lo, Math.min(hi, v)) }
   function alpha(c, a) { return Qt.rgba(c.r, c.g, c.b, a) }
@@ -150,25 +150,19 @@ Panel {
     return isFinite(ms) ? ms - root.nowMs : -1
   }
 
-  function formatDuration(ms) {
-    if (!(ms > 0)) return "now"
+  // Countdowns ("2h 5m") keep the minute detail; the compact form is for
+  // the stale pill, where "12h 0m" would read as noise next to the provider
+  // name. A falsy ms renders "now", or the empty string when compact.
+  function formatDuration(ms, compact) {
+    if (!(ms > 0)) return compact ? "" : "now"
     var minutes = Math.floor(ms / 60000)
     var hours = Math.floor(minutes / 60)
     var days = Math.floor(hours / 24)
     if (days > 0) return days + "d " + (hours % 24) + "h"
-    if (hours > 0) return hours + "h " + (minutes % 60) + "m"
-    return Math.max(1, minutes) + "m"
-  }
-
-  // Compact age for the stale pill, where "12h 0m" would read as noise next
-  // to the provider name. Countdowns keep the minute detail; ages drop it.
-  function formatAge(ms) {
-    if (!(ms > 0)) return ""
-    var minutes = Math.floor(ms / 60000)
-    var hours = Math.floor(minutes / 60)
-    var days = Math.floor(hours / 24)
-    if (days > 0) return days + "d " + (hours % 24) + "h"
-    if (hours > 0) return hours + "h"
+    if (hours > 0) {
+      if (compact) return hours + "h"
+      return hours + "h " + (minutes % 60) + "m"
+    }
     return Math.max(1, minutes) + "m"
   }
 

--- a/shell/plugins/agents/README.md
+++ b/shell/plugins/agents/README.md
@@ -70,12 +70,14 @@ signed in there.
 OpenCode Go is opencode.ai's Go subscription plan: three credit windows — a
 rolling 5-hour, a weekly, and a monthly — each reported as a percentage with
 a reset time. There is no usage API, so the collector reads the workspace
-console pages: the meters from `/workspace/<id>/go` and the recent
-per-request token records from `/workspace/<id>/usage`, using the `auth`
-session cookie Firefox or Zen Browser stores for opencode.ai. The usage
-page embeds the last ~50 requests, so the all-time totals describe that
-window rather than the account's whole history. Session counts are not
-exposed, so the panel hides the prompt/session line. A workspace is
+console pages: the meters from `/workspace/<id>/go` and the per-request
+token records from the usage list, using the `auth` session cookie Firefox or
+Zen Browser stores for opencode.ai. The console renders only the newest 50
+requests in HTML and fetches older pages on demand, so the collector pages
+through them and keeps the trailing 7 local days — "tokens by day" and
+"tokens by model" both describe that week, and a day survives a later
+refresh once it has left the newest page. Session counts are not exposed, so
+the panel hides the prompt/session line. A workspace is
 required: set `workspaceId` in `~/.config/omarchy/agents/opencode-go.json`
 (or `OPENCODE_WORKSPACE`) when the session has more than one. With no
 sign-in and no previously recorded meters the provider stays hidden — the

--- a/shell/plugins/agents/README.md
+++ b/shell/plugins/agents/README.md
@@ -9,8 +9,12 @@ cross-device aggregation); `Agent.qml` is the per-record file watcher.
 
 ## Panel
 
-- **Hero** — the mark, the tool, and the plan it runs on ("Max 20x", "Pro").
-  Auth and endpoint problems replace the plan line and repeat in a card.
+- **Hero** — the mark, the tool, and the plan it runs on ("Max 20x", "Pro",
+  "Go"). Auth and endpoint problems replace the plan line and repeat in a
+  card; so does an exhausted rate-limit window, which explains what happens
+  next (blocked, or billed to the Zen balance). A record that survives a
+  refresh cycle without being rewritten earns a `stale` detail pill — the
+  collector behind it stopped running.
 - **Subscription switch** — one chip per enabled agent (`h`/`l` or click).
   It appears only when more than one agent is enabled.
 - **Limits** — the percentage of each allowance used, a matching meter, and
@@ -55,7 +59,7 @@ light surfaces — and the bar glyph stands in when there is none.
 | `claude` | Anthropic's OAuth usage endpoint (5-hour session + 7-day weekly) | `~/.claude/projects` transcripts, opencode sessions on an Anthropic provider, plus `stats-cache.json` and `history.jsonl` as fallback |
 | `codex` | The Codex app-server RPC | native Codex CLI session files (plus pi and opencode sessions) |
 | `fireworks` | Estimated prepaid balance: configured funding minus rated account costs | Fireworks billing API, grouped by day and model for the last 30 days |
-| `opencode-go` | Rolling 5-hour, weekly, and monthly Go-plan meters scraped from the opencode.ai workspace page | Server-side per-request records from the workspace usage page, grouped by day and model |
+| `opencode-go` | Rolling 5-hour, weekly, and monthly Go-plan meters scraped from the opencode.ai workspace page (rate-limited windows reported at full with a status card) | Server-side per-request records from the workspace usage page, grouped by day and model |
 
 Claude limits need a signed-in CLI; without credentials the panel says so and
 falls back to local stats only. A non-default Claude directory is honored via
@@ -71,26 +75,37 @@ OpenCode Go is opencode.ai's Go subscription plan: three credit windows — a
 rolling 5-hour, a weekly, and a monthly — each reported as a percentage with
 a reset time. There is no usage API, so the collector reads the workspace
 console pages: the meters from `/workspace/<id>/go` and the per-request
-token records from the usage list, using the `auth` session cookie any browser
-on the machine stores for opencode.ai. Firefox and Zen keep cookies in
-plaintext sqlite; Chrome-family profiles (Chrome, Chromium, Brave, Edge,
-Vivaldi, Opera — including Flatpak and snap layouts) are read the same way,
-deciphering their encrypted values with the browser's own SafeStorage
-password from the Secret Service (`secret-tool` must exist and the same
-user's keyring must be unlocked). Old `v10`-prefixed rows and the
-keyringless "peanuts" fallback are handled too; newer app-bound (`v20+`)
-rows cannot be deciphered outside the browser and are skipped, as are
-stores on machines without the `cryptography` Python module — the collector
-keeps working from the other browsers either way. The console renders only the newest 50
-requests in HTML and fetches older pages on demand, so the collector pages
-through them and keeps the trailing 7 local days — "tokens by day" and
-"tokens by model" both describe that week, and a day survives a later
-refresh once it has left the newest page. Session counts are not exposed, so
-the panel hides the prompt/session line. A workspace is
-required: set `workspaceId` in `~/.config/omarchy/agents/opencode-go.json`
-(or `OPENCODE_WORKSPACE`) when the session has more than one. With no
-sign-in and no previously recorded meters the provider stays hidden — the
-panel only lists providers that have produced data. Once meters have been
+token records from the usage list, using the `auth` session cookie any
+browser on the machine stores for opencode.ai.
+
+Cookies come from every browser on the machine:
+- Firefox and Zen keep them in plaintext sqlite; the collector reads those
+  profiles directly.
+- Chrome-family browsers (Chrome, Chromium, Brave, Edge, Vivaldi, Opera —
+  including Flatpak and snap layouts) encrypt their values with the
+  browser's SafeStorage password. The collector deciphers them with that
+  same password from the Secret Service (`secret-tool` must exist and the
+  same user's keyring must be unlocked), covering both the modern `v11`
+  fixed-IV layout and the legacy `v10` layout via the keyringless "peanuts"
+  fallback. Newer app-bound (`v20+`) rows cannot be deciphered outside the
+  browser and are skipped, as are stores on machines without the
+  `cryptography` Python module — the collector keeps working from the other
+  browsers either way.
+- When several browsers hold a session for opencode.ai, the one used most
+  recently wins.
+
+The console renders only the newest 50 requests in HTML and fetches older
+pages on demand, so the collector pages through them and keeps the trailing
+7 local days — "tokens by day" and "tokens by model" both describe that
+week, and a day survives a later refresh once it has left the newest page.
+Opening the panel runs a limits-only refresh: the meters are fetched fresh,
+the usage walk is skipped, and the previous record's stats stay on the
+chart rather than blanking out. Session counts are not exposed, so the
+panel hides the prompt/session line. A workspace is required: set
+`workspaceId` in `~/.config/omarchy/agents/opencode-go.json` (or
+`OPENCODE_WORKSPACE`) when the session has more than one. With no sign-in
+and no previously recorded meters the provider stays hidden — the panel
+only lists providers that have produced data. Once meters have been
 recorded, a stale or missing sign-in keeps the last meters visible with a
 status card until their windows reset.
 
@@ -178,8 +193,9 @@ the last 7 days, and the all-time totals cover every machine you code on —
 active days are unioned by date rather than summed. Rate limits stay
 per-account and are never merged. A record may declare `"scope": "account"`
 when its stats are account-global rather than machine-local (Fireworks'
-billing API); those merge by taking the widest value instead of summing, so
-the same account synced from two machines is not counted twice.
+billing API and OpenCode Go's server-side usage); those merge by taking the
+widest value instead of summing, so the same account synced from two
+machines is not counted twice.
 
 One caveat on "all-time": the Codex collector only reads native session files
 touched in the last 30 days, and Fireworks requests the last 30 days from its

--- a/shell/plugins/agents/README.md
+++ b/shell/plugins/agents/README.md
@@ -71,8 +71,17 @@ OpenCode Go is opencode.ai's Go subscription plan: three credit windows — a
 rolling 5-hour, a weekly, and a monthly — each reported as a percentage with
 a reset time. There is no usage API, so the collector reads the workspace
 console pages: the meters from `/workspace/<id>/go` and the per-request
-token records from the usage list, using the `auth` session cookie Firefox or
-Zen Browser stores for opencode.ai. The console renders only the newest 50
+token records from the usage list, using the `auth` session cookie any browser
+on the machine stores for opencode.ai. Firefox and Zen keep cookies in
+plaintext sqlite; Chrome-family profiles (Chrome, Chromium, Brave, Edge,
+Vivaldi, Opera — including Flatpak and snap layouts) are read the same way,
+deciphering their encrypted values with the browser's own SafeStorage
+password from the Secret Service (`secret-tool` must exist and the same
+user's keyring must be unlocked). Old `v10`-prefixed rows and the
+keyringless "peanuts" fallback are handled too; newer app-bound (`v20+`)
+rows cannot be deciphered outside the browser and are skipped, as are
+stores on machines without the `cryptography` Python module — the collector
+keeps working from the other browsers either way. The console renders only the newest 50
 requests in HTML and fetches older pages on demand, so the collector pages
 through them and keeps the trailing 7 local days — "tokens by day" and
 "tokens by model" both describe that week, and a day survives a later

--- a/shell/plugins/agents/README.md
+++ b/shell/plugins/agents/README.md
@@ -18,7 +18,7 @@ cross-device aggregation); `Agent.qml` is the per-record file watcher.
 - **Subscription switch** — one chip per enabled agent (`h`/`l` or click).
   It appears only when more than one agent is enabled.
 - **Limits** — the percentage of each allowance used, a matching meter, and
-  the time until the session or weekly window resets.
+  the time until the session, weekly, or monthly window resets.
 - **Balance** — prepaid agents report a credit ledger instead of limits:
   remaining credit, a fuel-gauge meter that drains toward empty, and
   funded-versus-spent detail.
@@ -180,7 +180,8 @@ edit `shell.json` directly):
 omarchy bar set omarchy.agents providers '{
   "claude": { "enabled": true },
   "codex": { "enabled": false },
-  "fireworks": { "enabled": true }
+  "fireworks": { "enabled": true },
+  "opencode-go": { "enabled": true }
 }' --json
 ```
 

--- a/shell/plugins/agents/README.md
+++ b/shell/plugins/agents/README.md
@@ -77,8 +77,11 @@ page embeds the last ~50 requests, so the all-time totals describe that
 window rather than the account's whole history. Session counts are not
 exposed, so the panel hides the prompt/session line. A workspace is
 required: set `workspaceId` in `~/.config/omarchy/agents/opencode-go.json`
-(or `OPENCODE_WORKSPACE`) when the session has more than one. Without a
-signed-in browser the panel shows an auth card instead of the meters.
+(or `OPENCODE_WORKSPACE`) when the session has more than one. With no
+sign-in and no previously recorded meters the provider stays hidden — the
+panel only lists providers that have produced data. Once meters have been
+recorded, a stale or missing sign-in keeps the last meters visible with a
+status card until their windows reset.
 
 ### Fireworks balance
 

--- a/shell/plugins/agents/README.md
+++ b/shell/plugins/agents/README.md
@@ -85,6 +85,13 @@ panel only lists providers that have produced data. Once meters have been
 recorded, a stale or missing sign-in keeps the last meters visible with a
 status card until their windows reset.
 
+A meter the console has flipped to `rate-limited` is the binding constraint,
+not a gap: the collector reports it at its percentage and reset time (so the
+panel shows a full window with "resets in" countdown) instead of dropping
+it, and the status card says what happens next — requests are blocked until
+spend ages out, or, when the workspace's "Use balance" option is on and Zen
+credits remain, the overage bills the Zen balance with the amount left.
+
 ### Fireworks balance
 
 The collector first asks the account's `:getBalance` endpoint for the real

--- a/shell/plugins/agents/README.md
+++ b/shell/plugins/agents/README.md
@@ -55,6 +55,7 @@ light surfaces — and the bar glyph stands in when there is none.
 | `claude` | Anthropic's OAuth usage endpoint (5-hour session + 7-day weekly) | `~/.claude/projects` transcripts, opencode sessions on an Anthropic provider, plus `stats-cache.json` and `history.jsonl` as fallback |
 | `codex` | The Codex app-server RPC | native Codex CLI session files (plus pi and opencode sessions) |
 | `fireworks` | Estimated prepaid balance: configured funding minus rated account costs | Fireworks billing API, grouped by day and model for the last 30 days |
+| `opencode-go` | Rolling 5-hour, weekly, and monthly Go-plan meters scraped from the opencode.ai workspace page | Server-side per-request records from the workspace usage page, grouped by day and model |
 
 Claude limits need a signed-in CLI; without credentials the panel says so and
 falls back to local stats only. A non-default Claude directory is honored via
@@ -63,6 +64,21 @@ falls back to local stats only. A non-default Claude directory is honored via
 `~/.fireworks/auth.ini` (which `firectl set-api-key` creates), then the key
 opencode stores in `~/.local/share/opencode/auth.json` when Fireworks is
 signed in there.
+
+### OpenCode Go
+
+OpenCode Go is opencode.ai's Go subscription plan: three credit windows — a
+rolling 5-hour, a weekly, and a monthly — each reported as a percentage with
+a reset time. There is no usage API, so the collector reads the workspace
+console pages: the meters from `/workspace/<id>/go` and the recent
+per-request token records from `/workspace/<id>/usage`, using the `auth`
+session cookie Firefox or Zen Browser stores for opencode.ai. The usage
+page embeds the last ~50 requests, so the all-time totals describe that
+window rather than the account's whole history. Session counts are not
+exposed, so the panel hides the prompt/session line. A workspace is
+required: set `workspaceId` in `~/.config/omarchy/agents/opencode-go.json`
+(or `OPENCODE_WORKSPACE`) when the session has more than one. Without a
+signed-in browser the panel shows an auth card instead of the meters.
 
 ### Fireworks balance
 

--- a/shell/plugins/agents/assets/opencode-go-light.svg
+++ b/shell/plugins/agents/assets/opencode-go-light.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <g fill="none" stroke="#161616" stroke-linecap="round" stroke-linejoin="round" stroke-width="6">
+    <path d="M19 21l13 11-13 11"/>
+    <path d="M36 45h13"/>
+  </g>
+</svg>

--- a/shell/plugins/agents/assets/opencode-go.svg
+++ b/shell/plugins/agents/assets/opencode-go.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <g fill="none" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="6">
+    <path d="M19 21l13 11-13 11"/>
+    <path d="M36 45h13"/>
+  </g>
+</svg>

--- a/shell/plugins/agents/manifest.json
+++ b/shell/plugins/agents/manifest.json
@@ -5,7 +5,7 @@
   "version": "1.0.0",
   "author": "Omarchy",
   "license": "MIT",
-  "description": "Claude Code, Codex, and Fireworks usage, limits, and pace in a native Omarchy bar panel.",
+  "description": "Claude Code, Codex, Fireworks, and OpenCode Go usage, limits, and pace in a native Omarchy bar panel.",
   "kinds": ["bar-widget"],
   "activation": "on-demand",
   "entryPoints": {
@@ -21,7 +21,8 @@
       "providers": {
         "claude": { "enabled": true },
         "codex": { "enabled": true },
-        "fireworks": { "enabled": true }
+        "fireworks": { "enabled": true },
+        "opencode-go": { "enabled": true }
       },
       "refreshIntervalSec": 900,
       "syncMode": "Off",

--- a/test/shell.d/agent-usage-opencode-go-test.sh
+++ b/test/shell.d/agent-usage-opencode-go-test.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+
+source "$(dirname "$0")/base-test.sh"
+
+require_command jq
+require_command python3
+
+TEST_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME"' EXIT
+
+# Without a session cookie the collector must still print a full, hidden-by-default
+# record: the update runner writes whatever valid JSON appears on stdout.
+no_cookie=$(HOME="$TEST_HOME" XDG_CONFIG_HOME="$TEST_HOME/.config" XDG_STATE_HOME="$TEST_HOME/.local/state" \
+  XDG_DATA_HOME="$TEST_HOME/.local/share" "$ROOT/bin/omarchy-agent-usage-opencode-go")
+
+[[ $(jq -r '.id + ":" + (.ready | tostring) + ":" + (.hasPromptStats | tostring)' <<<"$no_cookie") == "opencode-go:false:false" ]] ||
+  fail "OpenCode Go collector prints a valid record without a cookie" "$no_cookie"
+pass "OpenCode Go collector prints a valid record without a cookie"
+
+[[ $(jq -r '.authHelpText' <<<"$no_cookie") != "" ]] ||
+  fail "OpenCode Go collector explains the missing cookie" "$no_cookie"
+pass "OpenCode Go collector explains the missing cookie"
+
+result=$(python3 - "$ROOT/bin/omarchy-agent-usage-opencode-go" <<'PY'
+import importlib.machinery
+import importlib.util
+import json
+import sys
+import datetime as dt
+
+loader = importlib.machinery.SourceFileLoader("collector", sys.argv[1])
+spec = importlib.util.spec_from_loader(loader.name, loader)
+module = importlib.util.module_from_spec(spec)
+loader.exec_module(module)
+
+today = dt.date.today()
+yesterday = today - dt.timedelta(days=1)
+
+go_page = (
+    '<html><body><script>'
+    'rollingUsage:$R[1]={status:"ok",resetInSec:8073,usagePercent:1.0},'
+    'weeklyUsage:$R[2]={status:"ok",resetInSec:101069,usagePercent:60},'
+    'monthlyUsage:$R[3]={status:"ok",resetInSec:2347422,usagePercent:30},'
+    'liteSubscriptionID:"sub_test"'
+    '</script></body></html>'
+)
+
+def rec(rid, date, model, inp, out, reasoning, cread, w5m, w1h):
+    return (
+        '{id:"%s",workspaceID:"wrk_XXXXXXXXXXXXXXXXXXXXXXXXXX",'
+        'timeCreated:$R[10]=new Date("%sT10:00:00.000Z"),'
+        'timeUpdated:$R[11]=new Date("%sT10:00:01.000Z"),timeDeleted:null,'
+        'model:"%s",provider:"inf-go.oa-compat",'
+        'inputTokens:%d,outputTokens:%d,reasoningTokens:%d,cacheReadTokens:%d,'
+        'cacheWrite5mTokens:%s,cacheWrite1hTokens:%s,cost:12345,'
+        'keyID:"k",sessionID:"",enrichment:$R[12]={plan:"lite"}}' % (
+            rid, date, date, model, inp, out, reasoning, cread, w5m, w1h)
+    )
+
+usage_page = (
+    '<script>'
+    + rec("usg_01AAA", today, "deepseek-v4-flash", 100, 200, 50, 300, "null", "null")
+    + ',' + rec("usg_01BBB", today, "deepseek-v4-flash", 10, 20, 5, 30, "400", "50")
+    + ',' + rec("usg_01CCC", yesterday, "qwen3-coder", 1000, 0, 0, 0, "null", "null")
+    + '</script>'
+)
+
+meters, plan = module.parse_meters(go_page)
+limits = module.build_limits(meters)
+records = module.parse_usage_records(usage_page)
+stats = module.build_stats(records)
+full_record = module.build_record(meters, plan, records)
+limits_only = module.build_record(meters, plan, [])
+
+print(json.dumps({
+    "plan": plan,
+    "limits": limits,
+    "records": records,
+    "stats": stats,
+    "record": full_record,
+    "limitsOnly": limits_only,
+}))
+PY
+)
+
+[[ $(jq -r '.plan' <<<"$result") == "Go" ]] ||
+  fail "OpenCode Go collector reads the Go plan marker" "$result"
+pass "OpenCode Go collector reads the Go plan marker"
+
+[[ $(jq -r '.limits[0].label' <<<"$result") == "Rolling (5-hour)" ]] ||
+  fail "OpenCode Go collector labels the rolling window" "$result"
+pass "OpenCode Go collector labels the rolling window"
+
+[[ $(jq -c '[.limits[].percent]' <<<"$result") == '[0.01,0.6,0.3]' ]] ||
+  fail "OpenCode Go collector reports percent-scale meters as fractions" "$result"
+pass "OpenCode Go collector reports percent-scale meters as fractions"
+
+[[ $(jq -r '.limits[0].resetsAt' <<<"$result") > "$(date -u -d 'now + 2 hours' +%Y-%m-%dT%H:%M)" ]] ||
+  fail "OpenCode Go collector stamps a future resetsAt" "$result"
+pass "OpenCode Go collector stamps a future resetsAt"
+
+[[ $(jq -r '.records | length' <<<"$result") == "3" ]] ||
+  fail "OpenCode Go collector parses every usage record" "$result"
+pass "OpenCode Go collector parses every usage record"
+
+[[ $(jq -r '.stats.todayPrompts' <<<"$result") == "2" ]] ||
+  fail "OpenCode Go collector counts today's requests" "$result"
+pass "OpenCode Go collector counts today's requests"
+
+[[ $(jq -r '.stats.todayTotalTokens' <<<"$result") == "1165" ]] ||
+  fail "OpenCode Go collector totals today's tokens" "$result"
+pass "OpenCode Go collector totals today's tokens"
+
+[[ $(jq -c '.stats.modelUsage["deepseek-v4-flash"]' <<<"$result") == '{"inputTokens":110,"outputTokens":275,"cacheReadInputTokens":330,"cacheCreationInputTokens":450}' ]] ||
+  fail "OpenCode Go collector rolls reasoning into output and sums cache writes" "$result"
+pass "OpenCode Go collector rolls reasoning into output and sums cache writes"
+
+[[ $(jq -r '.stats.recentDays[-1].messageCount' <<<"$result") == "1165" ]] ||
+  fail "OpenCode Go collector builds the seven-day token series" "$result"
+pass "OpenCode Go collector builds the seven-day token series"
+
+[[ $(jq -r '.stats.activeDays' <<<"$result") == "2" ]] ||
+  fail "OpenCode Go collector counts active days from the record window" "$result"
+pass "OpenCode Go collector counts active days from the record window"
+
+[[ $(jq -c '.record | {schemaVersion, id, ready, hasLocalStats, hasPromptStats, tierLabel, usageStatusText}' <<<"$result") == '{"schemaVersion":1,"id":"opencode-go","ready":true,"hasLocalStats":true,"hasPromptStats":false,"tierLabel":"Go","usageStatusText":""}' ]] ||
+  fail "OpenCode Go collector prints the display-ready record contract" "$result"
+pass "OpenCode Go collector prints the display-ready record contract"
+
+[[ $(jq -r '.limitsOnly | has("todayTotalTokens")' <<<"$result") == "false" && $(jq -r '.limitsOnly.limits | length' <<<"$result") == "3" ]] ||
+  fail "OpenCode Go collector keeps limits when usage records are missing" "$result"
+pass "OpenCode Go collector keeps limits when usage records are missing"

--- a/test/shell.d/agent-usage-opencode-go-test.sh
+++ b/test/shell.d/agent-usage-opencode-go-test.sh
@@ -119,6 +119,12 @@ stats = module.build_stats(records)
 full_record = module.build_record(meters, plan, records)
 limits_only = module.build_record(meters, plan, [])
 
+assert module.number("null") == 0 and module.number("inf") == 0 and module.number("1e999") == 0, \
+    "number() maps null and non-finite values to zero, never crashing the parse"
+
+assert [entry["title"] for entry in limits] == ["Rolling", "Weekly", "Monthly"], \
+    "limits carry explicit window titles for the panel"
+
 # --- rate-limited meters and the Zen-balance fallback ------------------
 #
 # A meter the console flipped to 'rate-limited' is the binding constraint:
@@ -128,12 +134,16 @@ limits_only = module.build_record(meters, plan, [])
 
 rl_go_page = (
     '<html><body><script>'
+    # The serialized page wraps the workspace fields (meters, balance, lite:)
+    # in one $R object; parse_go_config bounds its balance search to it.
+    '$R[31]={'
     'rollingUsage:$R[1]={status:"ok",resetInSec:8073,usagePercent:1.0,usage:12000000,limit:1200000000},'
     'weeklyUsage:$R[2]={status:"ok",resetInSec:101069,usagePercent:60,usage:1800000000,limit:3000000000},'
     'monthlyUsage:$R[3]={status:"rate-limited",resetInSec:133420,usagePercent:100.1,usage:6007226480,limit:6000000000},'
     'balance:996544169,reload:null,'
     'liteSubscriptionID:"sub_test",'
     'lite:$R[33]={useBalance:!0}'
+    '}'
     '</script></body></html>'
 )
 
@@ -149,6 +159,11 @@ assert module.parse_go_config(rl_go_page) == {"useBalance": True, "balance": 996
     "go config reads useBalance and the Zen balance before lite:"
 assert module.parse_go_config('<script>lite:$R[7]={useBalance:!1}</script>') == {"useBalance": False, "balance": None}, \
     "useBalance off parses as false with no balance"
+assert module.parse_go_config(
+    '<script>customerID:"x",balance:777,'  # unrelated: outside the workspace object
+    '$R[9]={balance:996544169,lite:$R[2]={useBalance:!0}}'
+    '</script>'
+) == {"useBalance": True, "balance": 996544169}, "balance search is bounded to the workspace object"
 assert module.parse_go_config('<script>no config here</script>') == {"useBalance": False, "balance": None}, \
     "missing lite block parses as defaults"
 
@@ -225,7 +240,38 @@ assert result == [
 header = module.build_cookie_header(result)
 assert header == "auth=fresh-token; oc_locale=en", "build_cookie_header de-duplicates by name keeping freshest"
 
-# --- resolve_workspace precedence, never touching the network -------------
+# --- resolve_session profile discovery and cross-profile freshness -------
+discovery_home = os.path.join(fixture_dir, "home")
+profile_a = os.path.join(discovery_home, ".mozilla", "firefox", "profile1")
+profile_b = os.path.join(discovery_home, ".mozilla", "firefox", "profile2")
+for profile_dir in (profile_a, profile_b):
+    os.makedirs(profile_dir, exist_ok=True)
+    conn = sqlite3.connect(os.path.join(profile_dir, "cookies.sqlite"))
+    conn.execute(
+        "CREATE TABLE moz_cookies (host TEXT, name TEXT, value TEXT, expiry INTEGER, "
+        "lastAccessed INTEGER, creationTime INTEGER)"
+    )
+    conn.commit()
+    conn.close()
+conn = sqlite3.connect(os.path.join(profile_a, "cookies.sqlite"))
+conn.execute("INSERT INTO moz_cookies VALUES ('.opencode.ai', 'auth', 'stale-token', 9999999999, 1000, 1000)")
+conn.commit()
+conn.close()
+conn = sqlite3.connect(os.path.join(profile_b, "cookies.sqlite"))
+conn.execute("INSERT INTO moz_cookies VALUES ('.opencode.ai', 'auth', 'fresh-token', 9999999999, 9000, 1000)")
+conn.commit()
+conn.close()
+
+old_home = os.environ.get("HOME")
+os.environ["HOME"] = discovery_home
+try:
+    session = module.resolve_session({})
+finally:
+    if old_home is None:
+        del os.environ["HOME"]
+    else:
+        os.environ["HOME"] = old_home
+assert session == "auth=fresh-token", "resolve_session discovers profiles and picks the most recently accessed cookie across them"
 
 # --- resolve_workspace precedence, never touching the network -------------
 os.environ["OPENCODE_WORKSPACE"] = "wrk_eeeeeeeeeeeeeeeeeeeeeeeeee"
@@ -400,6 +446,27 @@ module.fetch_usage_chunk = lambda cookie, workspace, page, instance: "<script></
 assert module.fetch_usage_records("cookie", "wrk_x") == [], "an empty list page ends the walk"
 
 fetched_pages.clear()
+real_parse = module.parse_usage_records
+
+def fake_chunk_boom(cookie, workspace, page, instance):
+    fetched_pages.append(page)
+    if page == 0:
+        return page_html(fill(today, 50))
+    return "<script>boom</script>"
+
+def fake_parse_boom(html):
+    if html == "<script>boom</script>":
+        raise ValueError("unparsable page")
+    return real_parse(html)
+
+module.fetch_usage_chunk = fake_chunk_boom
+module.parse_usage_records = fake_parse_boom
+walk = module.fetch_usage_records("cookie", "wrk_x")
+assert fetched_pages == [0, 1], "an unparsable page stops the walk"
+assert len(walk) == 50, "pages already parsed survive a page that refuses to parse"
+module.parse_usage_records = real_parse
+
+fetched_pages.clear()
 
 def fake_always(cookie, workspace, page, instance):
     fetched_pages.append(page)
@@ -427,6 +494,28 @@ assert healthy["ready"] is True, "healthy record stays ready"
 assert healthy["usageStatusText"] == "", "healthy record carries no status card"
 assert healthy["limits"] != [], "healthy record carries fresh meters"
 
+cache_file = os.path.join(cache_root_dir, "omarchy", "agent-usage", "opencode-go-limits.json")
+assert os.path.exists(cache_file), "a healthy run writes the limits cache"
+with open(cache_file, encoding="utf-8") as handle:
+    cached_limits = json.load(handle)["limits"]
+assert len(cached_limits) == 3 and cached_limits[0]["title"] == "Rolling", \
+    "the limits cache carries the fresh meters with their window titles"
+
+# --- main() with --limits-only: fresh meters, no usage walk ----------------
+module.fetch_page = lambda cookie, path: go_page
+module.fetch_usage_chunk = fake_chunk
+fetched_pages.clear()
+sys.argv = ["omarchy-agent-usage-opencode-go", "--limits-only"]
+captured = io.StringIO()
+with contextlib.redirect_stdout(captured):
+    exit_code = module.main()
+assert exit_code == 0, "main returns 0 for a limits-only run"
+limits_only_run = json.loads(captured.getvalue())
+assert fetched_pages == [], "--limits-only skips the usage walk"
+assert limits_only_run["ready"] is True, "a limits-only run stays ready"
+assert limits_only_run["todayTotalTokens"] == 0, "a limits-only run yields zero-shaped stats"
+assert len(limits_only_run["limits"]) == 3, "a limits-only run keeps the fresh meters"
+
 print(json.dumps({
     "plan": plan,
     "limits": limits,
@@ -451,6 +540,10 @@ pass "OpenCode Go collector labels the rolling window"
 [[ $(jq -c '[.limits[].percent]' <<<"$result") == '[0.01,0.6,0.3]' ]] ||
   fail "OpenCode Go collector reports percent-scale meters as fractions" "$result"
 pass "OpenCode Go collector reports percent-scale meters as fractions"
+
+[[ $(jq -c '[.limits[].title]' <<<"$result") == '["Rolling","Weekly","Monthly"]' ]] ||
+  fail "OpenCode Go collector titles its windows" "$result"
+pass "OpenCode Go collector titles its windows"
 
 [[ $(jq -r '.limits[0].resetsAt' <<<"$result") > "$(date -u -d 'now + 2 hours' +%Y-%m-%dT%H:%M)" ]] ||
   fail "OpenCode Go collector stamps a future resetsAt" "$result"

--- a/test/shell.d/agent-usage-opencode-go-test.sh
+++ b/test/shell.d/agent-usage-opencode-go-test.sh
@@ -253,6 +253,131 @@ format_record = json.loads(captured.getvalue())
 assert format_record["usageStatusText"] == "Page format changed", "unrecognised HTML is reported as a format change, not auth failure"
 assert format_record["retryAdvised"] is True, "format change advises retry in case it was transient"
 
+# --- usage-list paging ---------------------------------------------------
+#
+# The usage page SSR renders only the newest 50 records; older days are
+# fetched page-by-page through the usage-list server function. A refresh that
+# stops at the first page would make every day that scrolled past it vanish
+# from the record, so the walk must reach back through the trailing week.
+
+assert module.seroval_args(["wrk_cccccccccccccccccccccccccc", 0]) == {
+    "t": {"t": 9, "i": 0, "l": 2,
+          "a": [{"t": 1, "s": "wrk_cccccccccccccccccccccccccc"}, {"t": 0, "s": 0}],
+          "o": 0},
+    "f": 31,
+    "m": [],
+}, "seroval encodes the SPA's (workspace, page) arguments"
+
+six_days_ago = today - dt.timedelta(days=6)
+week_cutoff = today - dt.timedelta(days=8)
+
+
+def page_html(rows):
+    return "<script>" + ",".join(rows) + "</script>"
+
+
+def fill(day, n):
+    return [rec("usg_01ZZZ%03d" % i, day, "deepseek-v4-flash", 1, 1, 0, 0, "null", "null")
+            for i in range(n)]
+
+
+fetched_pages = []
+
+
+def fake_chunk(cookie, workspace, page, instance):
+    fetched_pages.append(page)
+    if page == 0:
+        return page_html(fill(today, 50))
+    if page == 1:
+        return page_html(fill(yesterday, 50))
+    if page == 2:
+        return page_html(fill(six_days_ago, 50))
+    # Out of window: the walk must stop here without keeping these.
+    return page_html(fill(week_cutoff, 50))
+
+
+module.fetch_usage_chunk = fake_chunk
+walk = module.fetch_usage_records("cookie", "wrk_cccccccccccccccccccccccccc")
+assert fetched_pages == [0, 1, 2, 3], "usage walk pages newest-first until past the window"
+walk_days = {record["day"] for record in walk}
+assert today.isoformat() in walk_days, "today survives a later refresh"
+assert yesterday.isoformat() in walk_days, "yesterday survives a later refresh"
+assert week_cutoff.isoformat() not in walk_days, "records outside the trailing week are dropped"
+assert len(walk) == 150, "walk keeps exactly the in-window records"
+
+# The console's usage list pages back through retained history, and new
+# records land while a refresh walks it, so an interior page can come back
+# short without being the last one. Ending the walk on a short page dropped
+# whole days (yesterday scrolled off the newest page and vanished); only an
+# empty page — the list's oldest — or a page whose oldest record predates the
+# week ends it.
+
+fetched_pages.clear()
+
+def fake_short_mid(cookie, workspace, page, instance):
+    fetched_pages.append(page)
+    if page == 0:
+        return page_html(fill(today, 50))
+    if page == 1:
+        return page_html(fill(today, 10))  # short page, but not the last
+    if page == 2:
+        return page_html(fill(yesterday, 50))
+    return page_html(fill(week_cutoff, 50))
+
+
+module.fetch_usage_chunk = fake_short_mid
+walk = module.fetch_usage_records("cookie", "wrk_x")
+assert fetched_pages == [0, 1, 2, 3], "an interior short page does not end the walk"
+assert yesterday.isoformat() in {record["day"] for record in walk}, "yesterday survives a short page mid-history"
+assert len(walk) == 110, "interior short pages keep their records"
+
+# A mid-walk failure keeps the pages already parsed; a failed first page
+# yields the old empty-records shape.
+fetched_pages.clear()
+
+def fake_flaky(cookie, workspace, page, instance):
+    fetched_pages.append(page)
+    if page == 1:
+        raise urllib.error.URLError("no route")
+    return page_html(fill(today, 50))
+
+
+module.fetch_usage_chunk = fake_flaky
+walk = module.fetch_usage_records("cookie", "wrk_cccccccccccccccccccccccccc")
+assert fetched_pages == [0, 1], "a failed page stops the walk"
+assert len(walk) == 50, "pages already parsed survive a mid-walk failure"
+
+module.fetch_usage_chunk = lambda cookie, workspace, page, instance: "<script></script>"
+assert module.fetch_usage_records("cookie", "wrk_x") == [], "an empty list page ends the walk"
+
+fetched_pages.clear()
+
+def fake_always(cookie, workspace, page, instance):
+    fetched_pages.append(page)
+    return page_html(fill(today, 50))
+
+
+module.fetch_usage_chunk = fake_always
+walk = module.fetch_usage_records("cookie", "wrk_x")
+assert len(fetched_pages) == module.MAX_USAGE_PAGES, "a walk that never leaves the window is capped"
+assert len(walk) == module.MAX_USAGE_PAGES * 50, "the cap truncates instead of hanging"
+
+# --- healthy main(): meters plus a window walk that includes yesterday -----
+module.fetch_page = lambda cookie, path: go_page
+module.fetch_usage_chunk = fake_chunk
+captured = io.StringIO()
+with contextlib.redirect_stdout(captured):
+    exit_code = module.main()
+assert exit_code == 0, "main returns 0 on a healthy run"
+healthy = json.loads(captured.getvalue())
+by_day = {entry["date"]: entry["messageCount"] for entry in healthy["recentDays"]}
+assert by_day.get(today.isoformat(), 0) > 0, "healthy record keeps today's tokens"
+assert by_day.get(yesterday.isoformat(), 0) > 0, "healthy record keeps yesterday's tokens"
+assert by_day.get(week_cutoff.isoformat(), 0) == 0, "healthy record drops out-of-window days"
+assert healthy["ready"] is True, "healthy record stays ready"
+assert healthy["usageStatusText"] == "", "healthy record carries no status card"
+assert healthy["limits"] != [], "healthy record carries fresh meters"
+
 print(json.dumps({
     "plan": plan,
     "limits": limits,

--- a/test/shell.d/agent-usage-opencode-go-test.sh
+++ b/test/shell.d/agent-usage-opencode-go-test.sh
@@ -35,12 +35,33 @@ limits_out=$(HOME="$TEST_HOME" XDG_CONFIG_HOME="$TEST_HOME/.config" XDG_STATE_HO
   fail "OpenCode Go collector accepts --limits-only" "$limits_out"
 pass "OpenCode Go collector accepts --limits-only"
 
+# With a prepared limits cache, a missing cookie must keep the last meters on
+# the panel — a status card instead of a vanished provider — until the cached
+# windows reset.
+cache_dir="$TEST_HOME/.cache/omarchy/agent-usage"
+mkdir -p "$cache_dir"
+cache_resets=$(date -u -d 'now + 3 hours' +%Y-%m-%dT%H:%M:%SZ)
+printf '{"fetchedAtMs":%s000,"limits":[{"label":"Rolling (5-hour)","percent":0.22,"resetsAt":"%s"}]}\n' \
+  "$(date +%s)" "$cache_resets" > "$cache_dir/opencode-go-limits.json"
+cached_no_cookie=$(HOME="$TEST_HOME" XDG_CONFIG_HOME="$TEST_HOME/.config" XDG_CACHE_HOME="$TEST_HOME/.cache" \
+  XDG_STATE_HOME="$TEST_HOME/.local/state" XDG_DATA_HOME="$TEST_HOME/.local/share" \
+  "$ROOT/bin/omarchy-agent-usage-opencode-go")
+[[ $(jq -r '(.ready | tostring) + ":" + .usageStatusText + ":" + (.limits[0].label | tostring) + ":" + (.limits | length | tostring)' <<<"$cached_no_cookie") == "true:Waiting for sign-in:Rolling (5-hour):1" ]] ||
+  fail "OpenCode Go collector keeps cached limits and a status card without a cookie" "$cached_no_cookie"
+pass "OpenCode Go collector keeps cached limits and a status card without a cookie"
+
 result=$(python3 - "$ROOT/bin/omarchy-agent-usage-opencode-go" <<'PY'
+import contextlib
+import datetime as dt
 import importlib.machinery
 import importlib.util
+import io
 import json
+import os
+import sqlite3
 import sys
-import datetime as dt
+import tempfile
+import urllib.error
 
 loader = importlib.machinery.SourceFileLoader("collector", sys.argv[1])
 spec = importlib.util.spec_from_loader(loader.name, loader)
@@ -49,6 +70,14 @@ loader.exec_module(module)
 
 today = dt.date.today()
 yesterday = today - dt.timedelta(days=1)
+
+# The fixture stamps each record at LOCAL noon: a UTC-noon stamp is tomorrow
+# local east of UTC+12, which would file today's requests under tomorrow's
+# date and empty today's stats there.
+def local_noon_utc(day):
+    return dt.datetime.combine(
+        day, dt.time(12, 0), tzinfo=dt.datetime.now().astimezone().tzinfo
+    ).astimezone(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
 
 go_page = (
     '<html><body><script>'
@@ -60,15 +89,16 @@ go_page = (
 )
 
 def rec(rid, date, model, inp, out, reasoning, cread, w5m, w1h):
+    stamp = local_noon_utc(date)
     return (
         '{id:"%s",workspaceID:"wrk_XXXXXXXXXXXXXXXXXXXXXXXXXX",'
-        'timeCreated:$R[10]=new Date("%sT12:00:00.000Z"),'
-        'timeUpdated:$R[11]=new Date("%sT12:00:01.000Z"),timeDeleted:null,'
+        'timeCreated:$R[10]=new Date("%s"),'
+        'timeUpdated:$R[11]=new Date("%s"),timeDeleted:null,'
         'model:"%s",provider:"inf-go.oa-compat",'
         'inputTokens:%d,outputTokens:%d,reasoningTokens:%s,cacheReadTokens:%d,'
         'cacheWrite5mTokens:%s,cacheWrite1hTokens:%s,cost:12345,'
         'keyID:"k",sessionID:"",enrichment:$R[12]={plan:"lite"}}' % (
-            rid, date, date, model, inp, out, reasoning, cread, w5m, w1h)
+            rid, stamp, stamp, model, inp, out, reasoning, cread, w5m, w1h)
     )
 
 usage_page = (
@@ -88,6 +118,85 @@ records = module.parse_usage_records(usage_page)
 stats = module.build_stats(records)
 full_record = module.build_record(meters, plan, records)
 limits_only = module.build_record(meters, plan, [])
+
+# --- extract_auth_cookie fixture -------------------------------------------
+fixture_dir = tempfile.mkdtemp()
+cookie_db = os.path.join(fixture_dir, "cookies.sqlite")
+conn = sqlite3.connect(cookie_db)
+conn.execute("CREATE TABLE moz_cookies (host TEXT, name TEXT, value TEXT, expiry INTEGER)")
+conn.execute("INSERT INTO moz_cookies VALUES ('.opencode.ai', 'auth', 'auth-token-xyz', 9999999999)")
+conn.commit()
+conn.close()
+assert module.extract_auth_cookie(cookie_db) == "auth-token-xyz", "auth cookie value round-trips"
+
+empty_db = os.path.join(fixture_dir, "empty.sqlite")
+conn = sqlite3.connect(empty_db)
+conn.execute("CREATE TABLE moz_cookies (host TEXT, name TEXT, value TEXT, expiry INTEGER)")
+conn.commit()
+conn.close()
+assert module.extract_auth_cookie(empty_db) == "", "empty cookies db yields an empty cookie"
+
+# --- resolve_workspace precedence, never touching the network -------------
+os.environ["OPENCODE_WORKSPACE"] = "wrk_eeeeeeeeeeeeeeeeeeeeeeeeee"
+assert module.resolve_workspace({"workspaceId": "wrk_cccccccccccccccccccccccccc"}, "") == (
+    "wrk_cccccccccccccccccccccccccc", ""), "config workspaceId wins over env"
+assert module.resolve_workspace({}, "") == (
+    "wrk_eeeeeeeeeeeeeeeeeeeeeeeeee", ""), "env is used when the config has no workspaceId"
+del os.environ["OPENCODE_WORKSPACE"]
+
+def no_network(cookie):
+    raise urllib.error.URLError("name resolution failed")
+module.list_workspaces = no_network
+assert module.resolve_workspace({}, "cookie") == ("", "transport"), "RPC failure maps to transport"
+
+module.list_workspaces = lambda cookie: []
+assert module.resolve_workspace({}, "cookie") == ("", "unknown"), "zero workspaces maps to unknown"
+
+module.list_workspaces = lambda cookie: ["wrk_aaaaaaaaaaaaaaaaaaaaaaaaaa", "wrk_bbbbbbbbbbbbbbbbbbbbbbbbbb"]
+assert module.resolve_workspace({}, "cookie") == ("", "unknown"), "several workspaces maps to unknown"
+
+# --- main() failure branch: cached limits keep the tab alive --------------
+cfg_root = os.path.join(fixture_dir, "config")
+os.makedirs(os.path.join(cfg_root, "omarchy", "agents"), exist_ok=True)
+cookie_file = os.path.join(fixture_dir, "cookie.txt")
+with open(cookie_file, "w", encoding="utf-8") as handle:
+    handle.write("auth-token-xyz\n")
+with open(os.path.join(cfg_root, "omarchy", "agents", "opencode-go.json"), "w", encoding="utf-8") as handle:
+    json.dump({"cookieFile": cookie_file, "workspaceId": "wrk_cccccccccccccccccccccccccc"}, handle)
+
+cache_root_dir = os.path.join(fixture_dir, "cache")
+os.makedirs(os.path.join(cache_root_dir, "omarchy", "agent-usage"), exist_ok=True)
+future_resets = (dt.datetime.now(dt.timezone.utc) + dt.timedelta(hours=3)).isoformat().replace("+00:00", "Z")
+cache_payload = {
+    "fetchedAtMs": round(dt.datetime.now(dt.timezone.utc).timestamp() * 1000),
+    "limits": [
+        {"label": "Rolling (5-hour)", "percent": 0.15, "resetsAt": future_resets},
+        {"label": "Weekly", "percent": 0.4, "resetsAt": future_resets},
+        {"label": "Monthly", "percent": 0.7, "resetsAt": future_resets},
+    ],
+}
+with open(os.path.join(cache_root_dir, "omarchy", "agent-usage", "opencode-go-limits.json"), "w", encoding="utf-8") as handle:
+    json.dump(cache_payload, handle)
+
+os.environ["XDG_CONFIG_HOME"] = cfg_root
+os.environ["XDG_CACHE_HOME"] = cache_root_dir
+
+def fetch_boom(cookie, path):
+    raise urllib.error.URLError("no route to host")
+module.fetch_page = fetch_boom
+
+# The harness invoked python with the collector path as an argument; main()
+# must see a clean argv like a real launch.
+sys.argv = ["omarchy-agent-usage-opencode-go"]
+
+captured = io.StringIO()
+with contextlib.redirect_stdout(captured):
+    exit_code = module.main()
+assert exit_code == 0, "main returns 0 on a transport failure"
+failure_record = json.loads(captured.getvalue())
+assert failure_record["limits"] == cache_payload["limits"], "cached limits survive a refresh failure"
+assert failure_record["retryAdvised"] is True, "transport failure advises an earlier retry"
+assert failure_record["usageStatusText"] == "Couldn't reach opencode.ai", "status card explains the failure"
 
 print(json.dumps({
     "plan": plan,
@@ -148,6 +257,12 @@ pass "OpenCode Go collector counts active days from the record window"
   fail "OpenCode Go collector prints the display-ready record contract" "$result"
 pass "OpenCode Go collector prints the display-ready record contract"
 
-[[ $(jq -r '.limitsOnly | has("todayTotalTokens")' <<<"$result") == "false" && $(jq -r '.limitsOnly.limits | length' <<<"$result") == "3" ]] ||
-  fail "OpenCode Go collector keeps limits when usage records are missing" "$result"
-pass "OpenCode Go collector keeps limits when usage records are missing"
+[[ $(jq -r '.limitsOnly | has("todayTotalTokens")' <<<"$result") == "true" && \
+   $(jq -r '.limitsOnly.todayTotalTokens' <<<"$result") == "0" && \
+   $(jq -r '.limitsOnly.limits | length' <<<"$result") == "3" ]] ||
+  fail "OpenCode Go collector keeps limits and zero-shaped stats when usage records are missing" "$result"
+pass "OpenCode Go collector keeps limits and zero-shaped stats when usage records are missing"
+
+[[ $(jq -r '.record.scope' <<<"$result") == "account" ]] ||
+  fail "OpenCode Go collector marks account-scoped records" "$result"
+pass "OpenCode Go collector marks account-scoped records"

--- a/test/shell.d/agent-usage-opencode-go-test.sh
+++ b/test/shell.d/agent-usage-opencode-go-test.sh
@@ -65,7 +65,7 @@ def rec(rid, date, model, inp, out, reasoning, cread, w5m, w1h):
         'timeCreated:$R[10]=new Date("%sT12:00:00.000Z"),'
         'timeUpdated:$R[11]=new Date("%sT12:00:01.000Z"),timeDeleted:null,'
         'model:"%s",provider:"inf-go.oa-compat",'
-        'inputTokens:%d,outputTokens:%d,reasoningTokens:%d,cacheReadTokens:%d,'
+        'inputTokens:%d,outputTokens:%d,reasoningTokens:%s,cacheReadTokens:%d,'
         'cacheWrite5mTokens:%s,cacheWrite1hTokens:%s,cost:12345,'
         'keyID:"k",sessionID:"",enrichment:$R[12]={plan:"lite"}}' % (
             rid, date, date, model, inp, out, reasoning, cread, w5m, w1h)
@@ -76,6 +76,9 @@ usage_page = (
     + rec("usg_01AAA", today, "deepseek-v4-flash", 100, 200, 50, 300, "null", "null")
     + ',' + rec("usg_01BBB", today, "deepseek-v4-flash", 10, 20, 5, 30, "400", "50")
     + ',' + rec("usg_01CCC", yesterday, "qwen3-coder", 1000, 0, 0, 0, "null", "null")
+    # reasoningTokens comes back null for models that report no reasoning
+    # tokens; the record must still parse.
+    + ',' + rec("usg_01DDD", today, "deepseek-v4-flash", 1000, 500, "null", 0, "null", "null")
     + '</script>'
 )
 
@@ -113,23 +116,27 @@ pass "OpenCode Go collector reports percent-scale meters as fractions"
   fail "OpenCode Go collector stamps a future resetsAt" "$result"
 pass "OpenCode Go collector stamps a future resetsAt"
 
-[[ $(jq -r '.records | length' <<<"$result") == "3" ]] ||
+[[ $(jq -r '.records | length' <<<"$result") == "4" ]] ||
   fail "OpenCode Go collector parses every usage record" "$result"
 pass "OpenCode Go collector parses every usage record"
 
-[[ $(jq -r '.stats.todayPrompts' <<<"$result") == "2" ]] ||
+[[ $(jq -r '.records[3].reasoning' <<<"$result") == "0" ]] ||
+  fail "OpenCode Go collector treats a null reasoning token count as zero" "$result"
+pass "OpenCode Go collector treats a null reasoning token count as zero"
+
+[[ $(jq -r '.stats.todayPrompts' <<<"$result") == "3" ]] ||
   fail "OpenCode Go collector counts today's requests" "$result"
 pass "OpenCode Go collector counts today's requests"
 
-[[ $(jq -r '.stats.todayTotalTokens' <<<"$result") == "1165" ]] ||
+[[ $(jq -r '.stats.todayTotalTokens' <<<"$result") == "2665" ]] ||
   fail "OpenCode Go collector totals today's tokens" "$result"
 pass "OpenCode Go collector totals today's tokens"
 
-[[ $(jq -c '.stats.modelUsage["deepseek-v4-flash"]' <<<"$result") == '{"inputTokens":110,"outputTokens":275,"cacheReadInputTokens":330,"cacheCreationInputTokens":450}' ]] ||
+[[ $(jq -c '.stats.modelUsage["deepseek-v4-flash"]' <<<"$result") == '{"inputTokens":1110,"outputTokens":775,"cacheReadInputTokens":330,"cacheCreationInputTokens":450}' ]] ||
   fail "OpenCode Go collector rolls reasoning into output and sums cache writes" "$result"
 pass "OpenCode Go collector rolls reasoning into output and sums cache writes"
 
-[[ $(jq -r '.stats.recentDays[-1].messageCount' <<<"$result") == "1165" ]] ||
+[[ $(jq -r '.stats.recentDays[-1].messageCount' <<<"$result") == "2665" ]] ||
   fail "OpenCode Go collector builds the seven-day token series" "$result"
 pass "OpenCode Go collector builds the seven-day token series"
 

--- a/test/shell.d/agent-usage-opencode-go-test.sh
+++ b/test/shell.d/agent-usage-opencode-go-test.sh
@@ -81,9 +81,9 @@ def local_noon_utc(day):
 
 go_page = (
     '<html><body><script>'
-    'rollingUsage:$R[1]={status:"ok",resetInSec:8073,usagePercent:1.0},'
-    'weeklyUsage:$R[2]={status:"ok",resetInSec:101069,usagePercent:60},'
-    'monthlyUsage:$R[3]={status:"ok",resetInSec:2347422,usagePercent:30},'
+    'rollingUsage:$R[1]={status:"ok",resetInSec:8073,usagePercent:1.0,usage:12000000,limit:1200000000},'
+    'weeklyUsage:$R[2]={status:"ok",resetInSec:101069,usagePercent:60,usage:1800000000,limit:3000000000},'
+    'monthlyUsage:$R[3]={status:"ok",resetInSec:2347422,usagePercent:30,usage:1800000000,limit:6000000000},'
     'liteSubscriptionID:"sub_test"'
     '</script></body></html>'
 )
@@ -119,22 +119,64 @@ stats = module.build_stats(records)
 full_record = module.build_record(meters, plan, records)
 limits_only = module.build_record(meters, plan, [])
 
-# --- extract_auth_cookie fixture -------------------------------------------
+# --- extract_all_cookies fixture -------------------------------------------
 fixture_dir = tempfile.mkdtemp()
 cookie_db = os.path.join(fixture_dir, "cookies.sqlite")
 conn = sqlite3.connect(cookie_db)
-conn.execute("CREATE TABLE moz_cookies (host TEXT, name TEXT, value TEXT, expiry INTEGER)")
-conn.execute("INSERT INTO moz_cookies VALUES ('.opencode.ai', 'auth', 'auth-token-xyz', 9999999999)")
+conn.execute(
+    "CREATE TABLE moz_cookies (host TEXT, name TEXT, value TEXT, expiry INTEGER, "
+    "lastAccessed INTEGER, creationTime INTEGER)"
+)
+conn.execute(
+    "INSERT INTO moz_cookies VALUES ('.opencode.ai', 'auth', 'auth-token-xyz', "
+    "9999999999, 5000, 1000)"
+)
 conn.commit()
 conn.close()
-assert module.extract_auth_cookie(cookie_db) == "auth-token-xyz", "auth cookie value round-trips"
+assert module.extract_all_cookies(cookie_db) == [("auth", "auth-token-xyz", 5000)], "auth cookie value round-trips"
 
 empty_db = os.path.join(fixture_dir, "empty.sqlite")
 conn = sqlite3.connect(empty_db)
-conn.execute("CREATE TABLE moz_cookies (host TEXT, name TEXT, value TEXT, expiry INTEGER)")
+conn.execute(
+    "CREATE TABLE moz_cookies (host TEXT, name TEXT, value TEXT, expiry INTEGER, "
+    "lastAccessed INTEGER, creationTime INTEGER)"
+)
 conn.commit()
 conn.close()
-assert module.extract_auth_cookie(empty_db) == "", "empty cookies db yields an empty cookie"
+assert module.extract_all_cookies(empty_db) == [], "empty cookies db yields an empty list"
+
+multi_db = os.path.join(fixture_dir, "multi.sqlite")
+conn = sqlite3.connect(multi_db)
+conn.execute(
+    "CREATE TABLE moz_cookies (host TEXT, name TEXT, value TEXT, expiry INTEGER, "
+    "lastAccessed INTEGER, creationTime INTEGER)"
+)
+# Two auth cookies with different lastAccessed — the more recent one wins.
+conn.execute(
+    "INSERT INTO moz_cookies VALUES ('opencode.ai', 'auth', 'stale-token', "
+    "9999999999, 1000, 1000)"
+)
+conn.execute(
+    "INSERT INTO moz_cookies VALUES ('opencode.ai', 'auth', 'fresh-token', "
+    "1818027938219, 9000, 2000)"
+)
+conn.execute(
+    "INSERT INTO moz_cookies VALUES ('opencode.ai', 'oc_locale', 'en', "
+    "1818028166359, 8000, 3000)"
+)
+conn.commit()
+conn.close()
+result = module.extract_all_cookies(multi_db)
+assert result == [
+    ("auth", "fresh-token", 9000),
+    ("oc_locale", "en", 8000),
+    ("auth", "stale-token", 1000),
+], "multi-cookie db returns all cookies sorted by lastAccessed"
+
+header = module.build_cookie_header(result)
+assert header == "auth=fresh-token; oc_locale=en", "build_cookie_header de-duplicates by name keeping freshest"
+
+# --- resolve_workspace precedence, never touching the network -------------
 
 # --- resolve_workspace precedence, never touching the network -------------
 os.environ["OPENCODE_WORKSPACE"] = "wrk_eeeeeeeeeeeeeeeeeeeeeeeeee"
@@ -197,6 +239,19 @@ failure_record = json.loads(captured.getvalue())
 assert failure_record["limits"] == cache_payload["limits"], "cached limits survive a refresh failure"
 assert failure_record["retryAdvised"] is True, "transport failure advises an earlier retry"
 assert failure_record["usageStatusText"] == "Couldn't reach opencode.ai", "status card explains the failure"
+
+# --- format change detection: no meters and no auth redirect ----------------
+def fetch_unknown_format(cookie, path):
+    return "<html><body><h1>Go Plan Dashboard</h1><p>Loading...</p></body></html>"
+module.fetch_page = fetch_unknown_format
+
+captured = io.StringIO()
+with contextlib.redirect_stdout(captured):
+    exit_code = module.main()
+assert exit_code == 0, "main returns 0 when the page format changes"
+format_record = json.loads(captured.getvalue())
+assert format_record["usageStatusText"] == "Page format changed", "unrecognised HTML is reported as a format change, not auth failure"
+assert format_record["retryAdvised"] is True, "format change advises retry in case it was transient"
 
 print(json.dumps({
     "plan": plan,

--- a/test/shell.d/agent-usage-opencode-go-test.sh
+++ b/test/shell.d/agent-usage-opencode-go-test.sh
@@ -273,6 +273,121 @@ finally:
         os.environ["HOME"] = old_home
 assert session == "auth=fresh-token", "resolve_session discovers profiles and picks the most recently accessed cookie across them"
 
+# --- chrome-family cookies: v11 decryption, v10 legacy, app-bound skip ----
+import hashlib as _hashlib
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from cryptography.hazmat.primitives import hashes as _hashes
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC as _PBKDF2
+
+
+def _chrome_key(secret):
+    if isinstance(secret, str):
+        secret = secret.encode("utf-8")
+    return _PBKDF2(algorithm=_hashes.SHA1(), length=16, salt=b"saltysalt",
+                   iterations=1).derive(secret)
+
+
+def _pad7(bs):
+    pad = 16 - len(bs) % 16
+    return bs + bytes([pad]) * pad
+
+
+def _v11_blob(host, value, secret):
+    # The modern store: b"v11" + AES-128-CBC with the fixed all-space IV,
+    # plaintext prefixed with SHA256(host_key) as the wrong-key check.
+    key = _chrome_key(secret)
+    plain = _hashlib.sha256(host.encode()).digest()[:32] + value
+    enc = Cipher(algorithms.AES(key), modes.CBC(b" " * 16)).encryptor()
+    return b"v11" + enc.update(_pad7(plain)) + enc.finalize()
+
+
+def _v10_blob(host, value):
+    # The legacy store: b"v10" + random IV + ciphertext, keyed by the
+    # keyringless "peanuts" fallback passphrase.
+    key = _chrome_key(b"peanuts")
+    iv = bytes(range(16))
+    plain = _hashlib.sha256(host.encode()).digest()[:32] + value
+    enc = Cipher(algorithms.AES(key), modes.CBC(iv)).encryptor()
+    return b"v10" + iv + enc.update(_pad7(plain)) + enc.finalize()
+
+
+chrome_home = os.path.join(fixture_dir, "chrome-home")
+chrome_profile = os.path.join(chrome_home, ".config", "chromium", "Default")
+os.makedirs(chrome_profile, exist_ok=True)
+now_us = int(dt.datetime.now(dt.timezone.utc).timestamp() * 1e6)
+filetime = now_us + module.FILETIME_EPOCH_UNIX_US
+chrome_db = os.path.join(chrome_profile, "Cookies")
+conn = sqlite3.connect(chrome_db)
+conn.execute(
+    "CREATE TABLE cookies (host_key TEXT, name TEXT, value TEXT, "
+    "encrypted_value BLOB, last_access_utc INTEGER)"
+)
+conn.executemany(
+    "INSERT INTO cookies VALUES (?,?,?,?,?)",
+    [
+        (".opencode.ai", "auth", "", _v11_blob(".opencode.ai", b"jwt-token", "S3cRet!"), filetime),
+        ("opencode.ai", "oc_locale", "en", b"", filetime),
+        # Subdomain-scoped: must never be sent to the main site.
+        ("login.opencode.ai", "sid", "", _v11_blob("login.opencode.ai", b"sub-token", "S3cRet!"), filetime),
+        # App-bound (v20+) and unknown schemes: skipped, never fatal.
+        ("opencode.ai", "appbound", "", b"v20 app-bound-blob", filetime),
+        # A legacy v10 row must decrypt through the peanuts fallback.
+        (".opencode.ai", "legacy", "", _v10_blob(".opencode.ai", b"old-token"), filetime),
+    ],
+)
+conn.commit()
+conn.close()
+
+real_chrome_secret = module.chrome_secret
+module.chrome_secret = lambda app: "S3cRet!"
+try:
+    chrome_cookies = module.extract_chrome_cookies(chrome_db, "chromium")
+finally:
+    module.chrome_secret = real_chrome_secret
+chrome_by_name = {name: (value, accessed) for name, value, accessed in chrome_cookies}
+assert chrome_by_name["auth"][0] == "jwt-token", "v11 rows decrypt to their value"
+assert chrome_by_name["oc_locale"][0] == "en", "plaintext value column rides through"
+assert chrome_by_name["legacy"][0] == "old-token", "legacy v10 rows decrypt via the peanuts fallback"
+assert "sid" not in chrome_by_name, "subdomain-scoped cookies are excluded"
+assert "appbound" not in chrome_by_name, "app-bound and unknown schemes are skipped"
+assert chrome_by_name["auth"][1] == now_us, "FILETIME last_access_utc normalizes to Unix microseconds"
+
+# resolve_session integration across browsers: discovery through HOME, merge,
+# and the freshest value per name wins across stores.
+firefox_dir = os.path.join(chrome_home, ".mozilla", "firefox", "profile1")
+os.makedirs(firefox_dir, exist_ok=True)
+conn = sqlite3.connect(os.path.join(firefox_dir, "cookies.sqlite"))
+conn.execute(
+    "CREATE TABLE moz_cookies (host TEXT, name TEXT, value TEXT, expiry INTEGER, "
+    "lastAccessed INTEGER, creationTime INTEGER)"
+)
+# Firefox's auth was used 10 minutes after chrome's; the freshest must win.
+conn.execute("INSERT INTO moz_cookies VALUES ('.opencode.ai', 'auth', 'ff-fresher-token', 9999999999, ?, 1000)",
+             (now_us + 600_000_000,))
+conn.execute("INSERT INTO moz_cookies VALUES ('.opencode.ai', 'oc_locale', 'en-GB', 9999999999, ?, 1000)",
+             (now_us + 600_000_000,))
+conn.commit()
+conn.close()
+
+old_home = os.environ.get("HOME")
+os.environ["HOME"] = chrome_home
+try:
+    assert [(str(db.name), app) for db, app in module.find_chrome_cookie_dbs()] == [("Cookies", "chromium")], \
+        "chrome-family profiles are discovered through HOME"
+    real_secret = module.chrome_secret
+    module.chrome_secret = lambda app: "S3cRet!"
+    try:
+        session = module.resolve_session({})
+    finally:
+        module.chrome_secret = real_secret
+finally:
+    if old_home is None:
+        del os.environ["HOME"]
+    else:
+        os.environ["HOME"] = old_home
+assert session == "auth=ff-fresher-token; oc_locale=en-GB; legacy=old-token", \
+    "resolve_session merges browsers and picks the most recently accessed cookie per name"
+
 # --- resolve_workspace precedence, never touching the network -------------
 os.environ["OPENCODE_WORKSPACE"] = "wrk_eeeeeeeeeeeeeeeeeeeeeeeeee"
 assert module.resolve_workspace({"workspaceId": "wrk_cccccccccccccccccccccccccc"}, "") == (

--- a/test/shell.d/agent-usage-opencode-go-test.sh
+++ b/test/shell.d/agent-usage-opencode-go-test.sh
@@ -119,6 +119,55 @@ stats = module.build_stats(records)
 full_record = module.build_record(meters, plan, records)
 limits_only = module.build_record(meters, plan, [])
 
+# --- rate-limited meters and the Zen-balance fallback ------------------
+#
+# A meter the console flipped to 'rate-limited' is the binding constraint:
+# requests for that window block (or bill the Zen balance when 'Use balance'
+# is on). The collector must report it with its percentage and reset time,
+# and the record must say which of the two behaviours applies.
+
+rl_go_page = (
+    '<html><body><script>'
+    'rollingUsage:$R[1]={status:"ok",resetInSec:8073,usagePercent:1.0,usage:12000000,limit:1200000000},'
+    'weeklyUsage:$R[2]={status:"ok",resetInSec:101069,usagePercent:60,usage:1800000000,limit:3000000000},'
+    'monthlyUsage:$R[3]={status:"rate-limited",resetInSec:133420,usagePercent:100.1,usage:6007226480,limit:6000000000},'
+    'balance:996544169,reload:null,'
+    'liteSubscriptionID:"sub_test",'
+    'lite:$R[33]={useBalance:!0}'
+    '</script></body></html>'
+)
+
+rl_meters, _ = module.parse_meters(rl_go_page)
+rl_limits = module.build_limits(rl_meters)
+assert len(rl_limits) == 3, "build_limits keeps a rate-limited meter"
+rl_monthly = [entry for entry in rl_limits if entry["label"] == "Monthly"][0]
+assert rl_monthly["percent"] == 1.0, "percent clamps at full"
+assert rl_monthly["status"] == "rate-limited", "rate-limited meter carries its status"
+assert "status" not in rl_limits[0], "healthy meters carry no status field"
+
+assert module.parse_go_config(rl_go_page) == {"useBalance": True, "balance": 996544169}, \
+    "go config reads useBalance and the Zen balance before lite:"
+assert module.parse_go_config('<script>lite:$R[7]={useBalance:!1}</script>') == {"useBalance": False, "balance": None}, \
+    "useBalance off parses as false with no balance"
+assert module.parse_go_config('<script>no config here</script>') == {"useBalance": False, "balance": None}, \
+    "missing lite block parses as defaults"
+
+note_hero, note_help = module.rate_limited_note(rl_limits, {"useBalance": True, "balance": 996544169})
+assert note_hero == "Monthly limit reached", "hero names the exhausted window"
+assert "$9.97" in note_help and "Zen balance" in note_help, "help bills the Zen balance with the amount left"
+_, note_help = module.rate_limited_note(rl_limits, {"useBalance": False, "balance": None})
+assert "Zen balance" not in note_help and "blocked" in note_help, "without Use balance, requests block"
+_, note_help = module.rate_limited_note(rl_limits, {"useBalance": True, "balance": None})
+assert "empty" in note_help, "Use balance with no credits still blocks"
+assert module.rate_limited_note(limits, {}) == ("", ""), "healthy meters carry no rate-limit note"
+
+rl_record = module.build_record(rl_meters, "Go", [], {"useBalance": True, "balance": 996544169})
+assert rl_record["ready"] is True, "a rate-limited meter is still a ready record"
+assert rl_record["usageStatusText"] == "Monthly limit reached", "record hero announces the limit"
+assert "Zen balance" in rl_record["authHelpText"], "record help explains the fallback"
+rl_blocked = module.build_record(rl_meters, "Go", [])
+assert rl_blocked["authHelpText"] == "Requests blocked until the window resets", "default is a hard block"
+
 # --- extract_all_cookies fixture -------------------------------------------
 fixture_dir = tempfile.mkdtemp()
 cookie_db = os.path.join(fixture_dir, "cookies.sqlite")
@@ -385,6 +434,8 @@ print(json.dumps({
     "stats": stats,
     "record": full_record,
     "limitsOnly": limits_only,
+    "rlRecord": rl_record,
+    "rlMonthly": rl_monthly,
 }))
 PY
 )
@@ -446,3 +497,11 @@ pass "OpenCode Go collector keeps limits and zero-shaped stats when usage record
 [[ $(jq -r '.record.scope' <<<"$result") == "account" ]] ||
   fail "OpenCode Go collector marks account-scoped records" "$result"
 pass "OpenCode Go collector marks account-scoped records"
+
+[[ $(jq -r '.rlMonthly.status + ":" + (.rlMonthly.percent | tostring)' <<<"$result") == "rate-limited:1.0" ]] ||
+  fail "OpenCode Go collector reports a rate-limited meter at full percentage" "$result"
+pass "OpenCode Go collector reports a rate-limited meter at full percentage"
+
+[[ $(jq -c '.rlRecord | {ready, usageStatusText, authHelpText}' <<<"$result") == '{"ready":true,"usageStatusText":"Monthly limit reached","authHelpText":"Billing the Zen balance ($9.97 left) until the window resets"}' ]] ||
+  fail "OpenCode Go collector announces a rate-limited window and the Zen-balance fallback" "$result"
+pass "OpenCode Go collector announces a rate-limited window and the Zen-balance fallback"

--- a/test/shell.d/agent-usage-opencode-go-test.sh
+++ b/test/shell.d/agent-usage-opencode-go-test.sh
@@ -21,6 +21,20 @@ pass "OpenCode Go collector prints a valid record without a cookie"
   fail "OpenCode Go collector explains the missing cookie" "$no_cookie"
 pass "OpenCode Go collector explains the missing cookie"
 
+# The update runner passes --force and --limits-only to every collector; both
+# must still print a valid record.
+force_out=$(HOME="$TEST_HOME" XDG_CONFIG_HOME="$TEST_HOME/.config" XDG_STATE_HOME="$TEST_HOME/.local/state" \
+  XDG_DATA_HOME="$TEST_HOME/.local/share" "$ROOT/bin/omarchy-agent-usage-opencode-go" --force)
+[[ $(jq -r '.id' <<<"$force_out") == "opencode-go" ]] ||
+  fail "OpenCode Go collector accepts --force" "$force_out"
+pass "OpenCode Go collector accepts --force"
+
+limits_out=$(HOME="$TEST_HOME" XDG_CONFIG_HOME="$TEST_HOME/.config" XDG_STATE_HOME="$TEST_HOME/.local/state" \
+  XDG_DATA_HOME="$TEST_HOME/.local/share" "$ROOT/bin/omarchy-agent-usage-opencode-go" --limits-only)
+[[ $(jq -r '.id' <<<"$limits_out") == "opencode-go" ]] ||
+  fail "OpenCode Go collector accepts --limits-only" "$limits_out"
+pass "OpenCode Go collector accepts --limits-only"
+
 result=$(python3 - "$ROOT/bin/omarchy-agent-usage-opencode-go" <<'PY'
 import importlib.machinery
 import importlib.util
@@ -48,8 +62,8 @@ go_page = (
 def rec(rid, date, model, inp, out, reasoning, cread, w5m, w1h):
     return (
         '{id:"%s",workspaceID:"wrk_XXXXXXXXXXXXXXXXXXXXXXXXXX",'
-        'timeCreated:$R[10]=new Date("%sT10:00:00.000Z"),'
-        'timeUpdated:$R[11]=new Date("%sT10:00:01.000Z"),timeDeleted:null,'
+        'timeCreated:$R[10]=new Date("%sT12:00:00.000Z"),'
+        'timeUpdated:$R[11]=new Date("%sT12:00:01.000Z"),timeDeleted:null,'
         'model:"%s",provider:"inf-go.oa-compat",'
         'inputTokens:%d,outputTokens:%d,reasoningTokens:%d,cacheReadTokens:%d,'
         'cacheWrite5mTokens:%s,cacheWrite1hTokens:%s,cost:12345,'

--- a/test/shell.d/agent-usage-opencode-go-test.sh
+++ b/test/shell.d/agent-usage-opencode-go-test.sh
@@ -502,6 +502,15 @@ assert len(cached_limits) == 3 and cached_limits[0]["title"] == "Rolling", \
     "the limits cache carries the fresh meters with their window titles"
 
 # --- main() with --limits-only: fresh meters, no usage walk ----------------
+# The panel opens every time with a limits-only refresh: the walk must be
+# skipped, and the chart must keep the stats the last full run recorded
+# instead of blanking out. A hermetic state dir keeps prior-record reads away
+# from the real user's state.
+state_root = os.path.join(fixture_dir, "state")
+state_usage_dir = os.path.join(state_root, "omarchy", "agents", "usage")
+os.makedirs(state_usage_dir, exist_ok=True)
+os.environ["XDG_STATE_HOME"] = state_root
+
 module.fetch_page = lambda cookie, path: go_page
 module.fetch_usage_chunk = fake_chunk
 fetched_pages.clear()
@@ -513,8 +522,30 @@ assert exit_code == 0, "main returns 0 for a limits-only run"
 limits_only_run = json.loads(captured.getvalue())
 assert fetched_pages == [], "--limits-only skips the usage walk"
 assert limits_only_run["ready"] is True, "a limits-only run stays ready"
-assert limits_only_run["todayTotalTokens"] == 0, "a limits-only run yields zero-shaped stats"
+assert limits_only_run["todayTotalTokens"] == 0, "a limits-only run with no prior record yields zero-shaped stats"
 assert len(limits_only_run["limits"]) == 3, "a limits-only run keeps the fresh meters"
+
+with open(os.path.join(state_usage_dir, "opencode-go.json"), "w", encoding="utf-8") as handle:
+    json.dump({
+        "schemaVersion": 1, "id": "opencode-go", "ready": True,
+        "todayPrompts": 126, "todaySessions": 0, "todayTotalTokens": 3120000,
+        "todayTokensByModel": {"deepseek-v4-flash": 3120000},
+        "recentDays": [{"date": today.isoformat(), "messageCount": 3120000}],
+        "modelUsage": {"deepseek-v4-flash": {"inputTokens": 100, "outputTokens": 50}},
+        "totalPrompts": 400, "totalSessions": 0, "activeDays": 3,
+        "activeDates": [today.isoformat()],
+    }, handle)
+fetched_pages.clear()
+captured = io.StringIO()
+with contextlib.redirect_stdout(captured):
+    exit_code = module.main()
+assert exit_code == 0, "main returns 0 for a limits-only run with prior stats"
+reused = json.loads(captured.getvalue())
+assert fetched_pages == [], "the walk stays skipped even with a prior record"
+assert reused["todayPrompts"] == 126, "limits-only keeps the prior record's today stats"
+assert reused["recentDays"][-1]["messageCount"] == 3120000, "limits-only keeps the prior chart"
+assert reused["modelUsage"]["deepseek-v4-flash"]["inputTokens"] == 100, "limits-only keeps the prior model rows"
+assert len(reused["limits"]) == 3, "limits-only still refreshes the meters"
 
 print(json.dumps({
     "plan": plan,

--- a/test/shell.d/agents-panel-test.sh
+++ b/test/shell.d/agents-panel-test.sh
@@ -20,7 +20,7 @@ assert(!/if \(buttonCode === Qt\.RightButton\) root\.refreshNow\(\)/.test(panelS
 // it stopped writing. Two refresh intervals leave room for a single missed
 // run without crying wolf.
 assert(/2 \* usage\.refreshIntervalSec \* 1000/.test(panelSource), 'agents panel flags records older than two refresh intervals')
-assert(/function formatAge\(/.test(panelSource), 'agents panel formats the stale-record age')
+assert(/function formatDuration\(ms, compact\)/.test(panelSource), 'agents panel formats the stale-record age')
 assert(/detail: root\.staleText/.test(panelSource), 'agents panel shows the stale marker in the hero detail pill')
 assert(/detailAlarming: root\.stale/.test(panelSource), 'agents panel paints the stale marker as an alarm')
 assert(/updatedAtMs: Number\(new Date\(String\(record\.updatedAt/.test(mainSource), 'agents panel carries the record timestamp for staleness')

--- a/test/shell.d/agents-panel-test.sh
+++ b/test/shell.d/agents-panel-test.sh
@@ -7,6 +7,7 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 run_node_test <<'JS'
 const fs = require('fs')
 const panelSource = fs.readFileSync(root + '/shell/plugins/agents/Panel.qml', 'utf8')
+const mainSource = fs.readFileSync(root + '/shell/plugins/agents/Main.qml', 'utf8')
 
 assert(/function launchAgent\(\)/.test(panelSource), 'agents panel launches the default agent')
 assert(/root\.bar\.run\("omarchy-agent --pick"\)/.test(panelSource), 'agents panel uses the desktop agent launcher')
@@ -14,4 +15,13 @@ assert(/if \(buttonCode === Qt\.RightButton\) root\.launchAgent\(\)/.test(panelS
 assert(/else if \(buttonCode === Qt\.MiddleButton\) root\.selectProvider\(root\.providerIndex \+ 1\)/.test(panelSource), 'agents middle click still advances the subscription')
 assert(/else root\.toggle\(\)/.test(panelSource), 'agents left click still toggles the panel')
 assert(!/if \(buttonCode === Qt\.RightButton\) root\.refreshNow\(\)/.test(panelSource), 'agents right click no longer refreshes')
+
+// A record that outlives the refresh cadence is stale: the collector behind
+// it stopped writing. Two refresh intervals leave room for a single missed
+// run without crying wolf.
+assert(/2 \* usage\.refreshIntervalSec \* 1000/.test(panelSource), 'agents panel flags records older than two refresh intervals')
+assert(/function formatAge\(/.test(panelSource), 'agents panel formats the stale-record age')
+assert(/detail: root\.staleText/.test(panelSource), 'agents panel shows the stale marker in the hero detail pill')
+assert(/detailAlarming: root\.stale/.test(panelSource), 'agents panel paints the stale marker as an alarm')
+assert(/updatedAtMs: Number\(new Date\(String\(record\.updatedAt/.test(mainSource), 'agents panel carries the record timestamp for staleness')
 JS


### PR DESCRIPTION
## Summary

Adds the OpenCode Go provider to the agents panel: a new collector (`omarchy-agent-usage-opencode-go`) plus the small panel-side plumbing it needs (stale-data marker, assets, manifest entry, docs).

OpenCode Go exposes no usage API, so the collector reads the opencode.ai workspace console, using the `auth` session cookie any browser on the machine stores for opencode.ai:

- **Limits** — the rolling 5-hour / weekly / monthly percent meters with reset times from `/workspace/<id>/go`. Meters the console has flipped to `rate-limited` are reported at full percentage with their reset countdown (each window travels with an explicit `Rolling`/`Weekly`/`Monthly` title), and the status card explains the consequence: requests block until spend ages out, or — with the workspace's "Use balance" option on and Zen credits remaining — the overage bills the balance, with the amount left.
- **Usage stats** — per-request token records from the workspace usage list, paged newest-first through the SPA's server function so the trailing 7 local days survive later refreshes (with a page cap and a wall-clock deadline). "Tokens by day" and "tokens by model" both describe that week. Session counts are not exposed, so the panel hides the prompt/session line.
- **Session cookies from every browser** — Firefox and Zen keep cookies in plaintext sqlite. Chrome-family profiles (Chrome, Chromium, Brave, Edge, Vivaldi, Opera — Flatpak and snap layouts included) encrypt their values, so the collector deciphers them with the browser's own SafeStorage password from the Secret Service: PBKDF2-derived AES-128-CBC for the modern `v11` fixed-IV layout and the legacy `v10` layout, with the keyringless "peanuts" fallback. App-bound (`v20+`) rows, locked keyrings, and machines without `cryptography`/`secret-tool` are skipped, never fatal; when several browsers hold a session, the one used most recently wins.
- **Failure behavior** — last known meters are cached and kept visible with a status card when the sign-in is stale or the console is unreachable; transport failures advise an earlier retry. Opening the panel runs a limits-only refresh: meters fresh, usage walk skipped, and the previous record's stats stay on the chart.
- **Panel** — a stale-data marker (record age past two refresh intervals → hero detail pill) so a collector that stops running is visible.

## Notes for reviewers

- The two SolidStart server-function IDs (`WORKSPACES_SERVER_FN_ID`, `USAGE_SERVER_FN_ID`) and the seroval argument encoding are pinned to the current opencode.ai SPA; a console redesign needs those constants refreshed, as documented in the collector.
- The console's meters are workspace-level; the per-model dollar allowances behind them are not exposed on the page, so limits report what the page shows.
- Stats are `scope: "account"`, so cross-device sync aggregation takes the widest value rather than summing the same account twice.
- A workspace id is required when the session has more than one (`workspaceId` in `~/.config/omarchy/agents/opencode-go.json` or `OPENCODE_WORKSPACE`).
- The branch went through three review rounds; every finding is addressed — limits-only freshness keeps the panel chart alive (the one regression the second round caught), explicit window titles, pagination deadline, bounded balance parsing, cookie freshness across profiles, interrupt-safe cache writes, and the Chrome-family cookie support added after the first round.

## Tests

- Collector suite: 22 checks — meters and window titles, paging including interior short pages, the page cap, mid-walk and unparsable-page failures, rate-limited meters, the Zen-balance fallback, limits-only freshness, cache fallback, cookie extraction and profile discovery, and Chrome-family coverage (v11/v10 decryption, plaintext rows, subdomain scoping, app-bound skipping, FILETIME timestamp normalization, cross-browser freshest-wins merge).
- `agents-panel-test.sh` (11) and `agent-usage-update-test.sh` (7) extended and passing; `./test/cli` green.
- Live-validated against a genuinely rate-limited account and against the machine's own Chromium cookie store (the auth token deciphers to its Django-signed value).