### PR TITLE
Match the en dash Google Meet uses in its PiP window title

### DIFF
--- a/default/hypr/apps/pip.lua
+++ b/default/hypr/apps/pip.lua
@@ -11,8 +11,11 @@ o.window({ tag = "pip" }, {
   move = { "(monitor_w-window_w-40)", "(monitor_h*0.04)" },
 })
 
--- Google Meet PiP uses the meeting title instead of "Picture-in-Picture".
-o.window({ tag = "chromium-based-browser", title = "^Meet - .+" }, {
+-- Google Meet PiP uses the meeting title instead of "Picture-in-Picture", and
+-- separates it with an en dash. The browser's own window uses an ASCII hyphen
+-- ("Meet - <meeting> - Google Chrome"), so matching the dash is what keeps this
+-- rule off the main window.
+o.window({ tag = "chromium-based-browser", title = "^Meet [–—] .+" }, {
   tag = "-default-opacity",
   float = true,
   pin = true,


### PR DESCRIPTION
The Google Meet PiP rule in `default/hypr/apps/pip.lua` matches the wrong window. It is written for the Picture-in-Picture overlay, but as written it never matches the overlay and always matches the main browser window.

```lua
o.window({ tag = "chromium-based-browser", title = "^Meet - .+" }, {
  float = true, pin = true, size = { 600, 338 }, border_size = 0, ...
})
```

The separator is the discriminator, and the pattern picks the wrong one:

| Window | Title | Dash |
| --- | --- | --- |
| Meet PiP overlay | `Meet – Standup` | en dash, U+2013 |
| Main browser window | `Meet - abc-defg-hij - Google Chrome` | ASCII hyphen, U+002D |

So `^Meet - .+` misses the overlay and catches the browser window, producing the two open reports:

- #10152 — the PiP overlay never floats or pins. It keeps `tile = true` from `browser.lua`, joins the focused group, and opens at full group size.
- #9823 — the main browser window loses its border whenever a Meet tab is in front, because `border_size = 0` applies to it instead.

`float`, `pin`, `size` and `move` are only evaluated when a window opens, so an already-open browser window is not floated or resized — but `border_size` and `opacity` are re-evaluated on every title change. That is why the main window silently drops its border the moment a Meet tab comes to the front and gets it back when you switch away, which made #9823 look like it was specific to session restore.

### The change

Match the dash Meet actually uses. This fixes both reports at once: the overlay matches for the first time, and the browser window stops matching.

I did not keep the ASCII hyphen as an alternative. The fix suggested in #10152, `^Meet (-|–|—) .+`, would fix the overlay but leave #9823 in place, since the hyphen branch still matches the main window.

### Verification

Hyprland 0.56.2, Omarchy 4.0.3-1, Google Chrome 152.

I confirmed the regex semantics directly, using two windows with controlled titles so the match could be observed in isolation:

```
title 'Meet – Test'                    ->  at [5115, 36]  size [2540, 1394]   (matched: border stripped)
title 'Meet - Test - Google Chrome'    ->  at [7667, 38]  size [2541, 1390]   (not matched: bordered)
```

The 2px expansion and up-left shift into the border gutter is the `border_size = 0` signature. So the en dash matches through Hyprland's regex engine, and the ASCII-hyphen browser title does not.

I also reproduced #9823 on a real Chrome window — no session restore involved, just a Meet tab in the foreground:

```
Meet tab in front:    at [1290, 36]  size [2540, 1394]    # no border
any other tab:        at [1292, 38]  size [2536, 1390]    # bordered
```

Chrome window titles use an ASCII hyphen for the browser suffix generally (`GitHub - Google Chrome`, `Inbox - … - Gmail - Google Chrome`), so the suffix never introduces an en dash. The en-dash overlay title is from #10152, which includes the byte-level dump (`b'Meet \xe2\x80\x93 Team standup'`); I could not spawn a real Meet PiP window to re-confirm that independently.

`./test/all` shows no new failures — `config`, `locate`, `snapper` and `unowned-system-paths` fail the same way on a clean `quattro` checkout here.

### Note on `dev`

The Meet rule exists on `quattro` but is absent from `dev`'s `pip.lua`, so `dev` has no Meet PiP rule at all. This PR targets `quattro`; if the rule is meant to come back on `dev`, it should come back in this form.

#10152 also suggests adding `group = "deny"` to stop the overlay being grouped manually. I left that out to keep the change to one thing.
