### PR TITLE
Fix third-party menu plugins losing their shell facade and app library

### DIFF
--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -1298,7 +1298,7 @@ ShellRoot {
       if (!shell.pluginRegistry.isEnabled(id)) continue
       var kind = m.kinds.indexOf("panel") !== -1 ? "panel"
         : (m.kinds.indexOf("overlay") !== -1 ? "overlay" : "menu")
-      out.push({ id: id, manifest: m, kind: kind, keepLoaded: m.keepLoaded === true })
+      out.push({ id: id, kind: kind, keepLoaded: m.keepLoaded === true })
     }
     return out
   }
@@ -1316,7 +1316,8 @@ ShellRoot {
       id: panelEntry
       required property var modelData
       readonly property string pluginId: modelData.id
-      readonly property var manifest: modelData.manifest
+      // Read the registry's manifest rather than carrying it through the model
+      readonly property var manifest: shell.pluginRegistry.installedPlugins[pluginId] || null
       readonly property string entryKind: modelData.kind
       readonly property bool keepLoaded: modelData.keepLoaded === true
       readonly property string sourceUrl: shell.pluginRegistry.entryPointUrl(manifest, entryKind)

--- a/test/shell.d/plugin-auth-boundary-test.sh
+++ b/test/shell.d/plugin-auth-boundary-test.sh
@@ -72,6 +72,17 @@ qml_matches "$shell_qml" 'target\.shell *= *shell\.pluginShellFor\( *manifest *\
   fail "full-bar plugins receive a scoped shell facade"
 pass "third-party entry points receive scoped shell facades"
 
+# A manifest carried through the Instantiator model comes back with `kinds` as
+# a sequence that fails Array.isArray. The panel loader would then request a
+# different capability profile than the bar does for the same plugin, and the
+# two would revoke each other's facade, nulling a menu clone's shell.
+qml_matches "$shell_qml" 'readonly property var manifest: *shell\.pluginRegistry\.installedPlugins\[ *pluginId *\]' ||
+  fail "panel plugins scope their facade from the registry manifest"
+if qml_matches "$shell_qml" 'modelData\.manifest'; then
+  fail "panel plugins scope their facade from a model-converted manifest"
+fi
+pass "panel and bar entry points request the same facade profile"
+
 if qml_matches "$plugin_shell_api" 'function +pluginShellForId\('; then
   fail "replacement-bar facade exposes a generic plugin-shell factory"
 fi


### PR DESCRIPTION
## Brief

A third-party menu plugin that also is on the bar (being what `omarchy plugin clone omarchy.menu` gives), shows "Nothing here yet" in its Apps sub-menu. The stock `omarchy.menu` is unaffected, since first-party plugins receive the whole `shell` object directly.

From the plugin's side, `root.shell` arrives with `appLibrary: null`, then becomes itself `null` shortly after load and stays that way.

The bug made access flicker on and off, and which way it landed was an accident!

In short, the security rules are the same. They're now applied consistently from one source instead of two that disagreed.

## Root cause

The panel loader and the bar request the scoped `PluginShellApi` for the same plugin under the same cache key, but they compute different capability profiles:

- The bar (`Bar.qml` -> `pluginShellForId`) passes the registry's manifest, so the profile is `own-service|no-bar|menu`.
- The panel loader passes `panelEntry.manifest`, which came through the `Instantiator` model. On the way through, `kinds` becomes a `V4Sequence`: `indexOf` still works, but `Array.isArray` returns false. So `manifestHasKind(manifest, "menu")` fails and the profile is `own-service|no-bar|no-menu`, with `appLibrary: null`.

`createScopedPluginShell` treats the mismatch as a capability change and revokes the cached facade, which destroys it. When the panel loads, it destroys the bar's facade. When the bar then injects its widget, it destroys the panel's facade, and destroying a QObject nulls the menu's `property var shell`. The menu is `keepLoaded` and nothing injects `shell` again, so it stays null for the whole session.

A standalone check confirms the conversion: a JS array inside an `Instantiator` model's `modelData` reports `[object V4Sequence]` and `Array.isArray(...) === false`.

## Fix

The panel delegate now reads the manifest from `pluginRegistry.installedPlugins[pluginId]`, which is the same source the bar path, `prunePluginApis()` and the facade callbacks already use. It no longer carries the manifest through the model. Both callers now compute the same profile, the menu gets its app-library facade, and nothing revokes it.

`manifestHasKind()` keeps its `Array.isArray` guard on purpose. Loosening it to accept sequences would also let a string `kinds` such as `"menus"` pass an `indexOf("menu")` test.

## Security

This doesn't widen any capability:

- Revoking on a genuine profile change is untouched. The fix only removes a **false mismatch between two callers describing the same plugin**.
- Third-party plugins still receive the scoped `PluginShellApi`, and `pluginShellFor()` still branches on the registry-stamped `__isFirstParty`.
- Their `manifest` is still the stripped deep copy from `publicPluginManifest()`.
- The app-library facade that menu plugins now reliably get is the actual documented design ("menu plugins receive an application-library facade"), and the bar path was already granting it to them.
- First-party panels now receive the registry manifest object instead of a converted copy. They already get the host `shell`, which exposes `pluginRegistry` so nothing new is granted.

> The `appsChanged` forwarding from `AppLibrary` to each `PluginAppLibraryApi` is already wired by `Connections { target: shell.appLibrary }` in `shell.qml`: live app-list updates reach third-party menus once they hold a facade.

## Verification

Tested live by running this branch's `shell/`, based on `quattro`, as the session shell on an Omarchy 4.0.3 system with quickshell 0.3.1 and Qt 6.11.2.

A cloned `omarchy.menu` sat on the bar, running the unmodified stock `Menu.qml`/`MenuModel .js`. Both runs used identical configuration, and only `shell.qml` differed:

| Desctiption                           | Before             | After                     |
| ------------------------------------- | ------------------ | ------------------------- |
| Facade revocations for the clone      | 2                  | 0                         |
| `appLibrary` at load                  | `null`             | `PluginAppLibraryApi`     |
| `root.shell` after load               | does become `null` | unchanged for the session |
| App rows built from `root.appLibrary` | 0                  | many                      |
| Apps submenu                          | "Nothing here yet" | populated                 |

## Tests:

- `test/shell.d/plugin-auth-boundary-test.sh` gains a check that the panel delegate scopes its facade from the registry manifest and never from `modelData.manifest`. It fails on the previous `shell.qml` and passes with this change. All existing boundary checks still pass, including the runtime fixture.
- `./test/cli` passes.
- `./test/shell` passes apart from failures that are unrelated or environmental. `bar-icon-geometry-test.sh` ("vertical indicator is not optically centered") fails identically without this change; it uses its own fixture shell. Three tests need an `omarchy-pkgs` checkout that isn't present here. `runtime-smoke-test.sh` failed once in the full run and passes on reruns both with and without this change.