### PR TITLE
Fix cloned menu plugins permanently losing app-library access

### DIFF
--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -347,8 +347,23 @@ ShellRoot {
   }
 
   function manifestHasKind(manifest, kind) {
-    return !!manifest && Array.isArray(manifest.kinds)
-      && manifest.kinds.indexOf(kind) !== -1
+    // manifest.kinds is a genuine JS array when read straight off
+    // pluginRegistry.installedPlugins, but a manifest that has passed through
+    // a QML model (panelEntries is used as an Instantiator's `model:`) comes
+    // back with its nested kinds array converted to a list-like value that
+    // Array.isArray() no longer recognizes, even though indexing and .length
+    // still work. That made createScopedPluginShell() compute this function
+    // differently for the same cloned menu plugin depending on which caller
+    // triggered it (the bar-widget path vs. the panel-loader path), and
+    // whichever call ran second silently evicted the correct cached
+    // PluginShellApi and replaced it with one missing appLibrary — permanently
+    // dropping app-library access for that clone's menu panel. Duck-type
+    // instead so both shapes are handled the same way.
+    if (!manifest || !manifest.kinds || typeof manifest.kinds.length !== "number") return false
+    for (var i = 0; i < manifest.kinds.length; i++) {
+      if (manifest.kinds[i] === kind) return true
+    }
+    return false
   }
 
   function pluginHasBarCapabilities(manifest) {

--- a/test/shell.d/fixtures/manifest-has-kind/shell.qml
+++ b/test/shell.d/fixtures/manifest-has-kind/shell.qml
@@ -1,0 +1,73 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+
+// Regression fixture for manifestHasKind()'s array check. A manifest read
+// straight off pluginRegistry.installedPlugins keeps its `kinds` as a real JS
+// array, but a manifest that has passed through a QML Instantiator's `model:`
+// (as shell.qml's panelEntries does) comes back with `kinds` as a list-like
+// value that Array.isArray() no longer recognizes, even though indexing and
+// .length still work. That inconsistency made shell.qml compute
+// manifestHasKind(manifest, "menu") differently for the same cloned menu
+// plugin depending on which caller triggered it, so one call silently evicted
+// the other's cached, working PluginShellApi and replaced it with one missing
+// appLibrary. This pins the underlying platform behavior and proves a
+// duck-typed length/index check (mirroring shell.qml's manifestHasKind)
+// handles both shapes the same way.
+ShellRoot {
+  id: root
+
+  FileView {
+    id: resultFile
+    path: Quickshell.env("OMARCHY_QML_TEST_RESULT")
+    atomicWrites: true
+  }
+
+  // Kept in sync with manifestHasKind() in shell.qml.
+  function manifestHasKind(manifest, kind) {
+    if (!manifest || !manifest.kinds || typeof manifest.kinds.length !== "number") return false
+    for (var i = 0; i < manifest.kinds.length; i++) {
+      if (manifest.kinds[i] === kind) return true
+    }
+    return false
+  }
+
+  property var directManifest: ({ id: "shashi.menu", kinds: ["menu", "bar-widget"] })
+  property var entries: [{ id: "shashi.menu", manifest: directManifest }]
+
+  function writeResult(viaModelManifest) {
+    var result = {
+      // Pins the platform quirk this fix works around. If a future Qt/
+      // Quickshell version starts preserving Array-ness through Instantiator
+      // models, this flips to true and the duck-typed check below is no
+      // longer load-bearing — the checks that matter are hasKindDirect and
+      // hasKindViaModel.
+      directKindsIsArray: Array.isArray(root.directManifest.kinds),
+      viaModelKindsIsArray: Array.isArray(viaModelManifest.kinds),
+      hasKindDirect: root.manifestHasKind(root.directManifest, "menu"),
+      hasKindViaModel: root.manifestHasKind(viaModelManifest, "menu"),
+      missingKindDirect: root.manifestHasKind(root.directManifest, "service"),
+      missingKindViaModel: root.manifestHasKind(viaModelManifest, "service")
+    }
+    result.ok = result.hasKindDirect === true
+      && result.hasKindViaModel === true
+      && result.missingKindDirect === false
+      && result.missingKindViaModel === false
+
+    resultFile.setText(JSON.stringify(result))
+    Qt.quit()
+  }
+
+  Instantiator {
+    id: modelInstantiator
+    model: root.entries
+    delegate: QtObject {
+      id: delegateItem
+      required property var modelData
+      readonly property var manifest: modelData.manifest
+    }
+    onObjectAdded: function(index, object) {
+      root.writeResult(object.manifest)
+    }
+  }
+}

--- a/test/shell.d/manifest-has-kind-test.sh
+++ b/test/shell.d/manifest-has-kind-test.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+TMPDIR=""
+QS_PID=""
+
+cleanup() {
+  if [[ -n $QS_PID ]] && kill -0 "$QS_PID" 2>/dev/null; then
+    kill "$QS_PID" 2>/dev/null || true
+    wait "$QS_PID" 2>/dev/null || true
+  fi
+  if [[ -n $TMPDIR && -d $TMPDIR ]]; then
+    rm -rf "$TMPDIR"
+  fi
+}
+trap cleanup EXIT
+
+shell_qml="$ROOT/shell/shell.qml"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const shellQml = fs.readFileSync(path.join(root, 'shell/shell.qml'), 'utf8')
+
+const fn = /function manifestHasKind\(manifest, kind\) \{[\s\S]*?\n  \}/.exec(shellQml)
+assert(!!fn, 'manifestHasKind is defined in shell.qml')
+
+assert(
+  !/Array\.isArray\(manifest\.kinds\)/.test(fn[0]),
+  'manifestHasKind does not gate on Array.isArray(manifest.kinds)',
+  'A manifest read through an Instantiator model (panelEntries) has its ' +
+  'kinds converted to a list-like value that Array.isArray() rejects even ' +
+  'though indexing and .length still work, so gating on it makes ' +
+  'manifestHasKind() answer differently for the same plugin depending on ' +
+  'the caller — see the panel-loader vs. bar-widget paths in ' +
+  'createScopedPluginShell().'
+)
+assert(
+  /typeof manifest\.kinds\.length !== "number"/.test(fn[0]),
+  'manifestHasKind duck-types on kinds.length instead'
+)
+JS
+
+require_compositor "manifestHasKind Instantiator-model runtime test"
+
+if ! command -v quickshell >/dev/null 2>&1; then
+  pass "quickshell not installed; skipping manifestHasKind Instantiator-model runtime test"
+  exit 0
+fi
+
+require_command jq
+
+TMPDIR=$(mktemp -d)
+result="$TMPDIR/result.json"
+log="$TMPDIR/quickshell.log"
+config_dir="$TMPDIR/manifest-has-kind"
+mkdir -p "$config_dir" "$TMPDIR/home"
+cp "$SHELL_TEST_DIR/fixtures/manifest-has-kind/"*.qml "$config_dir/"
+
+OMARCHY_QML_TEST_RESULT="$result" \
+HOME="$TMPDIR/home" \
+XDG_CONFIG_HOME="$TMPDIR/home/.config" \
+XDG_CACHE_HOME="$TMPDIR/home/.cache" \
+XDG_STATE_HOME="$TMPDIR/home/.local/state" \
+  quickshell -p "$config_dir" --no-color >"$log" 2>&1 &
+QS_PID=$!
+
+for _ in {1..80}; do
+  [[ -s $result ]] && break
+  if ! kill -0 "$QS_PID" 2>/dev/null; then
+    sed -n '1,220p' "$log" >&2
+    fail "manifestHasKind fixture exited before writing result"
+  fi
+  sleep 0.1
+done
+
+[[ -s $result ]] || {
+  sed -n '1,220p' "$log" >&2
+  fail "manifestHasKind Instantiator-model runtime test timed out"
+}
+
+if ! jq -e '.viaModelKindsIsArray == false' "$result" >/dev/null; then
+  jq . "$result" >&2
+  fail "fixture no longer reproduces the Instantiator-model Array.isArray quirk it exists to guard against"
+fi
+
+if ! jq -e '.ok == true' "$result" >/dev/null; then
+  jq . "$result" >&2
+  sed -n '1,220p' "$log" >&2
+  fail "manifestHasKind gives the same answer for a direct manifest and one read through an Instantiator model"
+fi
+
+pass "manifestHasKind gives the same answer for a direct manifest and one read through an Instantiator model"


### PR DESCRIPTION
> **🤖 AI-assisted submission:** This PR was investigated, fixed, tested, and submitted by Claude (Anthropic's Claude Code), working on behalf of a user who hit this bug. A human (the repo owner of this fork) reviewed and approved opening the PR, but did not author the diagnosis or patch by hand. Flagging this transparently for maintainer review.

## Summary

- Cloning the first-party `omarchy.menu` plugin (`omarchy plugin clone omarchy.menu`) and switching the bar to the clone leaves the clone's Apps list permanently empty — no apps ever show, on every restart.
- Root cause: `manifestHasKind()` gates on `Array.isArray(manifest.kinds)`. A manifest read straight off `pluginRegistry.installedPlugins` keeps `kinds` as a real JS array, but a manifest read through `panelEntries` — used as an `Instantiator`'s `model:` — comes back with `kinds` converted to a list-like value that `Array.isArray()` no longer recognizes, even though indexing and `.length` still work.
- `createScopedPluginShell()` calls `manifestHasKind()` for a cloned menu plugin from two call sites that share the same cache key: the bar-widget path (a direct manifest, `Array.isArray` true) and the panel-loader path (a model-derived manifest, `Array.isArray` false). Because the two calls disagree, they compute different capability profiles, so whichever call runs second evicts the other's cached `PluginShellApi` and replaces it with one missing `appLibrary` — permanently, for the shell process's lifetime.
- First-party plugins never hit this because they bypass the scoped-shell caching path entirely (`pluginShellFor` returns the real `shell` singleton directly for `manifest.__isFirstParty`), so this only affects cloned/third-party menu+bar-widget plugins.
- Fix: duck-type on `kinds.length` instead of `Array.isArray`, so both manifest shapes are handled identically.

## How I found this

A user's cloned menu plugin showed a permanently empty Apps list. I reproduced it safely by copying `shell/` into a scratch directory, running it standalone with a scratch `$HOME`/`OMARCHY_PATH` (never touching the live session), and instrumenting `createScopedPluginShell()` to log `Array.isArray(manifest.kinds)` and the resulting `appLibrary` at each call site with a captured stack trace. That showed the two call sites (`Bar.qml:237` → `pluginBarApiFor` vs. `shell.qml:1348` → the panel loader's `onLoaded`) disagreeing on `Array.isArray`, and whichever ran second winning the cache and leaving `appLibrary` `null`. Reverted `manifestHasKind` to duck-typing and confirmed `appLibrary` stayed valid across 4 repeated runs.

## Test plan

- [x] Added `test/shell.d/manifest-has-kind-test.sh` with a fixture (`test/shell.d/fixtures/manifest-has-kind/shell.qml`) that pins the underlying quirk (a manifest read through an `Instantiator` model loses `Array.isArray`-ness) and asserts `manifestHasKind` answers identically for a direct manifest and a model-derived one. Verified the new test fails on the unpatched `manifestHasKind` and passes with the fix.
- [x] `./test/shell` — full suite passes except 4 pre-existing failures unrelated to this change (missing sibling `omarchy-pkgs` checkout for packaging-coverage tests, and an unrelated locale/encoding issue in `locate-test.sh`), reproducible identically on `quattro` before this change.
- [x] `./test/cli` passes.
