### PR TITLE
Make network speed test resilient with dynamic token fetch and Cloudflare fallback (#11166)

### DIFF
--- a/bin/omarchy-network-speedtest
+++ b/bin/omarchy-network-speedtest
@@ -40,12 +40,45 @@ if ! omarchy-cmd-present curl; then
   exit 1
 fi
 
-fast_token="YXNkZmFzZGxmbnNkYWZoYXNkZmhrYWxm"
-fast_api_url="https://api.fast.com/netflix/speedtest/v2?https=true&token=$fast_token&urlCount=$url_count"
+fetch_fast_urls() {
+  local token="$1"
+  local api_url="https://api.fast.com/netflix/speedtest/v2?https=true&token=$token&urlCount=$url_count"
+  curl -fsS --max-time 5 "$api_url" 2>/dev/null | jq -r '.targets[]?.url // empty'
+}
 
-fast_urls=$(curl -fsS "$fast_api_url" 2>/dev/null | jq -r '.targets[]?.url // empty')
+fetch_speed_urls() {
+  local urls
+  urls=$(fetch_fast_urls "YXNkZmFzZGxmbnNkYWZoYXNkZmhrYWxm")
+  if [[ -n $urls ]]; then
+    echo "$urls"
+    return 0
+  fi
 
-if [[ -z $fast_urls ]]; then
+  # Dynamic token fetch if hardcoded token failed or expired
+  local js_file dynamic_token
+  js_file=$(curl -fsS --max-time 3 https://fast.com 2>/dev/null | grep -oE 'app-[a-f0-9]+\.js' | head -n1)
+  if [[ -n $js_file ]]; then
+    dynamic_token=$(curl -fsS --max-time 3 "https://fast.com/$js_file" 2>/dev/null | grep -oE 'token:"[^"]+"' | head -n1 | cut -d'"' -f2)
+    if [[ -n $dynamic_token ]]; then
+      urls=$(fetch_fast_urls "$dynamic_token")
+      if [[ -n $urls ]]; then
+        echo "$urls"
+        return 0
+      fi
+    fi
+  fi
+
+  # Fallback to Cloudflare speed test endpoints (tokenless, high availability, global Anycast CDN)
+  if [[ $direction == "down" ]]; then
+    echo "https://speed.cloudflare.com/__down?bytes=25000000"
+  else
+    echo "https://speed.cloudflare.com/__up"
+  fi
+}
+
+readarray -t speed_urls < <(fetch_speed_urls)
+
+if [[ ${#speed_urls[@]} -eq 0 || -z ${speed_urls[0]} ]]; then
   echo "Failed to fetch speed test endpoints" >&2
   exit 1
 fi
@@ -66,11 +99,12 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# Round-robin across the returned URLs so we spread load across Netflix OCA nodes.
+# Round-robin across the returned URLs so we spread load across nodes.
 traffic_worker() {
   local urls=("$@")
   local url_count=${#urls[@]}
   local idx=$RANDOM
+  local url
   if [[ $direction == "down" ]]; then
     while true; do
       url=${urls[$((idx % url_count))]}
@@ -87,7 +121,7 @@ traffic_worker() {
 }
 
 for (( i = 0; i < parallel; i++ )); do
-  traffic_worker $fast_urls &
+  traffic_worker "${speed_urls[@]}" &
   traffic_pids+=("$!")
 done
 

--- a/test/shell.d/network-speedtest-test.sh
+++ b/test/shell.d/network-speedtest-test.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# Test argument validation
+if "$ROOT/bin/omarchy-network-speedtest" 2>/dev/null; then
+  fail "speedtest requires argument"
+fi
+pass "speedtest requires argument"
+
+if "$ROOT/bin/omarchy-network-speedtest" invalid 2>/dev/null; then
+  fail "speedtest rejects invalid direction"
+fi
+pass "speedtest rejects invalid direction"
+
+# Mock curl to simulate Fast.com 403 failure and verify fallback
+mkdir -p "$TMPDIR/bin"
+
+cat >"$TMPDIR/bin/curl" <<'SH'
+#!/bin/bash
+for arg in "$@"; do
+  if [[ $arg == *"api.fast.com"* ]]; then
+    # Simulate 403 Forbidden
+    exit 22
+  fi
+  if [[ $arg == *"fast.com"* ]]; then
+    # Simulate JS bundle fetch failure
+    exit 22
+  fi
+done
+# For other URLs (e.g. Cloudflare endpoint), return success
+exit 0
+SH
+
+chmod +x "$TMPDIR/bin/curl"
+
+# Test that when Fast.com fails, the script falls back to Cloudflare without erroring
+output=$(PATH="$TMPDIR/bin:$PATH" timeout 1 "$ROOT/bin/omarchy-network-speedtest" down 2>&1 || true)
+if [[ $output == *"Failed to fetch speed test endpoints"* ]]; then
+  fail "speedtest fails when fast.com is unavailable instead of falling back"
+fi
+pass "speedtest falls back to alternative endpoints when Fast.com fails"


### PR DESCRIPTION
Resolves #11166

### Problem
When the hardcoded Fast.com token is rejected (HTTP 403 Forbidden), rotated by Netflix, or blocked in certain network regions, `omarchy-network-speedtest` aborted immediately with:
```
Failed to fetch speed test endpoints
```
This caused the network speed test overlay in the Wi-Fi panel to immediately fail without running any measurements.

### Solution
1. **Dynamic Token Resolution**: If the static token fails or is rejected with 403, inspect `fast.com` to extract the currently active token from its app bundle.
2. **Cloudflare Fallback**: If Fast.com endpoints cannot be retrieved (due to ISP blocking, geo-restriction, or API changes), fall back to public Anycast Cloudflare speed test endpoints (`https://speed.cloudflare.com/__down?bytes=25000000` and `/__up`), which require no credentials and work reliably worldwide.
3. **Tests**: Added `test/shell.d/network-speedtest-test.sh` verifying argument validation and fallback behavior when Fast.com is unavailable.