### PR TITLE
Show wind in m/s for Russian locales

### DIFF
--- a/bin/omarchy-weather-status
+++ b/bin/omarchy-weather-status
@@ -10,7 +10,15 @@ if [[ -z $place ]]; then
 fi
 
 query=$(jq -rn --arg place "$place" '$place | @uri')
-weather=$(curl -fsS --max-time 4 "https://wttr.in/${query}?format=%t|%w" 2>/dev/null | tr -d '\n')
+
+# Russian forecasts read wind in m/s (Roshydromet standard). wttr's M option
+# converts its default km/h without changing the rest of the report.
+wind_flag=""
+if [[ ${LANG,,} =~ ^ru($|[_.-]) ]]; then
+  wind_flag="&M"
+fi
+
+weather=$(curl -fsS --max-time 4 "https://wttr.in/${query}?format=%t|%w${wind_flag}" 2>/dev/null | tr -d '\n')
 
 if [[ -z $weather ]]; then
   echo "Weather unavailable"

--- a/shell/plugins/panels/weather/Model.js
+++ b/shell/plugins/panels/weather/Model.js
@@ -91,6 +91,19 @@ function formatTemp(value, useImperial) {
   return value + "°" + (useImperial ? "F" : "C")
 }
 
+// Wind follows the same imperial/metric decision as temperature, except that
+// metric-Russian renders m/s (see localeUsesMsWind). Both wind speeds arrive
+// pre-rounded in the normalized wttr shape.
+function formatWind(windspeedKmph, windspeedMiles, useImperial, useMsWind) {
+  if (useImperial) return windspeedMiles + " mph"
+  if (useMsWind) {
+    var n = parseFloat(String(windspeedKmph))
+    if (isNaN(n)) return ""
+    return (Math.round(n / 3.6)) + " m/s"
+  }
+  return windspeedKmph + " km/h"
+}
+
 function normalizedUnit(value) {
   return String(value || "").replace(/^\s+|\s+$/g, "").toLowerCase()
 }
@@ -98,6 +111,13 @@ function normalizedUnit(value) {
 function localeUsesImperial(localeName) {
   var name = String(localeName || "").replace(".", "_")
   return /^en[_-]US($|[_.-])/.test(name) || /^en[_-]LR($|[_.-])/.test(name) || /^my($|[_.-])/.test(name)
+}
+
+// Russian forecasts are read in m/s (Roshydromet standard), so the wind row
+// converts km/h to m/s in Russian locales instead of showing km/h.
+function localeUsesMsWind(localeName) {
+  var name = String(localeName || "").replace(".", "_")
+  return /^ru($|[_.-])/.test(name)
 }
 
 function countryUsesImperial(countryName) {
@@ -275,8 +295,10 @@ if (typeof module !== "undefined") {
     roundedTemp: roundedTemp,
     celsiusToFahrenheit: celsiusToFahrenheit,
     formatTemp: formatTemp,
+    formatWind: formatWind,
     normalizedUnit: normalizedUnit,
     localeUsesImperial: localeUsesImperial,
+    localeUsesMsWind: localeUsesMsWind,
     countryUsesImperial: countryUsesImperial,
     shouldUseImperial: shouldUseImperial,
     dayName: dayName,

--- a/shell/plugins/panels/weather/Panel.qml
+++ b/shell/plugins/panels/weather/Panel.qml
@@ -138,6 +138,7 @@ Panel {
   readonly property string reportCountry: areaInfo && areaInfo.country && areaInfo.country[0] ? areaInfo.country[0].value : ""
 
   readonly property bool useImperial: Model.shouldUseImperial(setting("unit", ""), Qt.locale().name, reportCountry)
+  readonly property bool useMsWind: !useImperial && Model.localeUsesMsWind(Qt.locale().name)
 
   // Auto-refresh interval in minutes; clamped to a sane minimum.
   readonly property int refreshMinutes: Math.max(1, parseInt(setting("refreshMinutes", 15), 10) || 15)
@@ -146,7 +147,7 @@ Panel {
   readonly property string reportTempNum:   current ? String(useImperial ? current.temp_F : current.temp_C) : ""
   readonly property string tempUnit:        "°" + (useImperial ? "F" : "C")
   readonly property string reportFeels:     current ? formatTemp(useImperial ? current.FeelsLikeF : current.FeelsLikeC) : ""
-  readonly property string reportWind:      current ? (useImperial ? (current.windspeedMiles + " mph") : (current.windspeedKmph + " km/h")) : ""
+  readonly property string reportWind:      current ? Model.formatWind(current.windspeedKmph, current.windspeedMiles, useImperial, useMsWind) : ""
   readonly property string reportHumidity:  current ? (current.humidity + "%") : ""
 
   function refresh() {

--- a/test/shell.d/weather-test.sh
+++ b/test/shell.d/weather-test.sh
@@ -61,6 +61,19 @@ assertEqual(weather.shouldUseImperial('metric', 'en_US', 'United States of Ameri
 assertEqual(weather.shouldUseImperial('imperial', 'da_DK', 'Denmark'), true, 'weather imperial override wins')
 assertEqual(weather.dayName('2026-05-25'), 'Monday', 'weather derives day names')
 
+assert(weather.localeUsesMsWind('ru_RU.UTF-8'), 'weather wind reads m/s in the ru_RU locale')
+assert(weather.localeUsesMsWind('ru'), 'weather wind reads m/s in a bare ru locale')
+assert(!weather.localeUsesMsWind('en_US.UTF-8'), 'weather wind stays km/h in US English')
+assert(!weather.localeUsesMsWind('de_DE.UTF-8'), 'weather wind stays km/h in German')
+assert(!weather.localeUsesMsWind(''), 'weather wind stays km/h without a locale')
+
+assertEqual(weather.formatWind('14', '9', false, false), '14 km/h', 'weather formats metric wind in km/h')
+assertEqual(weather.formatWind('14', '9', true, false), '9 mph', 'weather formats imperial wind in mph')
+assertEqual(weather.formatWind('14', '9', false, true), '4 m/s', 'weather converts metric wind to m/s for Russian readers')
+assertEqual(weather.formatWind('18', '11', false, true), '5 m/s', 'weather rounds m/s wind to the nearest whole unit')
+assertEqual(weather.formatWind('', '', false, true), '', 'weather renders no wind without a reading')
+assertEqual(weather.formatWind('14', '9', true, true), '9 mph', 'weather imperial wind wins over the m/s locale')
+
 const openMeteo = {
   daily: {
     time: ['2026-05-25', '2026-05-26', '2026-05-27', '2026-05-28', '2026-05-29'],
@@ -145,6 +158,15 @@ assert(
   panelSource.split('root.controller.show()\n    locationFile.reload()\n    root.refresh()').length === 3,
   'weather reloads external location changes whenever either open path runs'
 )
+assert(
+  panelSource.includes('readonly property bool useMsWind: !useImperial && Model.localeUsesMsWind(Qt.locale().name)'),
+  'weather wind falls back to m/s only for metric Russian locales'
+)
+assert(
+  panelSource.includes('Model.formatWind(current.windspeedKmph, current.windspeedMiles, useImperial, useMsWind)'),
+  'weather panel renders wind through Model.formatWind'
+)
+
 assert(!weather.weatherResponseCompletesSave(true, 'wttr'), 'weather keeps the spinner through a non-authoritative pinned-location response')
 assert(weather.weatherResponseCompletesSave(true, 'open-meteo'), 'weather completes a pinned-location save with Open-Meteo data')
 assert(weather.weatherResponseCompletesSave(false, 'wttr'), 'weather completes a name-only location save with wttr data')
@@ -182,3 +204,35 @@ pass "weather location rejects malformed coordinates"
 weather_location --clear
 [[ ! -e "$test_tmp/.local/state/omarchy/settings/weather.json" ]] || fail "weather location clear removes the state file"
 pass "weather location clear removes the state file"
+
+# ---- omarchy-weather-status: ru locales ask wttr for m/s wind --------------
+
+status_dir="$test_tmp/status"
+mkdir -p "$status_dir/bin"
+
+# Records the wttr URL the script requests so tests can pin the unit flag,
+# then serves a canned one-line report.
+cat >"$status_dir/bin/curl" <<EOF
+#!/bin/bash
+printf '%s\n' "\$*" > "$status_dir/last-url"
+echo '+21°C|↑13km/h'
+EOF
+
+cat >"$status_dir/bin/omarchy-weather-location" <<'STUB'
+#!/bin/bash
+echo "malibu"
+STUB
+
+chmod +x "$status_dir/bin/curl" "$status_dir/bin/omarchy-weather-location"
+
+weather_status_url() {
+  HOME="$test_tmp" PATH="$status_dir/bin:$PATH" LANG="$1" "$ROOT/bin/omarchy-weather-status" >/dev/null
+  cat "$status_dir/last-url"
+}
+
+[[ $(weather_status_url "en_US.UTF-8") == *"format=%t|%w" ]] || fail "weather status leaves wttr units alone outside ru locales"
+[[ $(weather_status_url "en_US.UTF-8") != *"&M"* ]] || fail "weather status adds no wind flag outside ru locales"
+pass "weather status leaves wttr units alone outside ru locales"
+
+[[ $(weather_status_url "ru_RU.UTF-8") == *"format=%t|%w&M"* ]] || fail "weather status asks wttr for m/s wind in the ru locale"
+pass "weather status asks wttr for m/s wind in the ru locale"


### PR DESCRIPTION
Fixes #11139

## Problem
Russian forecasts always read wind in m/s (Roshydromet standard) — wttr.in and Open-Meteo both return km/h by default, so the weather panel's WIND row and the omarchy-weather-status notification read as foreign on a Russian desktop.

## Change
- Model.js: new localeUsesMsWind() (ru* locales) and formatWind() (km/h ÷ 3.6, rounded) helpers
- Panel.qml: useMsWind gates on !useImperial so imperial units still win; the WIND row renders through Model.formatWind()
- bin/omarchy-weather-status: appends wttr's M option (verified live: ↑13km/h → ↑4m/s) when LANG is ru*, so notification and panel match (see also #7706)

Other locales are unchanged. Explicit metric/imperial unit overrides still take precedence via shouldUseImperial.

## Tests
- Node asserts for localeUsesMsWind (ru/ru_RU/en_US/de_DE/empty) and formatWind (km/h, mph, m/s conversion + rounding, empty reading, imperial-wins)
- Hermetic curl-stub test pinning the wttr URL: no &M for en_US.UTF-8, &M present for ru_RU.UTF-8
- Live verification: LANG=ru_RU.UTF-8 omarchy-weather-status → Wind ←1m/s; en_US → ←5km/h

./test/shell.d/weather-test.sh passes; the 5 unrelated suite failures (config, locate, snapper, unowned-system-paths, update-lock) pre-exist on a clean quattro checkout — they need a sibling omarchy-pkgs checkout and a UTF-8 locale that my environment doesn't have.