### PR TITLE
Close open bar panels while the screensaver is up

### DIFF
--- a/shell/plugins/bar/Bar.qml
+++ b/shell/plugins/bar/Bar.qml
@@ -31,12 +31,14 @@ Item {
   // the panel above it and leaves whatever the widget was showing on a screen
   // meant to conceal the session. Close the panel whenever the enabled idle
   // service reports a screensaver window. Resolve through the registry so this
-  // also follows a user-cloned idle service.
-  readonly property string idleServiceId: shell && shell.pluginRegistry
-    ? shell.pluginRegistry.resolveEnabledId("omarchy.idle")
-    : "omarchy.idle"
-  readonly property var idleService: shell && typeof shell.serviceFor === "function"
-    ? shell.serviceFor(idleServiceId) : null
+  // also follows a user-cloned idle service; enabling a clone only bumps the
+  // registry revision, so the binding has to read it.
+  readonly property string idleServiceId: {
+    if (!shell || !shell.pluginRegistry) return "omarchy.idle"
+    var revision = shell.pluginRegistry.registryRevision
+    return shell.pluginRegistry.resolveEnabledId("omarchy.idle")
+  }
+  readonly property var idleService: shell && shell.services ? shell.serviceFor(idleServiceId) : null
   readonly property bool screensaverActive: !!idleService && idleService.screensaverWindowCount > 0
   onScreensaverActiveChanged: if (screensaverActive) closeActivePopout()
   // Manifest for the active bar option. Present for custom bars and useful for
@@ -326,7 +328,12 @@ Item {
     pluginBarApis = next
   }
 
-  onActivePopoutChanged: syncAllPluginBarApiObjects()
+  onActivePopoutChanged: {
+    syncAllPluginBarApiObjects()
+    // A panel can also be opened while the screensaver is already up (over
+    // IPC, say), when screensaverActive has no change left to report.
+    if (screensaverActive && activePopout) Qt.callLater(closeActivePopout)
+  }
   onClickTargetsChanged: syncAllPluginBarApiObjects()
   onLayoutConfigChanged: syncAllPluginBarApiObjects()
   onModuleSlotsChanged: Qt.callLater(prunePluginBarApis)
@@ -570,6 +577,7 @@ Item {
   function closeActivePopout() {
     if (!activePopout) return
     if ("close" in activePopout) activePopout.close()
+    else if ("closeForPopoutSwitch" in activePopout) activePopout.closeForPopoutSwitch()
     releasePopout(activePopout)
   }
 

--- a/shell/plugins/bar/Bar.qml
+++ b/shell/plugins/bar/Bar.qml
@@ -26,6 +26,19 @@ Item {
   // Injected by the host shell. Used for shell-wide actions such as opening
   // settings and persisting inline widget state.
   property var shell: null
+  // An open panel is a layer-shell surface anchored to the bar, while the
+  // fullscreen screensaver is a normal Wayland client, so the compositor draws
+  // the panel above it and leaves whatever the widget was showing on a screen
+  // meant to conceal the session. Close the panel whenever the enabled idle
+  // service reports a screensaver window. Resolve through the registry so this
+  // also follows a user-cloned idle service.
+  readonly property string idleServiceId: shell && shell.pluginRegistry
+    ? shell.pluginRegistry.resolveEnabledId("omarchy.idle")
+    : "omarchy.idle"
+  readonly property var idleService: shell && typeof shell.serviceFor === "function"
+    ? shell.serviceFor(idleServiceId) : null
+  readonly property bool screensaverActive: !!idleService && idleService.screensaverWindowCount > 0
+  onScreensaverActiveChanged: if (screensaverActive) closeActivePopout()
   // Manifest for the active bar option. Present for custom bars and useful for
   // diagnostics; the built-in bar does not otherwise need it.
   property var manifest: null
@@ -550,6 +563,14 @@ Item {
 
   function releasePopout(owner) {
     if (activePopout === owner) activePopout = null
+  }
+
+  // Close whatever popout is open, whoever owns it. Built-in panels and
+  // third-party plugin panels both register here, so both are covered.
+  function closeActivePopout() {
+    if (!activePopout) return
+    if ("close" in activePopout) activePopout.close()
+    releasePopout(activePopout)
   }
 
   readonly property bool vertical: position === "left" || position === "right"

--- a/test/shell.d/bar-test.sh
+++ b/test/shell.d/bar-test.sh
@@ -489,10 +489,21 @@ pass "put places a widget through a ready shell"
 # A panel left open when the session goes idle is a layer-shell surface drawn
 # above the fullscreen screensaver, which leaves the widget's contents on a
 # screen meant to conceal the session.
-if ! rg -q 'resolveEnabledId\("omarchy\.idle"\)' "$ROOT/shell/plugins/bar/Bar.qml"; then
+# Enabling a clone changes config without touching installedPlugins, so the
+# binding only re-resolves if it reads the registry revision.
+if ! perl -0ne 'exit(/idleServiceId: \{[^}]*?registryRevision[^}]*?resolveEnabledId\("omarchy\.idle"\)/s ? 0 : 1)' \
+  "$ROOT/shell/plugins/bar/Bar.qml"; then
   fail "bar follows the enabled idle service, including a user clone"
 fi
 pass "bar follows the enabled idle service, including a user clone"
+
+# Services register asynchronously; shell.services is the binding dependency
+# that re-resolves the idle service once it appears.
+if ! rg -q 'idleService: shell && shell\.services \? shell\.serviceFor\(idleServiceId\)' \
+  "$ROOT/shell/plugins/bar/Bar.qml"; then
+  fail "bar picks up the idle service once it registers"
+fi
+pass "bar picks up the idle service once it registers"
 
 if ! rg -q 'onScreensaverActiveChanged: if \(screensaverActive\) closeActivePopout\(\)' \
   "$ROOT/shell/plugins/bar/Bar.qml"; then
@@ -500,9 +511,16 @@ if ! rg -q 'onScreensaverActiveChanged: if \(screensaverActive\) closeActivePopo
 fi
 pass "an open bar panel closes while the screensaver is active"
 
+if ! perl -0ne 'exit(/onActivePopoutChanged: \{[^}]*?if \(screensaverActive && activePopout\) Qt\.callLater\(closeActivePopout\)/s ? 0 : 1)' \
+  "$ROOT/shell/plugins/bar/Bar.qml"; then
+  fail "a bar panel opened while the screensaver is up closes"
+fi
+pass "a bar panel opened while the screensaver is up closes"
+
 # Third-party plugin panels register through the same popout coordinator, so
-# closing whatever owns the popout covers them without naming plugin ids.
-if ! perl -0ne 'exit(/function closeActivePopout\(\)\s*\{[^}]*?"close" in activePopout[^}]*?\}/s ? 0 : 1)' \
+# closing whatever owns the popout covers them without naming plugin ids. Like
+# requestPopout, it falls back to closeForPopoutSwitch for owners without close.
+if ! perl -0ne 'exit(/function closeActivePopout\(\)\s*\{[^}]*?"close" in activePopout[^}]*?"closeForPopoutSwitch" in activePopout[^}]*?\}/s ? 0 : 1)' \
   "$ROOT/shell/plugins/bar/Bar.qml"; then
   fail "closing the popout goes through whichever owner registered it"
 fi

--- a/test/shell.d/bar-test.sh
+++ b/test/shell.d/bar-test.sh
@@ -485,3 +485,25 @@ put_output=$(PATH="$put_tmp/bin:$ROOT/bin:$PATH" \
   fail "put places a widget through a ready shell" "$put_output"
 [[ $put_output == "omarchy.keyboard-layout is on the bar" ]] || fail "put reports the placed widget" "$put_output"
 pass "put places a widget through a ready shell"
+
+# A panel left open when the session goes idle is a layer-shell surface drawn
+# above the fullscreen screensaver, which leaves the widget's contents on a
+# screen meant to conceal the session.
+if ! rg -q 'resolveEnabledId\("omarchy\.idle"\)' "$ROOT/shell/plugins/bar/Bar.qml"; then
+  fail "bar follows the enabled idle service, including a user clone"
+fi
+pass "bar follows the enabled idle service, including a user clone"
+
+if ! rg -q 'onScreensaverActiveChanged: if \(screensaverActive\) closeActivePopout\(\)' \
+  "$ROOT/shell/plugins/bar/Bar.qml"; then
+  fail "an open bar panel closes while the screensaver is active"
+fi
+pass "an open bar panel closes while the screensaver is active"
+
+# Third-party plugin panels register through the same popout coordinator, so
+# closing whatever owns the popout covers them without naming plugin ids.
+if ! perl -0ne 'exit(/function closeActivePopout\(\)\s*\{[^}]*?"close" in activePopout[^}]*?\}/s ? 0 : 1)' \
+  "$ROOT/shell/plugins/bar/Bar.qml"; then
+  fail "closing the popout goes through whichever owner registered it"
+fi
+pass "closing the popout goes through whichever owner registered it"


### PR DESCRIPTION
Fixes #11234.

A bar panel left open when the session goes idle is a layer-shell surface anchored to the bar, so the compositor draws it above the fullscreen screensaver. Whatever the widget was showing (calendar, mail, display settings) stays on a screen meant to conceal the session, and the panel keeps its keyboard focus grab.

## Change

- `Bar.qml` watches the enabled idle service's `screensaverWindowCount`, the same signal `Background.qml` already uses. When a screensaver window appears, it closes the active popout.
- The idle service is resolved through `pluginRegistry.resolveEnabledId("omarchy.idle")`, so a user-cloned idle service still counts.
- Closing goes through `Bar.activePopout`, the coordinator both built-in and third-party plugin panels register with. Plugin panels are covered without naming any ids, and closing (rather than hiding) releases the panel's focus grab.

## Verification

- `test/shell.d/bar-test.sh` passes, including 3 new assertions: the bar follows the enabled (or cloned) idle service, an open panel closes when the screensaver is active, and closing routes through whichever owner registered the popout.
- In the running UI (`omarchy dev link` on this branch, two monitors), I triggered `omarchy-launch-screensaver force` with a panel open:
  - Built-in `omarchy.monitor` (Display) panel: closed when the screensaver appeared and stayed closed after it exited.
  - Third-party plugin panel (`ninepointlabs.fastmail-calendar`): same result.
  - No QML errors in the shell log.

## Known gap

Replacement third-party *bars* get a service-less shell facade, so they can't resolve the idle service themselves. The guard makes that a no-op rather than an error, but those bars would need their own handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GyYBpCZqLPWr9Ja1VgQnte
