### PR TITLE
fix(hypr): add missing keybinding to zoom out

### DIFF
--- a/default/hypr/bindings/utilities.lua
+++ b/default/hypr/bindings/utilities.lua
@@ -120,6 +120,13 @@ o.bind("SUPER + CTRL + Z", "Zoom in", function()
   hl.config({ cursor = { zoom_factor = zoom + 1 } })
 end)
 
+o.bind("SUPER + CTRL + SHIFT + Z", "Zoom out", function()
+  local zoom = hl.get_config("cursor.zoom_factor") or 1
+  if zoom > 1 then
+    hl.config({ cursor = { zoom_factor = math.max(1, zoom - 1) } })
+  end
+end)
+
 o.bind("SUPER + CTRL + ALT + Z", "Reset zoom", function()
   hl.config({ cursor = { zoom_factor = 1 } })
 end)


### PR DESCRIPTION
## Description
Closes #11145.

Currently, Omarchy defines keybindings to zoom in and reset zoom:
- `SUPER + CTRL + Z`: Zoom in (`zoom + 1`)
- `SUPER + CTRL + ALT + Z`: Reset zoom (`1`)

However, there was no keybinding to zoom out step-by-step without resetting the zoom all the way back to 1.0.

This adds `SUPER + CTRL + SHIFT + Z` to step zoom back out towards 1.0 cleanly.

## Validation
- Verified with `luac -p default/hypr/bindings/utilities.lua`.