### PR TITLE
Stop speedtest workers when their parent is killed

### DIFF
--- a/bin/omarchy-network-speedtest
+++ b/bin/omarchy-network-speedtest
@@ -66,19 +66,25 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# The workers below outlive a hard kill of this script: a caller that kills the
+# process outright (for example the shell unloading the speedtest overlay) never
+# runs the EXIT trap, so without a parent check they would keep downloading
+# forever. Capturing the PID here lets each worker stop once the parent is gone.
+parent_pid=$$
+
 # Round-robin across the returned URLs so we spread load across Netflix OCA nodes.
 traffic_worker() {
   local urls=("$@")
   local url_count=${#urls[@]}
   local idx=$RANDOM
   if [[ $direction == "down" ]]; then
-    while true; do
+    while kill -0 "$parent_pid" 2>/dev/null; do
       url=${urls[$((idx % url_count))]}
       curl -fsS -o /dev/null "$url" 2>/dev/null || return
       idx=$((idx + 1))
     done
   else
-    while true; do
+    while kill -0 "$parent_pid" 2>/dev/null; do
       url=${urls[$((idx % url_count))]}
       dd if=/dev/zero bs=1M count=64 2>/dev/null | curl -fsS -o /dev/null -X POST --data-binary @- "$url" 2>/dev/null || return
       idx=$((idx + 1))


### PR DESCRIPTION
## Problem

Dismissing the internet speed test overlay can leave its workers running indefinitely, keeping the link saturated until they are killed by hand. This is easy to hit from the network panel's speed test button: run a test, close the overlay, and the traffic continues.

## Root cause

`omarchy-network-speedtest` spawns `parallel=8` background subshells (`traffic_worker`), and those workers only stop when the parent's `EXIT` trap (`cleanup`) runs. When the overlay is dismissed, the shell unloads the panel and kills the direct child outright, so the trap never runs and the workers are orphaned (reparented to init). They keep downloading/uploading forever.

Confirmed by reproducing the two paths directly:

- `kill -TERM <parent>` -> the `EXIT` trap runs -> 0 leftover processes.
- `kill -KILL <parent>` -> 8 orphaned workers, still pulling traffic.

## Fix

Each worker now loops on `kill -0 "$parent_pid"` and exits once the parent is gone, so a hard kill can no longer leave them behind.

```bash
parent_pid=$$
...
while kill -0 "$parent_pid" 2>/dev/null; do
```

## Testing

- Reproduced the orphaned workers before the change (`kill -KILL` left 8 running), and confirmed 0 leftovers after.
- `bash -n bin/omarchy-network-speedtest` passes.
- `./test/cli` passes.
- `./test/all` still reports the same pre-existing shell-suite failures on this machine (e.g. `bar-icon-geometry-test.sh`, `snapper-test.sh`, `unowned-system-paths-test.sh`), which reproduce on a clean checkout and are unrelated to this change.

## Steps to reproduce

1. Open the network panel and click the speed test button.
2. Dismiss the overlay.
3. `pgrep -af omarchy-network-speedtest` still lists the workers, and the interface keeps receiving data.
