### PR TITLE
Show time taken to boot on every boot

### DIFF
--- a/bin/omarchy-system-boot-time
+++ b/bin/omarchy-system-boot-time
@@ -1,0 +1,209 @@
+#!/bin/bash
+
+# omarchy:summary=Show how long this boot took, from power-on to desktop
+# omarchy:group=system
+# omarchy:args=[--record|--notify]
+# omarchy:examples=omarchy system boot time
+
+set -euo pipefail
+
+state_file="$HOME/.local/state/omarchy/boot-time"
+boot_id=$(</proc/sys/kernel/random/boot_id)
+glyph=󰔛
+
+usage() {
+  cat <<USAGE
+Usage: omarchy-system-boot-time [--record|--notify]
+
+Prints how long this boot took, from power-on to the desktop starting.
+
+  --record  Stamp the moment the desktop started. Only the first start after a
+            boot is kept, so a logout and login does not overwrite the figure.
+  --notify  Stamp if not yet stamped, then send the boot-time notification once
+            the notification server is up. Shows once per boot; run from
+            Hyprland autostart.
+USAGE
+}
+
+# systemd's monotonic timestamps are microseconds since kernel entry, the same
+# clock /proc/uptime reports in seconds. Firmware and loader are only known on
+# EFI boots where the loader hands them over; elsewhere they read 0 and the
+# figure can only be counted from kernel start.
+systemd_us() {
+  local value
+
+  value=$(systemctl show -p "$1" --value 2>/dev/null) || value=0
+  [[ $value =~ ^[0-9]+$ ]] || value=0
+  echo "$value"
+}
+
+uptime_seconds() {
+  local uptime _idle
+
+  read -r uptime _idle </proc/uptime
+  echo "$uptime"
+}
+
+# The state file is one key=value per line. Read it into the variables below
+# rather than sourcing it, so a stray line in the user's state directory is
+# ignored instead of executed.
+state_boot_id=""
+firmware_us=0
+loader_us=0
+userspace_us=0
+finish_us=0
+desktop_uptime=""
+notified=0
+
+load_state() {
+  local key value
+
+  [[ -f $state_file ]] || return 1
+
+  while IFS='=' read -r key value; do
+    case $key in
+      boot_id) state_boot_id=$value ;;
+      firmware_us | loader_us | userspace_us | finish_us)
+        [[ $value =~ ^[0-9]+$ ]] && printf -v "$key" '%s' "$value"
+        ;;
+      desktop_uptime)
+        [[ $value =~ ^[0-9]+(\.[0-9]+)?$ ]] && desktop_uptime=$value
+        ;;
+      notified)
+        [[ $value == "1" ]] && notified=1
+        ;;
+    esac
+  done <"$state_file"
+
+  [[ $state_boot_id == "$boot_id" && -n $desktop_uptime ]]
+}
+
+write_state() {
+  mkdir -p "$(dirname "$state_file")"
+  cat >"$state_file" <<STATE
+boot_id=$boot_id
+firmware_us=$firmware_us
+loader_us=$loader_us
+userspace_us=$userspace_us
+finish_us=$finish_us
+desktop_uptime=$desktop_uptime
+notified=$notified
+STATE
+}
+
+record() {
+  # hyprland.start fires on every compositor start, not only the first after a
+  # boot. Keep the first stamp of this boot; a later login is not a boot.
+  if load_state; then
+    return 0
+  fi
+
+  firmware_us=$(systemd_us FirmwareTimestampMonotonic)
+  loader_us=$(systemd_us LoaderTimestampMonotonic)
+  userspace_us=$(systemd_us UserspaceTimestampMonotonic)
+  finish_us=$(systemd_us FinishTimestampMonotonic)
+  desktop_uptime=$(uptime_seconds)
+  notified=0
+  write_state
+}
+
+# Two lines: the headline, then the per-phase breakdown. The total is what the
+# user asked for; the breakdown is what makes a slow number actionable. When
+# the desktop moment was never recorded this boot, the figure stops where
+# systemd finished starting and says so.
+report() {
+  local recorded=$1
+
+  awk -v firmware_us="$firmware_us" -v loader_us="$loader_us" \
+    -v userspace_us="$userspace_us" -v finish_us="$finish_us" \
+    -v desktop_uptime="$desktop_uptime" -v recorded="$recorded" '
+    BEGIN {
+      prekernel = firmware_us / 1e6
+      loader = loader_us / 1e6
+      firmware = prekernel - loader
+      kernel = userspace_us / 1e6
+      finish = finish_us / 1e6
+      if (recorded) {
+        end = desktop_uptime + 0
+      } else {
+        end = finish
+      }
+
+      total = prekernel + end
+      headline = sprintf("Time taken to boot: %ds", int(total + 0.5))
+      if (prekernel == 0) {
+        headline = headline " (since kernel start)"
+      }
+      if (!recorded) {
+        headline = headline " (to system startup; desktop not recorded)"
+      }
+      print headline
+
+      parts = ""
+      if (prekernel > 0) {
+        parts = sprintf("firmware %.1fs · loader %.1fs", firmware, loader)
+      }
+      if (finish > kernel && finish <= end) {
+        parts = parts (parts ? " · " : "") sprintf("kernel %.1fs · system %.1fs", kernel, finish - kernel)
+        if (recorded) {
+          parts = parts sprintf(" · desktop %.1fs", end - finish)
+        }
+      } else {
+        parts = parts (parts ? " · " : "") sprintf("kernel %.1fs · system %.1fs", kernel, end - kernel)
+      }
+      print parts
+    }'
+}
+
+notify() {
+  local headline breakdown
+
+  # Stamp here rather than from a separate autostart line: Hyprland dispatches
+  # its exec lines without waiting, so a notify started alongside a record
+  # would look for the stamp before it was written.
+  record
+  (( notified == 0 )) || exit 0
+
+  { read -r headline; read -r breakdown; } < <(report 1)
+
+  # Autostart reaches this before the shell has claimed the notification bus
+  # name; without the wait the toast is sent into the void. The shell is
+  # usually up within a second, but give a slow disk room.
+  omarchy-notification-wait 30 || true
+
+  omarchy-notification-send -u low -g "$glyph" "$headline" "$breakdown"
+  notified=1
+  write_state
+}
+
+show() {
+  if load_state; then
+    report 1
+  else
+    firmware_us=$(systemd_us FirmwareTimestampMonotonic)
+    loader_us=$(systemd_us LoaderTimestampMonotonic)
+    userspace_us=$(systemd_us UserspaceTimestampMonotonic)
+    finish_us=$(systemd_us FinishTimestampMonotonic)
+    desktop_uptime=$(uptime_seconds)
+    report 0
+  fi
+}
+
+case "${1:-}" in
+  "")
+    show
+    ;;
+  --record)
+    record
+    ;;
+  --notify)
+    notify
+    ;;
+  -h | --help)
+    usage
+    ;;
+  *)
+    usage >&2
+    exit 1
+    ;;
+esac

--- a/default/hypr/autostart.lua
+++ b/default/hypr/autostart.lua
@@ -1,4 +1,8 @@
 hl.on("hyprland.start", function()
+  -- Stamp the moment the desktop started, then announce the time taken to boot
+  -- once the notification server is up. Shows once per boot.
+  hl.exec_cmd("omarchy-system-boot-time --notify")
+
   -- Slow app launch fix -- set systemd vars before starting session services.
   hl.exec_cmd("systemctl --user import-environment $(env | cut -d'=' -f 1)")
   hl.exec_cmd("dbus-update-activation-environment --systemd --all")

--- a/manual/10-notices.md
+++ b/manual/10-notices.md
@@ -21,3 +21,9 @@ The location is detected from your IP address, which is usually close enough, bu
 `Super + Ctrl + Alt + B`
 
  ![notice-battery](images/notice-battery.webp)
+
+### Boot time
+
+Every boot, once the desktop is up, Omarchy shows a notice with the time taken from power-on to the desktop starting, broken down by phase: firmware, boot loader, kernel, system startup, and desktop. It appears once per boot, so logging out and back in does not repeat it. Run `omarchy system boot time` in a terminal to see the figure again later.
+
+If your disk is encrypted and you type the passphrase during boot, the time you spend typing it is counted in the kernel phase; there is no way to measure boot without it. On machines whose firmware does not report its own timing, the figure is counted from kernel start and the notice says so.

--- a/plans/boot-time.md
+++ b/plans/boot-time.md
@@ -1,0 +1,132 @@
+# Plan: Boot time — show "Time taken to boot" on every boot
+
+Revision 1. Drafted against `origin/quattro` at 8ea51516 (the fingerprint branch in this checkout is 6420 commits behind and is not the base for this work).
+
+## Problem
+
+Omarchy tells the user nothing about how long the machine took to come up. The data is already there — systemd records firmware, loader, kernel and userspace timestamps, and Hyprland knows the moment the desktop starts — but nobody stitches it together or shows it. A user who wants to know whether a kernel update, a new initramfs hook, or a firmware setting made boot slower has to remember to run `systemd-analyze` by hand, and even that stops at `graphical.target`, before SDDM, Hyprland and the shell have started.
+
+The ask: on every boot, once the desktop is up, show a notification reading `Time taken to boot: 43s`.
+
+## What "time taken to boot" means
+
+Power button to usable desktop, as one number in whole seconds. Measured on this machine (`slovakdirect`, Omarchy 4.0.0.r2083, UKI via limine, LUKS root, SDDM autologin):
+
+| Phase | Source | This machine |
+|---|---|---|
+| Firmware + loader (pre-kernel) | `systemctl show -p FirmwareTimestampMonotonic` (µs) | 26.9s |
+| Kernel + initrd + userspace to `graphical.target` | `/proc/uptime` at the moment Hyprland starts | 16.1s |
+| Desktop startup (Hyprland → shell up) | `/proc/uptime` when the notification fires, minus the above | ~2–4s |
+| **Total** | pre-kernel offset + `/proc/uptime` at Hyprland start | **~43s** |
+
+Two facts drive the design:
+
+- `CLOCK_MONOTONIC` (what `/proc/uptime` reports) starts at kernel entry, so everything before the kernel has to come from systemd's firmware/loader timestamps. Those are only populated on EFI boots where the loader passes them along (limine does here). When `FirmwareTimestampMonotonic` is `0` the number is "since kernel start" and the notification says so.
+- `hyprland.start` fires on every Hyprland start, not just the first after boot: logout/login, a compositor crash, or `omarchy dev link` reboots all re-run `autostart.lua`. Without a once-per-boot guard, a re-login at 3pm would announce a "boot time" of nine hours.
+
+Caveat that stays in the docs, not in the code: if the LUKS passphrase is typed in the initrd, the time the user spends typing it is inside the kernel/initrd phase and inside the total. There is no clean way to subtract it, and pretending otherwise would misreport. The breakdown line lets the user see it.
+
+## Rejected approaches
+
+- **Parse `systemd-analyze time` text output.** Human-formatted, locale-sensitive, changes shape when initrd is or is not reported separately, and stops at `graphical.target` — it does not know when the desktop was actually usable. `systemctl show -p …Monotonic --value` gives the same numbers as plain integers.
+- **Post-boot hook sample only** (`config/omarchy/hooks/post-boot.d/boot-time.sample`, like `weather.sample`). Opt-in by design: the user has to rename the file, and existing installs only receive new samples through the config refresh manifest. The request is "every boot", which means on by default. A sample is kept as the fallback if upstream does not want it default-on (see Rollout).
+- **Bar widget** (Quickshell QML under `shell/plugins/bar/widgets/`). Persistent display is nice but it is a second product: manifest, QML, shell tests, visual verification in a VM, and a `shell.json` layout change for existing users. Listed as a follow-on, not the first cut.
+- **fastfetch line** (`/etc/fastfetch/config.jsonc` already has `uptime`). Only appears when a terminal opens, and not on boot.
+- **Measuring at the end of the `sleep 2 && omarchy-hook post-boot` line.** Simplest, but folds the 2s sleep plus whatever the user's own post-boot hooks take into the number. Recording the timestamp at the top of `hyprland.start` and notifying later keeps the measurement honest and the display reliable (the notification daemon is part of `omarchy-launch-shell`, which is not up yet at the top of `hyprland.start`).
+- **systemd user unit / timer instead of Hyprland autostart.** `graphical-session.target` is reached before Hyprland has finished starting the shell, and the repo's convention is that desktop-start work lives in `default/hypr/autostart.lua`.
+
+## Design
+
+### New command: `bin/omarchy-system-boot-time`
+
+Joins the existing `system` group (`omarchy system stats`, `omarchy system lock`, …), so it is `omarchy system boot time` on the CLI. Bash, `#!/bin/bash`, metadata comments per `agents/skills/command-metadata.md`:
+
+```bash
+# omarchy:summary=Show how long this boot took, from power-on to desktop
+# omarchy:group=system
+# omarchy:args=[--record|--notify|--breakdown]
+```
+
+Modes:
+
+- **`--record`** (hidden from users in practice; called from autostart). Reads `/proc/sys/kernel/random/boot_id`, `/proc/uptime` and `FirmwareTimestampMonotonic`. If `~/.local/state/omarchy/boot-time` already holds this `boot_id`, exits 0 without touching it — this is the once-per-boot guard. Otherwise writes:
+
+  ```
+  boot_id=<uuid>
+  prekernel_us=<FirmwareTimestampMonotonic>
+  desktop_uptime=<first field of /proc/uptime>
+  finish_us=<FinishTimestampMonotonic>
+  notified=0
+  ```
+
+  `~/.local/state/omarchy/` is the directory the repo already uses for per-user runtime state (`first-run.mode`, `migrations/`, `toggles`), and unlike `$XDG_RUNTIME_DIR` it survives a logout, which is exactly the case the guard exists for.
+
+- **`--notify`**. Reads the state file. If `boot_id` does not match the running kernel's or `notified=1`, exits 0 silently. Otherwise sends, via `omarchy-notification-send` (never `notify-send`, per AGENTS.md):
+
+  ```
+  headline:    Time taken to boot: 43s
+  description: firmware 19.0s · loader 7.9s · kernel 11.6s · system 4.4s · desktop 3.1s
+  urgency:     low   glyph: 󱎫 (or whatever the icon-font has for a stopwatch/rocket)
+  ```
+
+  then rewrites the state file with `notified=1`. The headline is the thing the user asked for; the breakdown is what makes the number actionable.
+
+- **no args** (terminal use). Prints the same headline and breakdown to stdout from the state file, so `omarchy system boot time` answers the question later in the day. If no state file exists for this boot (e.g. on a machine where autostart has not run), it computes a "since kernel start" figure from live data and says so.
+
+Arithmetic (all integer microseconds until the final format, `awk` or bash `(( ))`, no `bc`):
+
+```
+total_s    = (prekernel_us / 1e6) + desktop_uptime
+firmware_s = (prekernel_us - loader_us) / 1e6
+loader_s   = loader_us / 1e6
+kernel_s   = userspace_us / 1e6                   # kernel + initrd (+ LUKS prompt)
+system_s   = (finish_us - userspace_us) / 1e6     # userspace until systemd finished
+desktop_s  = desktop_uptime - finish_us / 1e6     # SDDM + Hyprland + shell
+```
+
+When `prekernel_us == 0` the headline becomes `Time taken to boot: 16s (since kernel start)` and the firmware/loader terms are dropped from the breakdown.
+
+### Wiring: `default/hypr/autostart.lua`
+
+```lua
+hl.on("hyprland.start", function()
+  hl.exec_cmd("omarchy-system-boot-time --record")   -- first line: stamp "desktop started"
+  ...existing lines unchanged...
+  -- Run post-boot hooks after startup config has loaded.
+  hl.exec_cmd("sleep 2 && omarchy-hook post-boot")
+  hl.exec_cmd("sleep 2 && omarchy-system-boot-time --notify")
+end)
+```
+
+`--record` is two file reads and one `systemctl show`; it does not delay the shell launch measurably. `--notify` is a separate `exec_cmd` rather than chained onto the hook line so a slow or failing user hook cannot suppress it.
+
+### Docs and metadata
+
+- `manual/10-notices.md` or `manual/14-omarchy-cli.md`: one paragraph on the boot-time notification and `omarchy system boot time`, including the "includes your passphrase typing time" caveat.
+- `GROUP_DESCRIPTIONS[system]` in `bin/omarchy` already reads "System status, reboot, shutdown, logout, and lock" — no change needed.
+- No migration: the command ships in `bin/` (covered by `$OMARCHY_PATH`) and the autostart change is in `default/hypr/`, which every install reads directly. Nothing lands in `~/.config`.
+
+### Tests
+
+- `./test/cli` already validates metadata for every file in `bin/`; the new command must pass it (routing to `omarchy system boot time`, help text present).
+- Add a focused test alongside the CLI suite that runs `omarchy-system-boot-time --notify` with `HOME` pointed at a temp dir and a fabricated state file, and asserts: (a) mismatched `boot_id` → no notification call and exit 0; (b) `notified=1` → no call; (c) fresh file → one call with a headline matching `^Time taken to boot: [0-9]+s`. `omarchy-notification-send` is stubbed via `PATH` (the suite already exports `$ROOT/bin` first, so a temp bin ahead of it works).
+- Manual: `omarchy dev link ~/Work/omarchy` (see Rollout), reboot, confirm the toast, then `omarchy system logout` → log in → confirm **no** second toast, then `omarchy system boot time` in a terminal prints the same figure.
+
+## Rollout
+
+1. In `~/Work`, this checkout (`omarchy-fingerprint`) is on `fix/fingerprint-edge-driver`, 6420 commits behind `origin/quattro`. Don't build on it. Either add a worktree — `git worktree add ../omarchy-boot-time -b feat/boot-time origin/quattro` — or clone fresh into `~/Work/omarchy`. Keep the fingerprint branch untouched.
+2. Implement `bin/omarchy-system-boot-time`, the autostart change, the test, the manual paragraph. Four files, one atomic commit per AGENTS.md ("succinct, one coherent change").
+3. `./test/cli` locally. Then `omarchy dev link <checkout>` and reboot to verify on this machine (the link only affects `$OMARCHY_PATH` trees, and both `bin/` and `default/hypr/` are covered, so no package rebuild is needed). `omarchy dev unlink` when done.
+4. Push `feat/boot-time` to `fork` (`powderluv/omarchy`) and open a PR against `omacom/omarchy:quattro`. If maintainers want it opt-in rather than default-on, the fallback is mechanical: drop the `--notify` line from `autostart.lua`, keep `--record`, and add `config/omarchy/hooks/post-boot.d/boot-time.sample` containing `omarchy-system-boot-time --notify`. The command and the once-per-boot guard stay the same either way.
+
+Follow-ons, only if wanted after the first cut lands:
+
+- A hotkey notice (`Super + Ctrl + Alt + …`) that re-shows the boot-time toast, matching the date/weather/battery notices in `manual/10-notices.md`.
+- A bar widget that shows the figure for the first N minutes after boot, then hides.
+- Keeping a per-boot history in the state file so the toast can say "3s slower than last boot".
+
+## Open questions
+
+- Should the toast auto-dismiss (`-t 8000`) or stay until clicked, like the weather sample (default `-1`)? Draft uses the default so a user who looked away still sees it.
+- Glyph: the repo's icon font is in `default/fonts/omarchy/omarchy.ttf`; pick an existing Nerd Font stopwatch glyph rather than adding one (`agents/skills/icon-font.md` is for branded glyphs only).
+- Whether upstream wants the breakdown in the description at all, or just the headline. Cheap to strip.

--- a/test/shell.d/system-boot-time-test.sh
+++ b/test/shell.d/system-boot-time-test.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+test_home="$test_tmp/home"
+notify_args="$test_tmp/notify-args"
+state_file="$test_home/.local/state/omarchy/boot-time"
+real_boot_id=$(</proc/sys/kernel/random/boot_id)
+mkdir -p "$stub_bin" "$test_home"
+
+# The figures from one real EFI boot: 26.86s before the kernel (of which 7.89s
+# in the loader), userspace at 11.58s, systemd finished at 16.03s.
+cat >"$stub_bin/systemctl" <<'SH'
+#!/bin/bash
+case "$*" in
+  *FirmwareTimestampMonotonic*) echo 26859570 ;;
+  *LoaderTimestampMonotonic*) echo 7888987 ;;
+  *UserspaceTimestampMonotonic*) echo 11583406 ;;
+  *FinishTimestampMonotonic*) echo 16029129 ;;
+  *) echo 0 ;;
+esac
+SH
+
+cat >"$stub_bin/omarchy-notification-wait" <<'SH'
+#!/bin/bash
+exit 0
+SH
+
+cat >"$stub_bin/omarchy-notification-send" <<'SH'
+#!/bin/bash
+printf '%s\n' "$@" >"$OMARCHY_TEST_NOTIFY_ARGS"
+SH
+chmod +x "$stub_bin"/*
+
+run_boot_time() {
+  HOME="$test_home" \
+  PATH="$stub_bin:$ROOT/bin:$PATH" \
+  OMARCHY_TEST_NOTIFY_ARGS="$notify_args" \
+    "$ROOT/bin/omarchy-system-boot-time" "$@"
+}
+
+write_state() {
+  mkdir -p "$(dirname "$state_file")"
+  cat >"$state_file" <<STATE
+boot_id=$1
+firmware_us=26859570
+loader_us=7888987
+userspace_us=11583406
+finish_us=16029129
+desktop_uptime=18.14
+notified=${2:-0}
+STATE
+}
+
+# --record stamps the current boot once.
+rm -f "$state_file"
+run_boot_time --record
+[[ -f $state_file ]] || fail "record writes the state file"
+grep -qx "boot_id=$real_boot_id" "$state_file" || fail "record stores the running kernel's boot id" "$(cat "$state_file")"
+grep -qx "firmware_us=26859570" "$state_file" || fail "record stores systemd's firmware timestamp"
+grep -qE '^desktop_uptime=[0-9]+(\.[0-9]+)?$' "$state_file" || fail "record stores the desktop uptime as seconds" "$(cat "$state_file")"
+pass "record stamps the desktop start for this boot"
+
+sed -i 's/^desktop_uptime=.*/desktop_uptime=18.14/' "$state_file"
+run_boot_time --record
+grep -qx "desktop_uptime=18.14" "$state_file" || fail "a second record in the same boot keeps the first stamp" "$(cat "$state_file")"
+pass "record keeps the first stamp of a boot across later compositor starts"
+
+write_state "00000000-0000-0000-0000-000000000000"
+run_boot_time --record
+grep -qx "boot_id=$real_boot_id" "$state_file" || fail "record replaces a stamp left by a previous boot" "$(cat "$state_file")"
+pass "record replaces the stamp from a previous boot"
+
+# --notify stamps the boot itself when nothing has, so a single autostart line
+# is enough and there is no record it could race against.
+rm -f "$state_file" "$notify_args"
+run_boot_time --notify
+grep -qx "boot_id=$real_boot_id" "$state_file" || fail "notify stamps the current boot when no record exists" "$(cat "$state_file")"
+grep -qx "notified=1" "$state_file" || fail "notify marks its own stamp as announced" "$(cat "$state_file")"
+grep -q "^Time taken to boot: [0-9]*s$" "$notify_args" || fail "notify announces the boot it stamped" "$(cat "$notify_args")"
+pass "notify stamps the boot itself when nothing has yet"
+
+# --notify sends the headline and breakdown once for the recorded boot.
+write_state "$real_boot_id"
+rm -f "$notify_args"
+run_boot_time --notify
+[[ -s $notify_args ]] || fail "notify sends a notification for a recorded boot"
+grep -qx "Time taken to boot: 45s" "$notify_args" || fail "notify headline is the rounded power-on to desktop total" "$(cat "$notify_args")"
+grep -qx "firmware 19.0s · loader 7.9s · kernel 11.6s · system 4.4s · desktop 2.1s" "$notify_args" || fail "notify body breaks the total down by phase" "$(cat "$notify_args")"
+grep -qx "notified=1" "$state_file" || fail "notify marks the boot as announced" "$(cat "$state_file")"
+pass "notify announces the boot time with a per-phase breakdown"
+
+rm -f "$notify_args"
+run_boot_time --notify
+[[ ! -e $notify_args ]] || fail "a second notify in the same boot stays silent" "$(cat "$notify_args")"
+pass "notify shows once per boot"
+
+write_state "00000000-0000-0000-0000-000000000000" 1
+rm -f "$notify_args"
+run_boot_time --notify
+grep -qx "boot_id=$real_boot_id" "$state_file" || fail "notify replaces a stamp from a previous boot" "$(cat "$state_file")"
+[[ -s $notify_args ]] || fail "notify announces a new boot over a stale stamp"
+pass "notify treats a stamp left by a previous boot as a new boot"
+
+# No arguments prints the same report to the terminal.
+write_state "$real_boot_id" 1
+output=$(run_boot_time)
+[[ $output == "Time taken to boot: 45s"$'\n'* ]] || fail "plain invocation prints the headline" "$output"
+pass "plain invocation prints the recorded boot time"
+
+# Without firmware timestamps (BIOS boot, or a loader that passes none) the
+# total can only be counted from kernel start, and the headline says so.
+sed -i 's/^firmware_us=.*/firmware_us=0/; s/^loader_us=.*/loader_us=0/' "$state_file"
+output=$(run_boot_time)
+[[ $output == "Time taken to boot: 18s (since kernel start)"$'\n'"kernel 11.6s · system 4.4s · desktop 2.1s" ]] || fail "missing firmware timestamps are reported as counted from kernel start" "$output"
+pass "reports from kernel start when firmware timestamps are unavailable"
+
+# With no stamp for this boot the report stops where systemd finished starting.
+rm -f "$state_file"
+output=$(run_boot_time)
+[[ $output == "Time taken to boot: 43s (to system startup; desktop not recorded)"$'\n'"firmware 19.0s · loader 7.9s · kernel 11.6s · system 4.4s" ]] || fail "an unrecorded boot reports up to systemd finish" "$output"
+pass "reports to system startup when the desktop start was not recorded"


### PR DESCRIPTION
## Summary

Every boot, once the desktop is up, Omarchy shows a low-urgency toast with the time taken from power-on to the desktop starting, plus a per-phase breakdown:

```
Time taken to boot: 44s
firmware 18.8s · loader 7.9s · kernel 12.3s · system 4.1s · desktop 1.3s
```

- New `bin/omarchy-system-boot-time` (`omarchy system boot time`). `--notify` stamps the moment Hyprland starts, waits for the notification server, and sends the toast; with no arguments it prints the same report in a terminal.
- `default/hypr/autostart.lua` runs it once at the top of `hyprland.start`.
- Once per boot: the stamp is keyed on the kernel boot id in `~/.local/state/omarchy/boot-time`, so a logout and login, or a compositor restart, does not announce a second figure.
- Pre-kernel time comes from systemd's `FirmwareTimestampMonotonic`; the rest from `/proc/uptime` at Hyprland start. On BIOS boots or loaders that pass no timestamps the headline says `(since kernel start)`.
- Manual paragraph in `manual/10-notices.md`, including the caveat that a LUKS passphrase typed in the initrd is counted.
- `plans/boot-time.md` records the design and the rejected alternatives (parsing `systemd-analyze`, opt-in hook sample, bar widget).

## Testing

- `test/shell.d/system-boot-time-test.sh`: 10 assertions against stubbed `systemctl` and notification helpers, covering stamping, once-per-boot, stale stamps, the breakdown, and the no-firmware and unrecorded fallbacks.
- `./test/cli` passes (metadata lint and routing for the new command).
- Verified on a laptop booting limine + UKI with a LUKS root and SDDM autologin via `omarchy dev link` and two reboots: toast appears once after boot, stays quiet after logout/login, and `omarchy system boot time` prints the same figure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)