### PR TITLE
Fail migrations when a pacman transaction outlasts the wait

### DIFF
--- a/bin/omarchy-migrate
+++ b/bin/omarchy-migrate
@@ -66,7 +66,7 @@ if [[ $mode == "pending" ]]; then
 fi
 
 wait_for_pacman_transaction() {
-  local lock_file=/var/lib/pacman/db.lck
+  local lock_file="${OMARCHY_PACMAN_LOCK:-/var/lib/pacman/db.lck}"
 
   [[ -e $lock_file ]] || return 0
   echo "Waiting for pacman transaction to finish before running Omarchy migrations..."
@@ -76,8 +76,10 @@ wait_for_pacman_transaction() {
     sleep 1
   done
 
-  echo "Pacman transaction is still running; Omarchy migrations will retry on next login."
-  exit 0
+  # Not exit 0: omarchy-update runs this between the package transaction and
+  # its post-update hooks, and a zero here reads as "migrations applied".
+  echo "Pacman transaction is still running; Omarchy migrations did not run. Retry once it finishes." >&2
+  exit 1
 }
 
 wait_for_pacman_transaction

--- a/test/shell.d/migrate-wrapper-test.sh
+++ b/test/shell.d/migrate-wrapper-test.sh
@@ -56,3 +56,21 @@ if run_migrate --force >"$test_tmp/force.out" 2>&1; then
 fi
 grep -q 'Unknown option: --force' "$test_tmp/force.out" || fail "omarchy-migrate reports obsolete --force option"
 pass "omarchy-migrate no longer needs --force"
+
+# A transaction that outlasts the wait has to fail rather than look applied:
+# omarchy-update runs this between the package transaction and its post-update
+# hooks, so a zero here took the update on against un-migrated state.
+ln -s /bin/true "$stub_bin/sleep"
+lock_file="$test_tmp/db.lck"
+: >"$lock_file"
+rm -rf "$test_home/.local/state/omarchy/migrations"
+: >"$test_tmp/calls"
+
+if OMARCHY_PACMAN_LOCK="$lock_file" run_migrate >"$test_tmp/locked.out" 2>&1; then
+  fail "omarchy-migrate fails when the pacman transaction outlasts the wait"
+fi
+[[ ! -s $test_tmp/calls ]] || fail "omarchy-migrate runs no migration while pacman holds its lock"
+grep -q 'Omarchy migrations did not run' "$test_tmp/locked.out" ||
+  fail "omarchy-migrate says the migrations did not run" "$(cat "$test_tmp/locked.out")"
+run_migrate --pending >/dev/null || fail "omarchy-migrate leaves the migration pending after a locked run"
+pass "omarchy-migrate fails instead of skipping migrations under a pacman lock"


### PR DESCRIPTION
`wait_for_pacman_transaction` gave up after 900s with `exit 0`, so a caller could not tell "no migrations were pending" from "migrations never ran".

`omarchy-update` runs `omarchy-migrate` between the package transaction and its post-update hooks, and took that zero as success: it went on to `omarchy-hook post-update`, `omarchy-update-status` and `omarchy-update-restart` against un-migrated state. That is the opposite of what the comment above the call asks for — "everything below waits on this finishing".

Exiting 1 is what every caller already wants:

- `bin/omarchy-update:48` stops on it through its own `set -e` and ERR trap.
- `bin/omarchy-upgrade-to-quattro:1199` already wraps the call in `if ! ... then fail`.
- `bin/omarchy-migrate-notify` only ever calls `--pending`, which returns before the wait.
- An interactive run (the notification opens a terminal on `omarchy-migrate`) still prints why it stopped.

Migration markers stay missing either way, so nothing is lost and the login notifier still prompts. The message no longer promises a retry "on next login", which was only true for one of those callers.

The lock path takes an `OMARCHY_PACMAN_LOCK` override so the timeout branch is testable at all. That matches `OMARCHY_MIGRATION_STATE` a few lines above it in the same script, and the `OMARCHY_*_PATH` overrides its siblings use for `/sys` reads.

`test/shell.d/migrate-wrapper-test.sh` gains coverage for the branch: it asserts the non-zero exit, that no migration ran, that the reason is printed, and that the migration is still pending afterwards. The file runs in ~1s. It fails on `quattro` and passes with the change; `./test/shell` and `./test/cli` show no other difference from the branch point.
