### PR TITLE
Document Dell XPS 13 silent speaker recovery

### DIFF
--- a/manual/45-troubleshooting.md
+++ b/manual/45-troubleshooting.md
@@ -34,6 +34,51 @@ Probably because they're not set as the primary output. Click on the speaker ico
 
 On some laptops, Omarchy automatically applies a speaker tuning that corrects the built-in speakers' frequency response. `omarchy audio tuning status` tells you whether one is active on your machine, and `omarchy audio tuning off` turns it off if you'd rather hear the speakers raw.
 
+### My Dell XPS 13 speakers went silent after an update
+
+On the **XPS 13 DX13260, SKU 0E53**, enabling the CS35L56 sidecar amplifiers can leave the internal speakers silent when their firmware fails to load. Linux 7.2 enables these amplifiers for this model by default; the `dell-xps13-sidecar-amps` package enables them on earlier kernels. PipeWire can still show a selected, unmuted Speaker output with applications playing normally.
+
+Check the model and the current boot's kernel log:
+
+```bash
+cat /sys/class/dmi/id/product_name /sys/class/dmi/id/product_sku
+journalctl -k -b --no-pager | grep -E 'cs35l56.*(FIRMWARE_MISSING|Calibration disabled|Can.t read tuning IDs)'
+```
+
+If this exact model previously played sound and now has these errors, a temporary fallback is to restore the earlier codec speaker path. This bypasses the sidecar amplifiers, so bass and output quality can be reduced. It does not repair the amplifier firmware. Do not apply it to other models or to speakers that already work.
+
+Create the override below, then rebuild the boot images. The filename intentionally matches the packaged sidecar override: a file in `/etc/modprobe.d` takes precedence over the same name in `/usr/lib/modprobe.d`. The command refuses to overwrite an existing local file; if one exists, inspect and back it up before changing it. Also check for any other local `snd_soc_sof_sdw` quirk overrides, which must not conflict with this one.
+
+```bash
+(
+  set -euo pipefail
+  omarchy-hw-dell-xps13-sidecar-amps
+  config=/etc/modprobe.d/dell-xps13-sidecar-amps.conf
+  if sudo test -e "$config"; then
+    echo "Existing override: $config. Inspect it before proceeding."
+    exit 1
+  fi
+  printf '%s\n' '# Temporary DX13260 speaker fallback; remove when amplifier support is fixed.' \
+    'options snd_soc_sof_sdw quirk=1' | sudo tee "$config" >/dev/null
+  sudo limine-mkinitcpio
+)
+```
+
+Only reboot once the rebuild finishes successfully. Save your work, reboot, and test the speakers. The following should report `1`, and the boot log should show `Overriding quirk 0x10000 => 0x1`:
+
+```bash
+cat /sys/module/snd_soc_sof_sdw/parameters/quirk
+journalctl -k -b --no-pager | grep 'Overriding quirk'
+```
+
+To undo **the file created above**, remove it and rebuild again, then reboot:
+
+```bash
+sudo rm /etc/modprobe.d/dell-xps13-sidecar-amps.conf && sudo limine-mkinitcpio
+```
+
+Removing the sidecar package alone will not restore the earlier routing on Linux 7.2, which enables it in the driver itself. Avoid substituting another speaker variant's firmware: Cirrus has [explained that the tuning is specific to the fitted speaker hardware](https://lore.kernel.org/linux-firmware/000b01dd3ac6$39c46210$ad4d2630$@opensource.cirrus.com/). See [#9687](https://github.com/omacom/omarchy/issues/9687) and [#10543](https://github.com/omacom/omarchy/issues/10543) for the amplifier firmware reports.
+
 ### Why can't I login or sudo with my password?
 
 You probably typed it wrong too many times and got locked out. If this is happening on the lock screen, you can hit `CTRL + ALT + F2` to start a new TTY where you can login as root, then run `faillock --reset --user [your-username]`. That'll reset the lockout, and you're good to go.


### PR DESCRIPTION
On a Dell XPS 13 DX13260 (SKU 0E53), running Omarchy 4.0.3-1, upgrading from Linux 7.1.9 to 7.2.3 changed working speaker playback into complete silence. The Speaker sink and Chrome stream remained selected, active, and unmuted, while both CS35L56 amplifiers reported `FIRMWARE_MISSING`, disabled calibration, and missing tuning IDs.

Document an opt-in fallback to `snd_soc_sof_sdw quirk=1`, restoring the earlier codec speaker path. Include the exact hardware and error checks, a local override that shadows the packaged sidecar configuration, boot-image rebuilding, post-reboot verification, and removal instructions. Explain that this bypasses the sidecar amplifiers and may reduce bass/output quality; it does not fix their firmware or justify substituting another speaker variant's tuning. No automatic hardware changes are introduced.

Validation on the affected laptop: after applying `quirk=1` and rebooting on the same 7.2.3 kernel, the log reports `Overriding quirk 0x10000 => 0x1`, the sidecar firmware errors are absent, and the owner confirmed audible speaker playback. The exact speaker ID was not captured, so this report does not assert that this particular unit is spkid0.

Related: #9687, #10543, #10987; follows the hardware enablement in #7032. These are related reports, not issues this documentation fully resolves.

Checks:
- Shell syntax validation for all added command blocks.
- Executed the installation block with stubbed hardware and privileged commands: matching hardware, non-matching hardware, pre-existing override, and failed boot-image rebuild.
- `./test/all`: CLI suite passed; shell suite completed with 9 of 236 files failing in this sandbox (`bar-icon-geometry`, `config`, `launch-about`, `locate`, `manifest-entrypoints`, `runtime-smoke`, `screenshot-sanity`, `snapper`, `unowned-system-paths`). Output includes unavailable graphics/runtime paths, missing sibling `omarchy-pkgs` checkout, and a locale decoding error. The existing XPS 13 sidecar tests passed. This PR changes only the manual; none of these test files or their implementation code is changed.
- `git diff --check` passed.

Prepared with Codex; playback verification was performed by the laptop owner.
