### PR TITLE
Fix Bluetooth tray icon and power switch when the radio is off

### DIFF
--- a/shell/plugins/panels/bluetooth/Panel.qml
+++ b/shell/plugins/panels/bluetooth/Panel.qml
@@ -56,8 +56,7 @@ Panel {
   readonly property var discoveredDevices: deviceGroups.discovered || []
 
   readonly property string icon: {
-    if (!adapter) return ""
-    if (!adapter.enabled) return "󰂲"
+    if (!adapter || !adapter.enabled) return "󰂲"
     if (connectedDevices.length > 0) return "󰂱"
     return "󰂯"
   }
@@ -497,7 +496,10 @@ Panel {
     if (selectedIndex < 0) selectedIndex = 0
   }
 
-  visible: adapter !== null
+  // rfkill-blocking the radio drops the adapter from BlueZ entirely (not just
+  // Powered: no), so hiding on `!adapter` hid the widget instead of showing the
+  // disabled icon above. Stay visible and let `icon` carry the off state.
+  visible: true
   implicitWidth: button.implicitWidth
   implicitHeight: button.implicitHeight
 

--- a/shell/plugins/panels/bluetooth/Panel.qml
+++ b/shell/plugins/panels/bluetooth/Panel.qml
@@ -635,8 +635,7 @@ Panel {
   // switch only moves once BlueZ catches up, so a second click inside that window
   // would re-read the old state and undo the first.
   function toggleBluetooth() {
-    if (!adapter) return
-    Quickshell.execDetached(["omarchy-bluetooth-power", adapter.enabled ? "off" : "on"])
+    Quickshell.execDetached(["omarchy-bluetooth-power", adapter && adapter.enabled ? "off" : "on"])
   }
 
   IpcHandler {
@@ -714,7 +713,7 @@ Panel {
           // header's only cursor target.
           ToggleSwitch {
             id: powerSwitch
-            visible: !!root.adapter
+            visible: true
             checked: !!root.adapter && root.adapter.enabled
             hasCursor: root.headerHasCursor
             foreground: root.bar.foreground

--- a/test/shell.d/bluetooth-test.sh
+++ b/test/shell.d/bluetooth-test.sh
@@ -17,8 +17,17 @@ assert(/IpcHandler[\s\S]*?function toggleBluetooth\(\) \{ root\.toggleBluetooth\
 assert(/manageIpc: false/.test(panelSource), 'bluetooth owns its IPC handler so it can extend the target methods')
 
 // Writing adapter.enabled sets BlueZ Powered, which does not survive a reboot.
-assert(/function toggleBluetooth\(\)[\s\S]*?execDetached\(\["omarchy-bluetooth-power", adapter\.enabled \? "off" : "on"\]\)/.test(panelSource), 'bluetooth toggles the radio through the rfkill soft block')
+assert(/function toggleBluetooth\(\)[\s\S]*?execDetached\(\["omarchy-bluetooth-power", adapter && adapter\.enabled \? "off" : "on"\]\)/.test(panelSource), 'bluetooth toggles the radio through the rfkill soft block')
 assert(!/adapter\.enabled = /.test(panelSource), 'bluetooth never writes the adapter power state directly')
+
+// rfkill-blocking drops the adapter from BlueZ entirely rather than merely
+// disabling it, so a null adapter means "off", not "unknown" or "no-op": the
+// icon must still show the disabled glyph, the widget must stay visible, and
+// the switch must still be able to turn the radio back on.
+assert(!/function toggleBluetooth\(\) \{\s*if \(!adapter\) return/.test(panelSource), 'bluetooth can still turn the radio on when no adapter is present')
+assert(/readonly property string icon: \{\s*if \(!adapter \|\| !adapter\.enabled\) return/.test(panelSource), 'bluetooth shows the disabled icon when the adapter is absent, not an empty glyph')
+assert(!/visible: adapter !== null/.test(panelSource), 'bluetooth widget does not hide itself when the adapter is absent')
+assert(/id: powerSwitch\s*visible: true/.test(panelSource), 'bluetooth power switch stays visible when the adapter is absent')
 
 // Discovery is a BlueZ session that nothing ends at panel close: it persists
 // until StopDiscovery or until quickshell's D-Bus connection drops with the


### PR DESCRIPTION
## Summary
- Turning Bluetooth off through the bar's power toggle calls `rfkill block bluetooth` (so the off-state survives reboots), which drops the adapter from BlueZ entirely rather than merely disabling it.
- `Panel.qml`'s `icon` property only accounted for a disabled-but-present adapter, returning an empty string when `adapter` was `null`; the widget's `visible: adapter !== null` binding then hid it outright — the tray icon vanished instead of showing the disabled glyph (`󰂲`).
- The power switch itself was also hidden (`visible: !!root.adapter`), and `toggleBluetooth()` no-op'd on a null adapter — so once Bluetooth was off, there was no way left to turn it back on from the panel at all.

## Fix
- `icon`: treat "no adapter" and "adapter disabled" the same way, both showing the disabled glyph.
- Widget: stay `visible: true` always, and let `icon` alone carry the on/off/disabled state.
- Power switch: stay visible regardless of adapter presence.
- `toggleBluetooth()`: no longer bails out when there's no adapter — it can still ask `omarchy-bluetooth-power` to turn the radio back on.
- Updated the pinned source-regex test for the toggle call, and added coverage for the null-adapter cases across the icon, widget visibility, and switch.

## Test plan
- [x] Reproduced: toggled Bluetooth off via the bar switch, tray icon disappeared entirely and the panel offered no way to turn it back on.
- [x] Applied the fix locally via `omarchy plugin clone omarchy.bluetooth`, confirmed with screenshots that the icon shows the disabled glyph when off and the normal glyph when on, and that the power switch stays visible and functional in both states.
- [x] Noted, but not part of this fix: after the adapter reappears, the tray icon can lag a few to ~20s before catching up, self-correcting without a shell restart. That reactivity gap lives in Quickshell's own Bluetooth service, not in this widget.
- [x] `./test/all` — 5 pre-existing failures (missing `omarchy-pkgs` checkout, a locale-encoding issue in an unrelated test, and a bar-icon centering test), all reproduced identically on unmodified `master`; none related to this change.