### PR TITLE
Make the adapter pairable while pairing a Bluetooth device

### DIFF
--- a/bin/omarchy-bluetooth-device
+++ b/bin/omarchy-bluetooth-device
@@ -29,10 +29,30 @@ trust_device() {
   bluetoothctl trust "$address" >/dev/null 2>&1 || true
 }
 
+adapter_pairable() {
+  [[ $(timeout 2s bluetoothctl show 2>/dev/null) == *"Pairable: yes"* ]]
+}
+
+# BlueZ only flags the adapter pairable while a default agent is registered,
+# and the non-interactive bluetoothctl pair does not register one. Against a
+# non-pairable adapter the kernel negotiates "no bonding": pairing succeeds and
+# audio plays, but the link key never reaches /var/lib/bluetooth, so the next
+# reconnect is refused and the device has to be forgotten and paired again.
+# Raise the flag for the handshake and put it back the way it was.
+pair_device() {
+  local raised=false
+  if ! adapter_pairable; then
+    bluetoothctl pairable on >/dev/null 2>&1 && raised=true
+  fi
+  timeout 20s bluetoothctl pair "$address" >/dev/null 2>&1 || true
+  [[ $raised == true ]] && bluetoothctl pairable off >/dev/null 2>&1
+  return 0
+}
+
 case "$action" in
   pair)
     power_on
-    timeout 20s bluetoothctl pair "$address" >/dev/null 2>&1 || true
+    pair_device
     trust_device
     timeout 20s bluetoothctl connect "$address" >/dev/null 2>&1 || true
     ;;

--- a/test/shell.d/bluetooth-test.sh
+++ b/test/shell.d/bluetooth-test.sh
@@ -151,12 +151,14 @@ trap 'rm -rf "$device_tmp"' EXIT
 mock_bin="$device_tmp/bin"
 mkdir -p "$mock_bin"
 export POWERED_FILE="$device_tmp/powered"
+export PAIRABLE_FILE="$device_tmp/pairable"
 
 cat >"$mock_bin/bluetoothctl" <<'SH'
 #!/bin/bash
 
 printf '%s\n' "$*" >>"$BLUETOOTHCTL_LOG"
 [[ $1 == "power" && $2 == "on" ]] && echo yes >"$POWERED_FILE"
+[[ $1 == "pairable" ]] && echo "$2" >"$PAIRABLE_FILE"
 [[ $1 == "list" ]] &&
   for c in ${MOCK_CONTROLLERS:-AA:BB:CC:DD:EE:FF}; do printf 'Controller %s mock\n' "$c"; done
 # Per-controller state where a test set it, the shared file otherwise.
@@ -164,6 +166,7 @@ if [[ $1 == "show" ]]; then
   state="$POWERED_FILE"
   [[ -n ${2:-} && -f "$POWERED_FILE.$2" ]] && state="$POWERED_FILE.$2"
   printf '\tPowered: %s\n' "$(cat "$state")"
+  printf '\tPairable: %s\n' "$(cat "$PAIRABLE_FILE" 2>/dev/null || echo no)"
 fi
 exit 0
 SH
@@ -262,6 +265,43 @@ pass "bluetooth lifts the block before connecting"
 grep -qx "connect AA:BB:CC:DD:EE:FF" "$unpowered_log" ||
   fail "bluetooth connects once the adapter is up" "$(cat "$unpowered_log")"
 pass "bluetooth connects once the adapter is up"
+
+# BlueZ only marks the adapter pairable while a default agent is registered, and
+# bt-agent is skipped whenever bluetoothd or a USB dongle comes up after the
+# session does. Pairing against a non-pairable adapter bonds without
+# persistence: the link key never reaches /var/lib/bluetooth and the next
+# reconnect is refused, so the device has to be forgotten and paired again.
+bluetooth_pair_log() {
+  echo "$1" >"$PAIRABLE_FILE"
+  bluetooth_run yes "$ROOT/bin/omarchy-bluetooth-device" pair AA:BB:CC:DD:EE:FF
+}
+
+log_line() {
+  grep -nx "$2" "$1" | cut -d: -f1 | head -1
+}
+
+pair_log=$(bluetooth_pair_log no)
+grep -qx "pairable on" "$pair_log" ||
+  fail "bluetooth makes the adapter pairable before pairing" "$(cat "$pair_log")"
+pass "bluetooth makes the adapter pairable before pairing"
+
+(( $(log_line "$pair_log" "pairable on") < $(log_line "$pair_log" "pair AA:BB:CC:DD:EE:FF") )) ||
+  fail "bluetooth raises pairable ahead of the pair handshake" "$(cat "$pair_log")"
+pass "bluetooth raises pairable ahead of the pair handshake"
+
+(( $(log_line "$pair_log" "pairable off") > $(log_line "$pair_log" "pair AA:BB:CC:DD:EE:FF") )) ||
+  fail "bluetooth lowers pairable again after the pair handshake" "$(cat "$pair_log")"
+pass "bluetooth lowers pairable again after the pair handshake"
+
+grep -qx "connect AA:BB:CC:DD:EE:FF" "$pair_log" ||
+  fail "bluetooth still connects after pairing" "$(cat "$pair_log")"
+pass "bluetooth still connects after pairing"
+
+# An adapter the agent already holds pairable is not ours to switch off.
+agent_log=$(bluetooth_pair_log yes)
+grep -q "pairable" "$agent_log" &&
+  fail "bluetooth leaves pairable alone when the agent already holds it" "$(cat "$agent_log")"
+pass "bluetooth leaves pairable alone when the agent already holds it"
 
 # Blocking hits every radio at once, so the read has to span them too. A bare
 # bluetoothctl show reports the default controller and misses a powered dongle.


### PR DESCRIPTION
## Problem

Bluetooth headphones paired from the Omarchy panel work once, then have to be forgotten and paired again every time they are powered on. "Connect" reports connected but no audio output appears.

Root cause: BlueZ only flags the adapter `Pairable` while a default agent is registered, and the non-interactive `bluetoothctl pair` that `omarchy-bluetooth-device` runs does not register one. Against a non-pairable adapter the kernel forces the "no bonding" authentication requirement (`hci_persistent_key` returns false), so pairing succeeds and audio plays, but the link key is never written to `/var/lib/bluetooth`. `bluetoothctl info` shows `Paired: yes` / `Bonded: no`. On the next reconnect the headphones reject the session-only key, BlueZ wipes the pairing, and the user is back to forget-and-pair.

`bt-agent.service` is what normally holds `Pairable`, but it is skipped whenever `/sys/class/bluetooth` or `bluetoothd` shows up after the user session starts, which is the normal case for a USB dongle:

```
bt-agent.service: skipped, unmet condition check ConditionPathIsDirectory=/sys/class/bluetooth
```

## Fix

`omarchy-bluetooth-device pair` raises `Pairable` around the pair handshake when nothing else holds it, and lowers it again afterwards. When the agent already holds it the script leaves it alone.

## Verification

- Reproduced on Omarchy 4.0.2, BlueZ 5.87, TP-Link UB500 (RTL8761BU), Bose QC35 II. With `bt-agent` stopped and `Pairable: no`, the stock script yields `Bonded: no` and no `[LinkKey]` on disk. The patched script yields `Bonded: yes`, a stored `[LinkKey]`, the PipeWire sink up, and `Pairable` restored to `no` afterwards. Subsequent power-cycles reconnect without re-pairing.
- `test/shell.d/bluetooth-test.sh` covers the ordering (pairable on before pair, off after) and the leave-alone case. `./test/cli` green.

The `bt-agent` startup race is a separate issue worth its own fix; this change makes bonding independent of it.

---

From Marcus (megamos): regards and thanks to DHH and the team. Loving Omarchy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BntCyAvwXhANA1b4UH9tek
