### PR TITLE
Document what a theme does not control, and the hook for per-theme app settings

### DIFF
--- a/default/agents/skills/omarchy/SKILL.md
+++ b/default/agents/skills/omarchy/SKILL.md
@@ -287,6 +287,7 @@ This skill intentionally does not cover Omarchy source development. Do not use t
 - "Clear all reminders" -> `omarchy reminder clear`
 - "Customize the catppuccin theme colors" -> Overlay: put an edited `colors.toml` in `~/.config/omarchy/themes/catppuccin/`, then re-apply the theme (see `theming.md`)
 - "Run a script every time I change themes" -> Install it with `omarchy hook install theme-set <script>`
+- "Make only my Tokyo Night theme translucent" -> Keep opacity out of `~/.config/foot/foot.ini`; drive the per-theme alpha from a `theme-set` hook (see `theming.md`)
 - "Change how workspace labels are rendered" -> Clone `omarchy.workspaces`, which switches the bar to `<username>.workspaces`, then edit the clone
 - "Lock after ten minutes" -> Set `idle.lock` to `600` in `~/.config/omarchy/shell.json`
 - "Reset shell/bar to defaults" -> `omarchy refresh shell`

--- a/default/agents/skills/omarchy/theming.md
+++ b/default/agents/skills/omarchy/theming.md
@@ -42,6 +42,39 @@ To change how Omarchy themes an app for every theme, write the template rather
 than the theme: `~/.config/omarchy/themed/<config-name>.tpl` overrides the
 built-in one. See `docs/theming.md` in the Omarchy repo.
 
+## What a Theme Does Not Control
+
+A theme owns color, plus the extras it may ship (`backgrounds/`, `icons.theme`,
+`keyboard.rgb`, `unlock.png`, `light.mode`). It does not own app preferences
+like terminal opacity or blur. Those live in the app's base config
+(`~/.config/foot/foot.ini`, `~/.config/kitty/kitty.conf`,
+`~/.config/ghostty/config`, `~/.config/alacritty/alacritty.toml`) and are
+global, so they persist across every theme switch. Setting them there to chase
+a themed look leaks a per-theme intent into a machine-wide setting.
+
+To make such a setting follow the current theme, drive it from a `theme-set`
+hook instead. The hook gets the theme slug in `$1` — lowercased, spaces turned
+into hyphens — so it can write a small file the base config already includes:
+
+```bash
+# One-time: create the file, and add under [main] in ~/.config/foot/foot.ini:
+#   include=~/.config/foot/theme-alpha.ini
+touch ~/.config/foot/theme-alpha.ini
+
+cat >~/.config/omarchy/hooks/theme-set.d/50-foot-alpha <<'EOF'
+#!/bin/bash
+# Translucent terminal for one theme, solid for the rest.
+if [[ $1 == "tokyo-night" ]]; then
+  printf '[colors-dark]\nalpha=0.80\nalpha-mode=all\n' >~/.config/foot/theme-alpha.ini
+else
+  : >~/.config/foot/theme-alpha.ini
+fi
+EOF
+chmod +x ~/.config/omarchy/hooks/theme-set.d/50-foot-alpha
+```
+
+Omarchy fires the hook after it activates a theme; see [`hooks.md`](hooks.md).
+
 ## Customizing a Stock Theme
 
 Never edit stock themes under `/usr/share/omarchy/themes/` — changes are lost


### PR DESCRIPTION
## What

The `omarchy` skill treats a "theme" as color plus the extras a theme may ship (`backgrounds/`, `icons.theme`, `keyboard.rgb`, `unlock.png`, `light.mode`). Nothing states that app preferences like terminal opacity/blur are **not** part of a theme. They live in the app's base config (`~/.config/foot/foot.ini`, etc.), are global, and persist across theme switches — so the natural mistake is to edit the base config for a themed look, which then leaks into every theme.

This adds a short "What a Theme Does Not Control" boundary section to `default/agents/skills/omarchy/theming.md`, plus one example request in `SKILL.md`. It also documents the supported way to get per-theme app settings today: a `theme-set` hook that writes a small file the base config includes, matching on the theme slug (the hook receives it in `$1`).

## Why

It's the sharp edge behind this class of request: "make only theme A translucent, theme B solid". Today that can't be a theme property, and the base config silently enforces it everywhere. Documenting the boundary and the hook keeps the intent theme-scoped.

Adjacent to #7942 (a per-theme template/options channel). Until that lands, the hook is the way.

## Testing

Docs-only. `./test/cli` passes. `./test/all` is unaffected (no code changed).
