### PR TITLE
Fix default tmux splits to preserve the current directory

### DIFF
--- a/config/tmux/tmux.conf
+++ b/config/tmux/tmux.conf
@@ -13,6 +13,8 @@ bind -N "Begin selection" -T copy-mode-vi v send -X begin-selection
 bind -N "Copy selection" -T copy-mode-vi y send -X copy-selection-and-cancel
 
 # Pane Controls
+bind -N "Split pane vertically" '"' split-window -v -c "#{pane_current_path}"
+bind -N "Split pane horizontally" % split-window -h -c "#{pane_current_path}"
 bind -N "Split pane vertically" -n M-Enter split-window -v -c "#{pane_current_path}"
 bind -N "Split pane horizontally" -n M-S-Enter split-window -h -c "#{pane_current_path}"
 bind -N "Kill pane" -n M-Escape kill-pane


### PR DESCRIPTION
## Summary

Bind the standard prefix + `%` and prefix + `"` split shortcuts with `-c "#{pane_current_path}"`, matching the existing Omarchy custom split shortcuts and their descriptive binding style.

Without this override, the standard shortcuts use tmux’s default starting directory rather than the active pane’s current directory. This makes the result depend on which split shortcut is used.

## Reproduction

1. Start a tmux session in one directory.
2. Change to a different directory in the active pane.
3. Split with prefix + `%` or prefix + `"`.
4. Run `pwd` in the new pane. It should match the source pane, as it already does with the custom `h`/`v` shortcuts.

This updates the default config. Existing users can add the two bindings to their config and reload it; no automatic migration of user keybindings is included.

## Verification

- Loaded the updated config into an isolated tmux server, with a session starting in `/` and its source pane running in a different directory. Executed each loaded split binding’s command and verified both child panes inherited the source directory.
- `git diff --check` passed.
- Ran `./test/all`: CLI suite passed; shell suite reported 5 failures out of 236 test files:
  - `config-test.sh`, `snapper-test.sh`, and `unowned-system-paths-test.sh`: missing companion `omarchy-pkgs` checkout. Reproduced on unchanged upstream.
  - `screenshot-sanity-test.sh`: screenshot capture failed with a jq parsing error. Reproduced on unchanged upstream.
  - `locate-test.sh`: UTF-8 decoding error while scanning runtime files during the aggregate run. A clean upstream worktree passed the focused test; the aggregate run left an ignored `bin/__pycache__/` directory in its checkout.
