### PR TITLE
Prevent nightlight toggle race conditions and temperature oscillation (#11122)

### DIFF
--- a/bin/omarchy-toggle-nightlight
+++ b/bin/omarchy-toggle-nightlight
@@ -34,8 +34,14 @@ if [[ ${1:-} == "--status" ]]; then
   exit 0
 fi
 
+# Drop overlapping toggle events so concurrent invocations do not race
+exec {lock_fd}>"${XDG_RUNTIME_DIR:-/tmp}/omarchy-toggle-nightlight.lock"
+flock -n "$lock_fd" || exit 0
+
 # Ensure hyprsunset is running
+was_running=true
 if ! pgrep -x hyprsunset >/dev/null; then
+  was_running=false
   setsid uwsm-app -- hyprsunset &
 fi
 
@@ -48,12 +54,16 @@ else
   TARGET_TEMP=$OFF_TEMP
 fi
 
-# A freshly-started hyprsunset applies its default temperature at the end of
-# its boot, overriding anything set before then — so resend until it sticks
-for _ in {1..10}; do
+if [[ $was_running == "false" ]]; then
+  # A freshly-started hyprsunset applies its default temperature at the end of
+  # its boot, overriding anything set before then — so resend until it sticks
+  for _ in {1..10}; do
+    hyprctl hyprsunset temperature $TARGET_TEMP >/dev/null 2>&1
+    sleep 0.2
+    [[ $(current_temp) == "$TARGET_TEMP" ]] && break
+  done
+else
   hyprctl hyprsunset temperature $TARGET_TEMP >/dev/null 2>&1
-  sleep 0.2
-  [[ $(current_temp) == "$TARGET_TEMP" ]] && break
-done
+fi
 
 omarchy-shell -q nightlight refresh

--- a/test/shell.d/nightlight-test.sh
+++ b/test/shell.d/nightlight-test.sh
@@ -90,3 +90,14 @@ if rg -q 'omarchy.indicators' "$ROOT/bin/omarchy-toggle-nightlight"; then
   fail "nightlight toggle leaves indicator refresh to the nightlight service"
 fi
 pass "nightlight toggle leaves indicator refresh to the nightlight service"
+
+mkdir -p "$TMPDIR/run"
+printf '6500\n' >"$STATE"
+(
+  exec 9>"$TMPDIR/run/omarchy-toggle-nightlight.lock"
+  flock -x 9
+  XDG_RUNTIME_DIR="$TMPDIR/run" nightlight_cli >/dev/null
+)
+[[ $(<"$STATE") == 6500 ]] || fail "concurrent nightlight toggle drops while lock is held"
+pass "concurrent nightlight toggle drops while lock is held"
+


### PR DESCRIPTION
Resolves #11122

### Problem
When the nightlight toggle shortcut (`SUPER + CTRL + N`) is pressed rapidly twice, multiple concurrent instances of `omarchy-toggle-nightlight` run in parallel. Both instances enter the 10-iteration retry loop (`for _ in {1..10}; do hyprctl hyprsunset temperature ...; sleep 0.2; done`) with opposing target temperatures, continuously fighting and overriding each other. This causes the screen to violently oscillate between daylight (6500K) and warm (4000K) for 2 seconds.

### Solution
1. **Concurrency Lock**: Add a non-blocking `flock` guard on `${XDG_RUNTIME_DIR:-/tmp}/omarchy-toggle-nightlight.lock` (matching the pattern used in `omarchy-brightness-display`) to drop overlapping toggle requests caused by key repeat or rapid double-tapping.
2. **Immediate Temperature Set**: Only execute the 10-iteration retry loop when `hyprsunset` was just launched. When `hyprsunset` is already running, apply the temperature once and exit immediately without sleeping.
3. **Tests**: Added a concurrency test in `test/shell.d/nightlight-test.sh` verifying overlapping invocations exit cleanly without corrupting state.