### PR TITLE
Support QVariantList in manifestHasKind for cloned menu plugins (#11190)

### DIFF
--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -198,8 +198,7 @@ ShellRoot {
 
   function isBarOptionManifest(manifest) {
     return manifest
-      && Array.isArray(manifest.kinds)
-      && manifest.kinds.indexOf("bar") !== -1
+      && shell.manifestHasKind(manifest, "bar")
       && manifest.entryPoints
       && manifest.entryPoints.bar
   }
@@ -347,8 +346,16 @@ ShellRoot {
   }
 
   function manifestHasKind(manifest, kind) {
-    return !!manifest && Array.isArray(manifest.kinds)
-      && manifest.kinds.indexOf(kind) !== -1
+    if (!manifest || !manifest.kinds) return false
+    var kinds = manifest.kinds
+    if (Array.isArray(kinds)) return kinds.indexOf(kind) !== -1
+    try {
+      if (typeof kinds.indexOf === "function") return kinds.indexOf(kind) !== -1
+      for (var i = 0; i < kinds.length; i++) {
+        if (kinds[i] === kind) return true
+      }
+    } catch (e) { }
+    return false
   }
 
   function pluginHasBarCapabilities(manifest) {

--- a/test/shell.d/plugin-auth-boundary-test.sh
+++ b/test/shell.d/plugin-auth-boundary-test.sh
@@ -62,6 +62,20 @@ assert(
   !store.has('omarchy.lock') && store.isTrusted('omarchy.lock'),
   'authentication classification survives service teardown'
 )
+
+const shellSource = fs.readFileSync(path.join(root, 'shell/shell.qml'), 'utf8')
+const fnMatch = shellSource.match(/function manifestHasKind\(manifest, kind\) \{[\s\S]*?\n {2}\}/)
+assert(fnMatch, 'manifestHasKind found in shell.qml')
+const manifestHasKind = new Function('manifest', 'kind', fnMatch[0].replace(/^function manifestHasKind\([^)]*\) \{/, '').replace(/\}$/, ''))
+
+assert(manifestHasKind({ kinds: ['menu', 'bar-widget'] }, 'menu') === true, 'manifestHasKind accepts array kinds')
+assert(manifestHasKind({ kinds: ['menu', 'bar-widget'] }, 'panel') === false, 'manifestHasKind rejects unmatched array kinds')
+const qvariantList = { 0: 'menu', 1: 'bar-widget', length: 2 }
+assert(Array.isArray(qvariantList) === false, 'qvariantList is not Array.isArray')
+assert(manifestHasKind({ kinds: qvariantList }, 'menu') === true, 'manifestHasKind accepts QVariantList / array-like kinds')
+assert(manifestHasKind({ kinds: qvariantList }, 'panel') === false, 'manifestHasKind rejects unmatched QVariantList kinds')
+assert(manifestHasKind(null, 'menu') === false, 'manifestHasKind handles null manifest')
+assert(manifestHasKind({}, 'menu') === false, 'manifestHasKind handles missing kinds')
 JS
 
 qml_matches "$shell_qml" 'inst\.shell *= *shell\.pluginShellFor\( *manifest *\)' ||


### PR DESCRIPTION
Resolves #11190

### Problem
In 4.0.3, panel and menu plugins are loaded through an `Instantiator` model (`shell.panelEntries`). When the manifest round-trips through the model, its nested `kinds` array is adapted as a `QVariantList`. In QML's JavaScript engine, `Array.isArray(qvariantlist)` evaluates to `false`.

As a result:
1. `shell.manifestHasKind(manifest, 'menu')` returned `false`.
2. `PluginShellApi` injected `appLibrary` as `null` for cloned / third-party menu plugins.
3. `Menu.qml:291` (`if (!root.appLibrary) return`) bailed, causing cloned menus to display an empty "Nothing here yet" Apps submenu.

First-party plugins were unaffected because `pluginShellFor` short-circuits on `__isFirstParty` and returns the raw `shell` object directly.

### Solution
1. **shell.qml**: Update `manifestHasKind()` to tolerate both native `Array` instances and array-like / `QVariantList` objects with `length` and index properties.
2. **shell.qml**: Update `isBarOptionManifest()` to use `manifestHasKind(manifest, 'bar')` for consistent kind resolution across boundaries.
3. **test/shell.d/plugin-auth-boundary-test.sh**: Add unit tests verifying `manifestHasKind` correctly matches kinds on both native `Array` and `QVariantList` shapes.