### PR TITLE
Fix idle timer 32-bit integer overflow on large timeout values (#11135)

### DIFF
--- a/shell/plugins/services/idle/IdleModel.js
+++ b/shell/plugins/services/idle/IdleModel.js
@@ -1,7 +1,9 @@
+var MAX_TIMEOUT_SECONDS = 2147483 // Math.floor(2147483647 / 1000)
+
 function secondsFromConfig(value, fallback) {
   var n = Number(value)
   if (!isFinite(n) || n < 0) return fallback
-  return Math.floor(n)
+  return Math.min(Math.floor(n), MAX_TIMEOUT_SECONDS)
 }
 
 function eventParts(event, count) {
@@ -45,6 +47,7 @@ function screensaverWindowsAfter(windows, address, visible) {
 
 if (typeof module !== "undefined") {
   module.exports = {
+    MAX_TIMEOUT_SECONDS: MAX_TIMEOUT_SECONDS,
     secondsFromConfig: secondsFromConfig,
     eventParts: eventParts,
     screensaverWindowsAfter: screensaverWindowsAfter

--- a/shell/plugins/services/idle/Service.qml
+++ b/shell/plugins/services/idle/Service.qml
@@ -23,6 +23,7 @@ Item {
   readonly property int firstIdleTimeoutSeconds: Math.min(screensaverTimeoutSeconds, lockTimeoutSeconds)
   readonly property int screensaverDelaySeconds: Math.max(0, screensaverTimeoutSeconds - firstIdleTimeoutSeconds)
   readonly property int lockDelaySeconds: Math.max(0, lockTimeoutSeconds - firstIdleTimeoutSeconds)
+  readonly property int maxTimerIntervalMs: 2147483647
   readonly property bool idleEnabled: stayAwakeStateLoaded && !stayAwake
   readonly property string screensaverClass: "org.omarchy.screensaver"
 
@@ -258,14 +259,14 @@ Item {
 
   Timer {
     id: screensaverTimer
-    interval: root.screensaverDelaySeconds * 1000
+    interval: Math.min(root.screensaverDelaySeconds * 1000, root.maxTimerIntervalMs)
     repeat: false
     onTriggered: root.launchScreensaver()
   }
 
   Timer {
     id: lockTimer
-    interval: root.lockDelaySeconds * 1000
+    interval: Math.min(root.lockDelaySeconds * 1000, root.maxTimerIntervalMs)
     repeat: false
     onTriggered: if (root.idleEnabled && root.idledThisCycle) root.lockSystem("lock-timeout")
   }

--- a/test/shell.d/idle-test.sh
+++ b/test/shell.d/idle-test.sh
@@ -10,6 +10,9 @@ const idle = requireFromRoot('shell/plugins/services/idle/IdleModel.js')
 assertEqual(idle.secondsFromConfig('42.9', 10), 42, 'idle floors configured seconds')
 assertEqual(idle.secondsFromConfig('-1', 10), 10, 'idle rejects negative seconds')
 assertEqual(idle.secondsFromConfig('nope', 10), 10, 'idle rejects invalid seconds')
+assertEqual(idle.secondsFromConfig('2592000', 10), idle.MAX_TIMEOUT_SECONDS, 'idle clamps large seconds to prevent 32-bit int overflow')
+assertEqual(idle.secondsFromConfig(3000000000, 10), idle.MAX_TIMEOUT_SECONDS, 'idle clamps huge seconds')
+assert(idle.MAX_TIMEOUT_SECONDS * 1000 <= 2147483647, 'idle max timeout in milliseconds fits in 32-bit signed integer')
 
 assertDeepEqual(idle.eventParts({ data: 'a,b,c' }, 2), ['a', 'b', 'c'], 'idle parses raw event data')
 assertDeepEqual(


### PR DESCRIPTION
Resolves #11135

### Problem
When large idle lock or screensaver timeouts are configured in `~/.config/omarchy/shell.json` (e.g. `idle.lock: 2592000` = 30 days), the calculated timer interval in milliseconds overflows QML's signed 32-bit integer (`Timer.interval`). This produces a negative interval (e.g. `2591850 * 1000 = 2,591,850,000 > 2,147,483,647` -> `-1,703,117,296 ms`).

When this occurs, Qt continuously emits `QBasicTimer::start: negative intervals aren't allowed` on every restart/loop, rapidly filling `/run/user/<uid>` tmpfs until it reaches 100%, causing `systemd-run --user` to fail with `ENOSPC` and breaking desktop launchers.

### Solution
1. **IdleModel.js**: Clamp `secondsFromConfig` to `MAX_TIMEOUT_SECONDS` (`2147483` seconds, matching `Math.floor(2147483647 / 1000)` ~ 24.8 days).
2. **Service.qml**: Clamp `screensaverTimer.interval` and `lockTimer.interval` to `maxTimerIntervalMs: 2147483647` using `Math.min(...)`.
3. **test/shell.d/idle-test.sh**: Add test cases covering large/overflowing timeout values and bounds verification.