### PR TITLE
Stop the bootstrap migration truncating a customized hyprland.lua

### DIFF
--- a/migrations/1781063758.sh
+++ b/migrations/1781063758.sh
@@ -4,11 +4,10 @@ hyprland_config="$HOME/.config/hypr/hyprland.lua"
 
 if [[ -f $hyprland_config ]] && ! grep -Fq '/default/hypr/bootstrap.lua' "$hyprland_config"; then
   tmp=$(mktemp)
+  consumed=$(mktemp)
 
-  awk '
-    BEGIN {
-      replaced = 0
-    }
+  awk -v consumed="$consumed" '
+    BEGIN { replaced = 0 }
 
     !replaced && $0 == "-- Load user modules from ~/.config and Omarchy defaults from $OMARCHY_PATH." {
       comment = $0
@@ -18,24 +17,54 @@ if [[ -f $hyprland_config ]] && ! grep -Fq '/default/hypr/bootstrap.lua' "$hyprl
         print "dofile((os.getenv(\"OMARCHY_PATH\") or \"/usr/share/omarchy\") .. \"/default/hypr/bootstrap.lua\")"
         replaced = 1
 
+        # The assignment ends where its continuations do, however the user has
+        # wrapped it. Anything else is the next statement and is printed, not
+        # dropped: looking for one exact terminator line ran to EOF and took
+        # the rest of the config with it.
         while ((getline line) > 0) {
-          if (line ~ /^[[:space:]]*\.\. package\.path$/) {
-            break
+          if (line ~ /^[[:space:]]*\.\./ || line ~ /^[[:space:]]*package\.path[[:space:]]*$/) {
+            print line > consumed
+            continue
           }
+          print line
+          break
         }
 
         next
       }
 
       print comment
-      if (got_next > 0) {
-        print next_line
-      }
+      if (got_next > 0) { print next_line }
       next
     }
 
     { print }
   ' "$hyprland_config" >"$tmp"
 
-  mv "$tmp" "$hyprland_config"
+  # Keep a copy only when the preamble was not the shipped one, so a path entry
+  # the user added is recoverable rather than absorbed without trace.
+  stock=$(mktemp)
+  cat >"$stock" <<'STOCK'
+  .. "/.config/?.lua;"
+  .. (os.getenv("OMARCHY_PATH") or "/usr/share/omarchy")
+  .. "/?.lua;"
+  .. package.path
+STOCK
+
+  if cmp -s "$tmp" "$hyprland_config"; then
+    # No preamble of the shape this migration rewrites, so there is nothing to
+    # replace and nothing to keep a copy of.
+    rm -f "$tmp"
+  else
+    if ! cmp -s "$consumed" "$stock"; then
+      backup="$hyprland_config.omarchy-bootstrap.bak"
+      cp "$hyprland_config" "$backup"
+      echo "Your hyprland.lua set package.path itself; the bootstrap owns that now."
+      echo "Saved your previous file as $backup."
+    fi
+
+    mv "$tmp" "$hyprland_config"
+  fi
+
+  rm -f "$consumed" "$stock"
 fi

--- a/test/shell.d/hyprland-bootstrap-migration-test.sh
+++ b/test/shell.d/hyprland-bootstrap-migration-test.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+migration="$ROOT/migrations/1781063758.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+# Writes the given hyprland.lua into a fresh fake $HOME and runs the migration
+# there. Echoes the config path so assertions can read what it produced.
+run_migration() {
+  local name="$1" home="$test_tmp/$1"
+
+  rm -rf "$home"
+  mkdir -p "$home/.config/hypr"
+  cat >"$home/.config/hypr/hyprland.lua"
+  cp "$home/.config/hypr/hyprland.lua" "$test_tmp/$name.original"
+
+  HOME="$home" OMARCHY_PATH="$ROOT" bash -euo pipefail "$migration" >"$test_tmp/$name.out" 2>&1 ||
+    fail "migration succeeds on $name" "$(cat "$test_tmp/$name.out")"
+
+  printf '%s\n' "$home/.config/hypr/hyprland.lua"
+}
+
+shipped_preamble() {
+  cat <<'LUA'
+-- Load user modules from ~/.config and Omarchy defaults from $OMARCHY_PATH.
+package.path = os.getenv("HOME")
+  .. "/.config/?.lua;"
+  .. (os.getenv("OMARCHY_PATH") or "/usr/share/omarchy")
+  .. "/?.lua;"
+  .. package.path
+LUA
+}
+
+body() {
+  cat <<'LUA'
+
+require("default.hypr.omarchy")
+require("hypr.monitors")
+hl.bind({ "SUPER", "T", "exec", "kitty" })
+LUA
+}
+
+# The shipped preamble is replaced and nothing else in the file moves.
+config=$({ shipped_preamble; body; } | run_migration shipped)
+grep -Fq 'dofile((os.getenv("OMARCHY_PATH") or "/usr/share/omarchy") .. "/default/hypr/bootstrap.lua")' "$config" ||
+  fail "migration installs the bootstrap dofile"
+grep -Fqx 'require("hypr.monitors")' "$config" || fail "migration keeps the user's requires"
+grep -Fq 'package.path' "$config" && fail "migration removes the old path preamble"
+[[ ! -e $config.omarchy-bootstrap.bak ]] || fail "a shipped preamble leaves no backup behind"
+pass "migration rewrites a shipped preamble and leaves the rest alone"
+
+# Running it again is a no-op: the guard sees the bootstrap is already there.
+cp "$config" "$test_tmp/shipped.after"
+HOME="$test_tmp/shipped" OMARCHY_PATH="$ROOT" bash -euo pipefail "$migration" >/dev/null 2>&1
+cmp -s "$config" "$test_tmp/shipped.after" || fail "migration is idempotent"
+pass "migration leaves an already-migrated config untouched"
+
+# A config that never carried this preamble is not this migration's business:
+# it must come out byte for byte, with no copy left beside it.
+config=$(body | run_migration foreign)
+cmp -s "$config" "$test_tmp/foreign.original" || fail "an unrelated config is left byte for byte"
+[[ ! -e $config.omarchy-bootstrap.bak ]] || fail "an unrelated config gets no backup"
+[[ ! -s $test_tmp/foreign.out ]] ||
+  grep -Fqv 'Saved your previous file' "$test_tmp/foreign.out" ||
+  fail "an unrelated config draws no backup notice"
+pass "migration ignores a config it has nothing to rewrite"
+
+# A user who wrapped the assignment differently: the terminator line the old
+# awk looked for is not there verbatim, and everything after it used to be
+# swallowed to EOF, leaving a two-line config.
+config=$({
+  cat <<'LUA'
+-- Load user modules from ~/.config and Omarchy defaults from $OMARCHY_PATH.
+package.path = os.getenv("HOME")
+  .. "/.config/?.lua;"
+  .. (os.getenv("OMARCHY_PATH") or "/usr/share/omarchy") .. "/?.lua;" .. package.path
+LUA
+  body
+} | run_migration rewrapped)
+grep -Fqx 'require("hypr.monitors")' "$config" || fail "a rewrapped assignment keeps the user's requires"
+grep -Fqx 'hl.bind({ "SUPER", "T", "exec", "kitty" })' "$config" ||
+  fail "a rewrapped assignment keeps the user's own lines"
+pass "migration keeps the config when the assignment is wrapped differently"
+
+# A user who appended their own path entry: that entry belongs to the
+# assignment the bootstrap now owns, so it goes -- but the whole original file
+# has to stay recoverable rather than being absorbed without trace.
+config=$({
+  shipped_preamble
+  printf '%s\n' '  .. ";" .. os.getenv("HOME") .. "/dotfiles/?.lua"'
+  body
+} | run_migration extended)
+grep -Fqx 'require("hypr.monitors")' "$config" || fail "an extended path keeps the user's requires"
+grep -Fq '.. ";" .. os.getenv("HOME")' "$config" &&
+  fail "an extended path is not left dangling after the dofile"
+[[ -f $config.omarchy-bootstrap.bak ]] || fail "an extended path is backed up"
+cmp -s "$config.omarchy-bootstrap.bak" "$test_tmp/extended.original" ||
+  fail "the backup is the file as it was before the migration"
+grep -Fq "$config.omarchy-bootstrap.bak" "$test_tmp/extended.out" ||
+  fail "the migration says where the backup went"
+pass "migration backs up a customized preamble instead of absorbing it"


### PR DESCRIPTION
Fixes #7103.

The migration replaces the `package.path` preamble with the bootstrap `dofile`, then swallows lines until one matches `.. package.path` exactly. A user who wrapped that assignment any other way has no such line, so `getline` runs to EOF and the `mv` at the end puts a two-line config over theirs — every `require`, bind and monitor gone, no backup. Snapper does not cover it either: Omarchy configures the root subvolume only, so `/home` is not in the pre-update snapshot.

Reproduced on `quattro` against the pre-bootstrap preamble as it shipped (`64581ec2^`), counting `require(` lines before and after:

```
                            before          after this change
shipped preamble         10→6  2→2 ✓        10→6  2→2 ✓   (byte identical output)
tail folded onto one line 8→2  2→0 ✗         8→6  2→2 ✓
own path entry appended  11→7  2→2 (*)      11→6  2→2 ✓
trailing ".." style        8→2  2→0 ✗         8→6  2→2 ✓

(*) not truncated, but the user's `.. ";" ..` line is left dangling right
    after the dofile, so the config no longer parses.
```

`package.path = ...` is one statement and its continuation lines all begin with `..`, so the assignment ends where those end. Consuming those and printing the first line that is not one replaces exactly the preamble, whatever shape it is in, and cannot run past it.

An appended path entry does belong to the assignment the bootstrap now owns, so it goes with it. Rather than absorbing it without trace, the file is copied to `hyprland.lua.omarchy-bootstrap.bak` first and the migration prints where — the way `1786643346` keeps its own repair backup. A shipped preamble leaves no copy behind, and a config this migration has nothing to rewrite comes out byte for byte with no copy and no notice.

`test/shell.d/hyprland-bootstrap-migration-test.sh` covers the five cases: shipped preamble, rerun, unrelated config, rewrapped assignment, appended path entry (asserting the backup matches the original file). It fails on `quattro` and passes with the change. `./test/shell` and `./test/cli` show no other difference from the branch point.

Migrations are kept for late updaters, so this still runs, including inside `omarchy-upgrade-to-quattro`. It cannot help anyone whose file it has already cut.
