### PR TITLE
Refuse a theme with no palette instead of applying it

### DIFF
--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -315,6 +315,18 @@ if [[ ! -f $NEXT_THEME_PATH/colors.toml && -f $NEXT_THEME_PATH/alacritty.toml ]]
   omarchy-theme-colors-from-alacritty "$NEXT_THEME_PATH"
 fi
 
+# Every generated theme file comes from the palette, and foot's include of the
+# generated foot.ini is not optional the way ghostty's config-file is. Staging a
+# theme that has no palette therefore leaves the default terminal unable to
+# start, with no terminal left to set a working theme from. Refuse before the
+# swap so the theme that is already applied stays applied.
+if [[ ! -f $NEXT_THEME_PATH/colors.toml ]]; then
+  echo "Theme '$THEME_NAME' has no colors.toml, so none of its theme files can be generated." >&2
+  echo "A theme needs colors.toml, or an alacritty.toml to derive one from." >&2
+  rm -rf "$NEXT_THEME_PATH"
+  exit 1
+fi
+
 # Generate dynamic configs
 omarchy-theme-set-templates
 

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -22,7 +22,7 @@ A theme installed from a git repo is held to a much shorter list; see [What an i
 
 1. Copy the first-party theme from `themes/<name>/`.
 2. Overlay `~/.config/omarchy/themes/<name>/`, in full when the user wrote it and filtered when it came from a git repo, naming anything it dropped on stderr.
-3. If needed, generate `colors.toml` from `alacritty.toml`.
+3. If needed, generate `colors.toml` from `alacritty.toml`. A theme that still has no palette is refused here, before anything is swapped in.
 4. Run `omarchy-theme-set-templates` to render templates into the staging
    theme.
 5. Move the staging theme into `~/.local/state/omarchy/current/theme`, write

--- a/test/shell.d/theme-palette-required-test.sh
+++ b/test/shell.d/theme-palette-required-test.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Every generated theme file comes from the palette, and foot's include of the
+# generated foot.ini is not optional. A theme with no palette therefore has to
+# be refused at staging rather than swapped in, or the default terminal stops
+# starting and there is no terminal left to set a working theme from.
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+home="$test_tmp/home"
+state="$home/.local/state/omarchy/current"
+themes="$home/.config/omarchy/themes"
+mkdir -p "$state" "$themes"
+
+set_theme() {
+  HOME="$home" OMARCHY_PATH="$ROOT" PATH="$ROOT/bin:$PATH" \
+    OMARCHY_THEME_HEADLESS=1 OMARCHY_THEME_SKIP_BACKGROUND=1 \
+    XDG_RUNTIME_DIR="$test_tmp" \
+    bash "$ROOT/bin/omarchy-theme-set" "$1" >"$test_tmp/stdout" 2>"$test_tmp/stderr"
+}
+
+write_colors() {
+  cat >"$themes/$1/colors.toml" <<'TOML'
+background = "#1a1b26"
+foreground = "#c0caf5"
+accent = "#7aa2f7"
+TOML
+}
+
+# A theme carrying a palette applies, and the terminal config the palette is
+# there to generate lands with it.
+mkdir -p "$themes/with-palette"
+write_colors with-palette
+set_theme with-palette || fail "a theme with colors.toml applies" "$(cat "$test_tmp/stderr")"
+[[ -f $state/theme/colors.toml ]] || fail "the applied theme keeps its palette"
+[[ -f $state/theme/foot.ini ]] || fail "the applied theme generates foot.ini"
+pass "a theme with a palette applies and generates its terminal config"
+
+# Now the case from the report: a theme directory carrying neither colors.toml
+# nor an alacritty.toml to derive one from.
+applied_before=$(cat "$state/theme.name")
+mkdir -p "$themes/no-palette"
+printf '%s\n' 'general { col.active_border = rgb(ffffff) }' >"$themes/no-palette/hyprland.conf"
+
+if set_theme no-palette; then
+  fail "a theme with no palette is refused" "$(cat "$test_tmp/stdout" "$test_tmp/stderr")"
+fi
+grep -Fq 'colors.toml' "$test_tmp/stderr" || fail "the refusal names colors.toml" "$(cat "$test_tmp/stderr")"
+pass "a theme with no palette is refused instead of applied"
+
+# The refusal has to be inert: the theme that was working stays working, and no
+# staging directory is left behind to be picked up as a half-applied theme.
+[[ $(cat "$state/theme.name") == "$applied_before" ]] ||
+  fail "a refused theme leaves the applied theme alone"
+[[ -f $state/theme/foot.ini ]] || fail "a refused theme leaves the generated terminal config in place"
+[[ ! -e $state/next-theme ]] || fail "a refused theme leaves no staging directory behind"
+pass "a refused theme changes nothing that was already applied"


### PR DESCRIPTION
Fixes #7105.

Every generated theme file comes from `colors.toml`, and `omarchy-theme-set-templates` only renders when the staged theme has one (`bin/omarchy-theme-set-templates:371`). A theme directory carrying neither `colors.toml` nor an `alacritty.toml` to derive one from therefore stages with no `foot.ini`, `alacritty.toml`, `kitty.conf` or `shell.toml` at all — and `omarchy theme set` still exits 0 without saying anything.

Reproduced on `quattro` with the report's own case:

```
$ mkdir -p ~/.config/omarchy/themes/qa-legacy
$ echo 'general { col.active_border = rgb(ffffff) }' > ~/.config/omarchy/themes/qa-legacy/hyprland.conf
$ omarchy theme set qa-legacy; echo "rc=$?"
rc=0

$ ls -A ~/.local/state/omarchy/current/theme
hyprland.conf
```

`config/foot/foot.ini:2` includes that missing `foot.ini` unconditionally and foot treats a missing include as fatal, so the default terminal stops starting. The siblings survive it — ghostty uses the optional `config-file = ?"..."` form, kitty and alacritty warn — and since `default/xdg-terminal-exec` makes foot the default terminal, there is no terminal left to set a working theme from.

The check goes at staging, after the `alacritty.toml` fallback has had its turn and before the swap, so the theme that is already applied stays applied. `docs/theming.md` keeps this kind of restriction in `omarchy-theme-set` rather than `omarchy-theme-install` on purpose ("Filtering at staging also covers themes installed before the rule existed and files a theme gains later through `omarchy theme update`"), and the same reasoning applies here: `omarchy theme install` clones any git URL and applies it immediately.

All 22 shipped themes carry `colors.toml`, and a user theme sharing a name with a first-party one still picks up the first-party palette at step 1, so neither path changes.

`test/shell.d/theme-palette-required-test.sh` covers the three outcomes: a theme with a palette applies and generates its terminal config, a theme without one is refused with `colors.toml` named in the message, and the refusal leaves the applied theme, its generated files and the staging directory exactly as they were. It fails on `quattro` and passes with the change.

Suites were run on Linux: `./test/shell` and `./test/cli` show no difference from the branch point. Like `theme-staging-test.sh`, the new file needs the template pipeline, so it does not run on a non-Arch host.
