### PR TITLE
Add GTK_IM_MODULE to fcitx environment defaults

### DIFF
--- a/default/environment.d/10-omarchy-fcitx.conf
+++ b/default/environment.d/10-omarchy-fcitx.conf
@@ -1,4 +1,5 @@
 INPUT_METHOD=fcitx
+GTK_IM_MODULE=fcitx
 QT_IM_MODULE=fcitx
 XMODIFIERS=@im=fcitx
 SDL_IM_MODULE=fcitx


### PR DESCRIPTION
## What

`default/environment.d/10-omarchy-fcitx.conf` sets `INPUT_METHOD`,
`QT_IM_MODULE`, `XMODIFIERS`, and `SDL_IM_MODULE` for fcitx5, but not
`GTK_IM_MODULE`. This adds it.

## Why

Without `GTK_IM_MODULE`, GTK-based and Chromium/Electron apps fall back
to the legacy XIM input protocol instead of fcitx5's module. XIM has a
long-documented history of dropped/eaten keystrokes under fcitx
(fcitx/fcitx5#1000 and others), and since the manual notes fcitx5 runs
"as part of every session" on Omarchy — not just for users who've added
a CJK input engine — this affects any GTK/Electron app on a stock
install, whether or not the user ever touches input methods.

I ran into this as consistently dropped characters in an Electron app
(Dabble, a writing app) — worse specifically when its live spellcheck
was on, which makes sense: spellcheck triggers far more IME
composition-state queries than plain typing, and that extra traffic is
exactly what the XIM fallback path handles poorly.

## Verification

- Confirmed `GTK_IM_MODULE` was unset in a live session while the other
  three variables were present, tracing back to this file.
- Added `GTK_IM_MODULE=fcitx` via a user-level `environment.d` override,
  logged out and back in, and the dropped-keystroke behavior in the
  affected app went away with spellcheck re-enabled.
- `./test/all` passes (`test/cli`, `test/shell` both green after fixing
  an unrelated local `mise` node-version gap in my dev environment).

Happy to add anything else that would help evaluate this for a future
dot release.