### PR TITLE
screensaver: use Matrix digital rain as the default effect

### DIFF
--- a/bin/omarchy-screensaver
+++ b/bin/omarchy-screensaver
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# omarchy:summary=Run the Omarchy screensaver using random effects from TTE.
+# omarchy:summary=Run the Omarchy screensaver using the Matrix digital rain effect.
 
 screensaver_in_focus() {
   hyprctl activewindow -j | jq -e '.class == "org.omarchy.screensaver"' >/dev/null 2>&1
@@ -35,10 +35,17 @@ wait_for_terminal_resize() {
 
 wait_for_terminal_resize
 
+logo="$HOME/.config/omarchy/branding/screensaver.txt"
+[[ -f $logo ]] || logo="$OMARCHY_PATH/logo.txt"
+
 while true; do
-  ttfx -i ~/.config/omarchy/branding/screensaver.txt \
-    --frame-rate 120 --canvas-width 0 --canvas-height 0 --reuse-canvas --anchor-canvas c --anchor-text c\
-    --random-effect --no-eol --no-restore-cursor &
+  ttfx -i "$logo" \
+    --frame-rate 120 --canvas-width 0 --canvas-height 0 --reuse-canvas --anchor-canvas c --anchor-text c \
+    --no-eol --no-restore-cursor \
+    matrix \
+    --rain-color-gradient 00ff41 00e63c 00c832 00a328 007a1f 004a12 \
+    --highlight-color d2ffd6 \
+    --rain-time 45 &
 
   while pgrep -t "${tty#/dev/}" -x ttfx >/dev/null; do
     if read -n1 -t 1 || ! screensaver_in_focus; then

--- a/bin/omarchy-screensaver
+++ b/bin/omarchy-screensaver
@@ -35,6 +35,20 @@ wait_for_terminal_resize() {
 
 wait_for_terminal_resize
 
+# The compositor can map the screensaver window before focus has settled on it,
+# which would trip the focus check below a moment after launch and dismiss the
+# screensaver immediately. Wait until the window has focus (or a short grace
+# period elapses) before arming that check.
+wait_for_focus() {
+  local deadline=$((SECONDS + 3))
+  while ((SECONDS < deadline)); do
+    screensaver_in_focus && return 0
+    sleep 0.1
+  done
+}
+
+wait_for_focus
+
 logo="$HOME/.config/omarchy/branding/screensaver.txt"
 [[ -f $logo ]] || logo="$OMARCHY_PATH/logo.txt"
 

--- a/manual/13-toggles-idle-screensaver.md
+++ b/manual/13-toggles-idle-screensaver.md
@@ -86,7 +86,7 @@ This is about locking and the screensaver, not power. Suspend and hibernation ha
 
 ### The screensaver
 
-Omarchy's screensaver is ASCII art running through random text effects, one instance per monitor. Any key or mouse movement exits it.
+Omarchy's screensaver is a Matrix-style digital rain — green glyphs falling down the screen, one instance per monitor — that resolves into your branding logo after the rain has run its course. Any key or mouse movement exits it.
 
 You can start it on demand from _System > Screensaver_ (`Super + Esc`), which forces it up even if you've turned the idle screensaver off. There's no hotkey bound to it by default.
 


### PR DESCRIPTION
## What

Replaces the screensaver's random text effects with a Matrix-style digital rain.

- `bin/omarchy-screensaver` now runs `ttfx matrix` with an Omarchy-green rain gradient (`00ff41 … 004a12`) and a light highlight, one instance per monitor as before.
- The rain falls for 45 seconds and then resolves into the branding logo, so the existing _Style > Screensaver_ branding keeps working unchanged.
- Falls back to `$OMARCHY_PATH/logo.txt` when no branding file exists yet.
- Adds a focus-settle guard: the compositor can map the screensaver window before focus lands on it, which would trip the existing focus check a moment after launch and dismiss the screensaver immediately. It now waits up to three seconds for focus before that check becomes authoritative.
- Updates `manual/13-toggles-idle-screensaver.md` to describe the new behavior.

## Why

The Matrix rain is the signature Omarchy look; making it the default gives the idle screen a cohesive visual identity instead of a rotating set of arbitrary text effects.

## Testing

- `./test/cli` passes (command metadata).
- `./test/all` passes except the three packaging-coverage suites that require a separate `omarchy-pkgs` checkout (`config-test.sh`, `snapper-test.sh`, `unowned-system-paths-test.sh`), unrelated to this change.
- Verified visually in a running Hyprland session: the rain fills the full screen and resolves into the branding logo.