### PR TITLE
Fit the weather panel to narrow popups

### DIFF
--- a/shell/plugins/panels/weather/Panel.qml
+++ b/shell/plugins/panels/weather/Panel.qml
@@ -521,8 +521,11 @@ Panel {
 
       // ---- Hero row: big icon + temp on the left; location and stats stacked on the right.
       Item {
-        width: parent.width
+        // Laid out at the width both halves need, then scaled to fit.
+        width: Math.max(parent.width, heroLeft.width + heroRight.width + Style.space(16 + 20 + 16))
         height: Math.max(heroLeft.height, heroRight.height)
+        scale: Math.min(1, parent.width / width)
+        transformOrigin: Item.Left
 
         Row {
           id: heroLeft
@@ -819,6 +822,8 @@ Panel {
           id: forecastRow
           anchors.horizontalCenter: parent.horizontalCenter
           spacing: Style.space(44)
+          // Scale rather than clip; the Flickable only scrolls vertically.
+          scale: Math.min(1, parent.width / Math.max(1, width))
 
           Repeater {
             model: root.forecastDays


### PR DESCRIPTION
On a screen narrower than the weather panel's 480px, the popup is fitted to the screen, but the two rows inside it are still laid out for 480, so they overlap and clip.

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/SimonSchubert/omarchy-mobile/1fd1dcdb0cce4938301cac8d8938074b6bf23c38/docs/screenshots/weather-before.png" width="300"> | <img src="https://raw.githubusercontent.com/SimonSchubert/omarchy-mobile/1fd1dcdb0cce4938301cac8d8938074b6bf23c38/docs/screenshots/weather-after.png" width="300"> |

- **Hero row.** Icon-and-temperature is anchored to the left edge and location-and-stats to the right. At 360 logical the popup's content is 318 wide and the halves need 403, so they print 85px on top of each other.
- **Forecast row.** Three days centred 44px apart, inside a `Flickable` that scrolls vertically only (`contentWidth: width`). The row is 329 wide in 318, so it's clipped at both ends with no way to reach the overflow: Friday's icon loses its left edge, and Sunday's low loses its degree sign.

## The change

Both rows scale down to fit, the way `SpeedTestOverlay` already scales its dial. The hero is laid out at the width its halves need and scaled from its left edge:

```qml
width: Math.max(parent.width, heroLeft.width + heroRight.width + Style.space(16 + 20 + 16))
scale: Math.min(1, parent.width / width)
transformOrigin: Item.Left
```

The `16 + 20 + 16` is the existing left margin, the existing right margin, and a minimum gap between the halves. The forecast row is scaled about its centre:

```qml
scale: Math.min(1, parent.width / Math.max(1, width))
```

## Why it's safe

- Both scales are exactly 1 wherever the content fits, and the hero's width is then `parent.width` as before, so on a desktop the popup is unchanged.
- Neither can loop: the widths they read are the rows' own implicit widths, which don't depend on scale or position.
- At 360 logical the hero renders at about 76%. It keeps the desktop layout's shape, and the popup doesn't grow taller.

## Verification

Per `agents/skills/visual-verification.md`, reference and candidate captures in the running shell (`omarchy-restart-shell`, then `omarchy-shell omarchy.weather open`):

- **720x1440 at scale 2** (360 logical): both rows fit and nothing overlaps or clips. That's the "after" image above.
- **1920x1080 at scale 1**: the popup is unchanged. The capture matches the unpatched one to within 3/255 on 38 pixels, which is llvmpipe's anti-aliasing:

| Desktop before | Desktop after |
| --- | --- |
| <img src="https://raw.githubusercontent.com/SimonSchubert/omarchy-mobile/1fd1dcdb0cce4938301cac8d8938074b6bf23c38/docs/screenshots/weather-desktop-before.png" width="420"> | <img src="https://raw.githubusercontent.com/SimonSchubert/omarchy-mobile/1fd1dcdb0cce4938301cac8d8938074b6bf23c38/docs/screenshots/weather-desktop-after.png" width="420"> |

- **Live switch between the two, in both directions**: each lands where a fresh start at the new size does, and the journal shows no binding-loop warnings.

A companion to #11034, found the same way on a phone-shaped screen. Like that one, it's a narrow-screen robustness fix rather than a mobile-specific one.
