### PR TITLE
Exit cleanly when the update log is missing

### DIFF
--- a/bin/omarchy-update-analyze-logs
+++ b/bin/omarchy-update-analyze-logs
@@ -4,6 +4,11 @@
 
 update_log="/tmp/omarchy-update.log"
 
+if [[ ! -f $update_log ]]; then
+  echo "No update log found; nothing to analyze."
+  exit 0
+fi
+
 # Check for initramfs generation failure
 if grep -q "Updating linux initcpios" "$update_log"; then
   if ! grep -q "Initcpio image generation successful" "$update_log"; then

--- a/test/shell.d/update-analyze-logs-test.sh
+++ b/test/shell.d/update-analyze-logs-test.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+script="$ROOT/bin/omarchy-update-analyze-logs"
+missing_log="$test_tmp/omarchy-update.log"
+
+# The production path is /tmp/omarchy-update.log. Isolate this run from a
+# leftover host transcript by pointing TMPDIR away and relying on the script's
+# missing-file branch (it hardcodes /tmp). We only assert missing-file behavior
+# by copying the script into a wrapper that substitutes the log path.
+
+wrapper="$test_tmp/analyze"
+sed "s|/tmp/omarchy-update.log|$missing_log|" "$script" >"$wrapper"
+chmod +x "$wrapper"
+
+out=$("$wrapper")
+[[ $out == "No update log found; nothing to analyze." ]] ||
+  fail "analyze logs reports a clean miss when the update log is absent" "$out"
+pass "analyze logs reports a clean miss when the update log is absent"
+
+printf '%s\n' "Updating linux initcpios" >"$missing_log"
+out=$("$wrapper")
+[[ $out == *$'\e[31mError: Initramfs generation may have failed. Review logs before restart.\e[0m'* ]] ||
+  fail "analyze logs still flags a failed initramfs when the log exists" "$out"
+pass "analyze logs still flags a failed initramfs when the log exists"
+
+printf '%s\n' "Updating linux initcpios" "Initcpio image generation successful" >"$missing_log"
+out=$("$wrapper")
+[[ -z $out ]] || fail "analyze logs stays quiet on a successful initramfs" "$out"
+pass "analyze logs stays quiet on a successful initramfs"


### PR DESCRIPTION
## Why

`omarchy update analyze logs` is a standalone command. When `/tmp/omarchy-update.log` does not exist (fresh boot, never updated this session), the script greps it anyway and dumps:

```
grep: /tmp/omarchy-update.log: No such file or directory
```

Fixes omacom/omarchy#11204.

## What

Check the log exists first. Print `No update log found; nothing to analyze.` and exit 0. Existing initramfs checks are unchanged.

## Proof

`test/shell.d/update-analyze-logs-test.sh` covers missing file, failed initramfs, and successful initramfs.

Does not ping maintainers.