### PR TITLE
Leave LIBVA_DRIVER_NAME unset on hybrid NVIDIA laptops

### DIFF
--- a/bin/omarchy-hw-nvidia-only
+++ b/bin/omarchy-hw-nvidia-only
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# omarchy:summary=Detect whether an NVIDIA GPU is the only GPU in the computer.
+
+# Read the cached sysfs IDs rather than lspci, which reads PCI config space and
+# resumes runtime-suspended GPUs.
+pci_devices_path="${OMARCHY_PCI_DEVICES_PATH:-/sys/bus/pci/devices}"
+
+shopt -s nullglob
+
+nvidia=false
+for device in "$pci_devices_path"/*; do
+  [[ $(< "$device/class") == 0x03* ]] || continue
+
+  if [[ $(< "$device/vendor") == "0x10de" ]]; then
+    nvidia=true
+  else
+    exit 1
+  fi
+done
+
+[[ $nvidia == true ]]

--- a/default/hypr/nvidia.lua
+++ b/default/hypr/nvidia.lua
@@ -3,6 +3,7 @@ local paths = require("default.hypr.paths")
 local nvidia = paths.omarchy_path .. "/bin/omarchy-hw-nvidia"
 local nvidia_gsp = paths.omarchy_path .. "/bin/omarchy-hw-nvidia-gsp"
 local nvidia_without_gsp = paths.omarchy_path .. "/bin/omarchy-hw-nvidia-without-gsp"
+local nvidia_only = paths.omarchy_path .. "/bin/omarchy-hw-nvidia-only"
 
 -- These detectors read cached sysfs IDs rather than shelling out to lspci.
 -- lspci reads PCI config space, which resumes a runtime-suspended GPU, and on a
@@ -10,8 +11,16 @@ local nvidia_without_gsp = paths.omarchy_path .. "/bin/omarchy-hw-nvidia-without
 if o.shell_succeeds(o.shell_quote(nvidia)) then
   if o.shell_succeeds(o.shell_quote(nvidia_gsp)) then
     hl.env("NVD_BACKEND", "direct")
-    hl.env("LIBVA_DRIVER_NAME", "nvidia")
     hl.env("__GLX_VENDOR_LIBRARY_NAME", "nvidia")
+
+    -- On a hybrid laptop the compositor and its apps render on the integrated
+    -- GPU, so forcing the NVIDIA VA-API driver hands them a decoder for a device
+    -- they aren't drawing with: Chromium's GPU process crashes and video
+    -- flickers. Leave it unset there and libva picks the driver from the
+    -- render node an app actually opens.
+    if o.shell_succeeds(o.shell_quote(nvidia_only)) then
+      hl.env("LIBVA_DRIVER_NAME", "nvidia")
+    end
   elseif o.shell_succeeds(o.shell_quote(nvidia_without_gsp)) then
     hl.env("NVD_BACKEND", "egl")
     hl.env("__GLX_VENDOR_LIBRARY_NAME", "nvidia")

--- a/test/shell.d/hw-nvidia-test.sh
+++ b/test/shell.d/hw-nvidia-test.sh
@@ -97,3 +97,34 @@ assert_detects "a non-display NVIDIA function is not a GPU" no no no
 
 write_pci_devices
 assert_detects "a machine with no PCI devices detects nothing" no no no
+
+assert_only() {
+  local description="$1" expected="$2"
+
+  local actual=no
+  hw_nvidia nvidia-only && actual=yes
+
+  [[ $actual == "$expected" ]] ||
+    fail "$description" "omarchy-hw-nvidia-only: expected $expected, got $actual"
+
+  pass "$description"
+}
+
+# NVIDIA GB203 [RTX 5080] on its own.
+write_pci_devices 0x10de:0x2c02:0x030000
+assert_only "a machine with only an NVIDIA GPU is NVIDIA-only" yes
+
+# NVIDIA GB206M [RTX 5070 Mobile] alongside AMD HawkPoint integrated graphics.
+write_pci_devices 0x1002:0x1900:0x030000 0x10de:0x2d59:0x030000
+assert_only "a hybrid laptop is not NVIDIA-only" no
+
+# The GA106 audio function is not a GPU, so it does not make a hybrid.
+write_pci_devices 0x10de:0x2560:0x030200 0x10de:0x228e:0x040300
+assert_only "a non-display NVIDIA function does not break NVIDIA-only" yes
+
+# AMD Cezanne integrated graphics.
+write_pci_devices 0x1002:0x15e7:0x030000
+assert_only "a machine without an NVIDIA GPU is not NVIDIA-only" no
+
+write_pci_devices
+assert_only "a machine with no PCI devices is not NVIDIA-only" no


### PR DESCRIPTION
## Problem

On a hybrid laptop (AMD/Intel iGPU + NVIDIA dGPU), `default/hypr/nvidia.lua` exports `LIBVA_DRIVER_NAME=nvidia` for the whole session. But Hyprland and every app render on the integrated GPU (Chromium's GPU process runs with `--render-node-override=/dev/dri/renderD129`, the AMD node). VA-API then loads `nvidia_drv_video.so` against a device the app isn't drawing with.

Observed on an RTX 5070 Mobile + AMD HawkPoint laptop, Omarchy 4.0.3, Chromium 152, libva-nvidia-driver 0.0.18:

- Chromium's GPU process crashes (`systemd-coredump`: SIGTRAP with `nvidia_drv_video.so` on the stack) and the whole browser window blinks out for a few frames while it recovers.
- Any page with a `<video>` flickers between the poster and the frame and "jumps" as the layout re-settles.
- Google Meet joins but video stays frozen and the camera toggle does nothing.

Side-by-side with compositor screenshots of the same page: `LIBVA_DRIVER_NAME=nvidia` → window vanishes for several consecutive frames; `LIBVA_DRIVER_NAME=radeonsi` or unset → stable. `--disable-accelerated-video-decode` also "fixes" it, which pins it on the VA-API path.

## Fix

Only set `LIBVA_DRIVER_NAME=nvidia` when NVIDIA is the only display-class GPU. On a hybrid machine leave it unset: libva resolves the driver from the kernel driver of the render node an app actually opens (`amdgpu` → radeonsi, `i915`/`xe` → iHD, `nvidia-drm` → nvidia), so apps that do land on the NVIDIA node still get the right driver.

`NVD_BACKEND` and `__GLX_VENDOR_LIBRARY_NAME` are untouched.

Adds `omarchy-hw-nvidia-only`, a sysfs detector in the same style as `omarchy-hw-nvidia-gsp` (no `lspci`, so it doesn't wake a suspended dGPU during the 1.5s config reload budget), with tests in `test/shell.d/hw-nvidia-test.sh`.

## Testing

- `bash test/shell.d/hw-nvidia-test.sh` — all pass, including the five new NVIDIA-only cases.
- `./test/cli` — passes (metadata lint covers the new command header).
- `./test/shell` — only failures are the three `omarchy-pkgs checkout` tests that need a sibling checkout not present locally.
- On the affected laptop the detector exits 1 as expected, and with `LIBVA_DRIVER_NAME` corrected the Chromium video flicker and Meet freeze are gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgkHe2Z7dbJZbgQi4yhnVs
