### PR TITLE
Clamp the lock screen's password field to the screen width

### DIFF
--- a/shell/plugins/lock/LockView.qml
+++ b/shell/plugins/lock/LockView.qml
@@ -23,7 +23,8 @@ Item {
   property bool syncingPasswordText: false
 
   readonly property string placeholderText: "Enter Password"
-  readonly property int fieldWidth: 381
+  // Clamped so the field cannot outgrow a narrow screen.
+  readonly property int fieldWidth: root.width > 0 ? Math.min(381, root.width - Style.gapsOut * 2) : 381
   readonly property int fieldHeight: 67
   readonly property int outlineThickness: 3
   readonly property int fieldFontSize: Math.round(Style.font.heading * 1.125)


### PR DESCRIPTION
The lock screen's password field is wider than any screen narrower than it, so its outline and rounded corners are cut off on both sides.

`LockView` sets `fieldWidth: 381`, a fixed width on a field anchored `centerIn: parent`. At 360 logical the field runs from x = −11 to x = 370. Its left and right borders are off-screen, so it reads as a full-width band:

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/SimonSchubert/omarchy-mobile/b48160126b35ffd9208bbe924960254d0b7dafa1/docs/screenshots/lock-before.png" width="300"> | <img src="https://raw.githubusercontent.com/SimonSchubert/omarchy-mobile/b48160126b35ffd9208bbe924960254d0b7dafa1/docs/screenshots/lock-after.png" width="300"> |

## The change

Clamp the field to the screen, less `Style.gapsOut` on each side. That's the same margin the polkit and reminder cards already leave with `panel.width - Style.gapsOut * 2`:

```qml
readonly property int fieldWidth: root.width > 0 ? Math.min(381, root.width - Style.gapsOut * 2) : 381
```

`root.width` is 0 until the lock surface is sized. The guard keeps the field at 381 until then, instead of a negative width.

## Why it's safe

- On a desktop `Math.min` returns 381 and the field is unchanged.
- The password dots already shrink to fit `passwordInput.width`, which follows the field, so long passwords still stay visible in a narrower field.

## Verification

Per `agents/skills/visual-verification.md`, reference and candidate captures of `omarchy-shell lock preview`:

- **720x1440 at scale 2** (360 logical): the field clamps to 350, with 5px on each side and its outline closed on all four sides. That's the "after" image above.
- **1920x1080 at scale 1**: the field stays 381, and the capture matches the unpatched one to within 2/255 on 8 pixels, which is llvmpipe's anti-aliasing:

| Desktop before | Desktop after |
| --- | --- |
| <img src="https://raw.githubusercontent.com/SimonSchubert/omarchy-mobile/b48160126b35ffd9208bbe924960254d0b7dafa1/docs/screenshots/lock-desktop-before.png" width="420"> | <img src="https://raw.githubusercontent.com/SimonSchubert/omarchy-mobile/b48160126b35ffd9208bbe924960254d0b7dafa1/docs/screenshots/lock-desktop-after.png" width="420"> |

- **Live switch between the two, in both directions**: each matches a fresh start at the new size, and the journal is clean.

The VM runs a v4.0.3 shell, where `LockView` predates `BackgroundMedia`. To test this exact file rather than a backport, I added `BackgroundMedia.qml` and `Util.isVideoPath` from `quattro` for the test. The field code is identical in both versions.

A companion to #11034 and #11238, found the same way on a phone-shaped screen. Like those, it's a narrow-screen robustness fix rather than a mobile-specific one.
