### PR TITLE
Pause Bluetooth discovery during pairing

### DIFF
--- a/bin/omarchy-bluetooth-device
+++ b/bin/omarchy-bluetooth-device
@@ -26,20 +26,37 @@ power_on() {
 }
 
 trust_device() {
-  bluetoothctl trust "$address" >/dev/null 2>&1 || true
+  if ! bluetoothctl trust "$address" >/dev/null 2>&1; then
+    echo "Could not trust the Bluetooth device" >&2
+    return 1
+  fi
+}
+
+pair_device() {
+  if ! timeout 20s bluetoothctl pair "$address" >/dev/null 2>&1; then
+    echo "Pairing failed. Keep the device in pairing mode and try again" >&2
+    return 1
+  fi
+}
+
+connect_device() {
+  if ! timeout 20s bluetoothctl connect "$address" >/dev/null 2>&1; then
+    echo "Could not connect to the Bluetooth device" >&2
+    return 1
+  fi
 }
 
 case "$action" in
   pair)
     power_on
-    timeout 20s bluetoothctl pair "$address" >/dev/null 2>&1 || true
+    pair_device
     trust_device
-    timeout 20s bluetoothctl connect "$address" >/dev/null 2>&1 || true
+    connect_device
     ;;
   connect)
     power_on
     trust_device
-    timeout 20s bluetoothctl connect "$address" >/dev/null 2>&1 || true
+    connect_device
     ;;
   disconnect)
     timeout 10s bluetoothctl disconnect "$address" >/dev/null 2>&1 || true

--- a/shell/plugins/panels/bluetooth/Panel.qml
+++ b/shell/plugins/panels/bluetooth/Panel.qml
@@ -21,6 +21,15 @@ Panel {
   // this map only keeps the panel responsive while BlueZ catches up.
   property var pendingActions: ({})
 
+  // BlueZ discovery and outgoing connections compete on some adapters. Keep
+  // the address as primitives while discovery stops, then run one observed
+  // pair/connect process so failures can make it back into the panel.
+  property var queuedConnectionAction: null
+  property string activeConnectionAction: ""
+  property string activeConnectionAddress: ""
+  property bool discoveryPausedForAction: false
+  property string actionFailure: ""
+
   readonly property var adapter: Bluetooth.defaultAdapter
 
   // True while this instance owes BlueZ a StopDiscovery: set when it starts
@@ -54,6 +63,7 @@ Panel {
   readonly property var connectedDevices: deviceGroups.connected || []
   readonly property var knownDevices: deviceGroups.known || []
   readonly property var discoveredDevices: deviceGroups.discovered || []
+  readonly property bool showDiscoveredDevices: adapter && (adapter.discovering || discoveryPausedForAction)
 
   readonly property string icon: {
     if (!adapter) return ""
@@ -120,12 +130,12 @@ Panel {
   function sectionVisible(section) {
     if (section === "connected") return connectedDevices.length > 0
     if (section === "known") return knownDevices.length > 0
-    if (section === "discovered") return adapter && adapter.discovering && discoveredDevices.length > 0
+    if (section === "discovered") return showDiscoveredDevices && discoveredDevices.length > 0
     return false
   }
 
   readonly property var visibleSections: {
-    return Model.visibleSections(deviceGroups, adapter && adapter.discovering)
+    return Model.visibleSections(deviceGroups, showDiscoveredDevices)
   }
 
   function devicesForSection(section) {
@@ -273,10 +283,59 @@ Panel {
     Quickshell.execDetached(deviceCommand(action, device.address))
   }
 
+  function runConnectionAction(device, action) {
+    if (!device || !device.address || connectionProc.running || queuedConnectionAction) return
+
+    actionFailure = ""
+    failureTimer.stop()
+    setPendingAction(device.address, "connecting")
+    queuedConnectionAction = { action: action, address: device.address }
+    discoveryPausedForAction = true
+
+    if (adapter && adapter.discovering) {
+      adapter.discovering = false
+      connectionStartTimeout.restart()
+    } else {
+      startQueuedConnectionAction()
+    }
+  }
+
+  function startQueuedConnectionAction() {
+    if (!queuedConnectionAction || connectionProc.running) return
+    connectionStartTimeout.stop()
+    var queued = queuedConnectionAction
+    queuedConnectionAction = null
+    activeConnectionAction = queued.action
+    activeConnectionAddress = queued.address
+    connectionProc.command = deviceCommand(queued.action, queued.address)
+    connectionProc.running = true
+  }
+
+  function finishConnectionAction(exitCode) {
+    if (exitCode !== 0) {
+      setPendingAction(activeConnectionAddress, "")
+      actionFailure = activeConnectionAction === "pair"
+        ? "Pairing failed — keep the device in pairing mode and try again"
+        : "Connection failed — make sure the device is nearby and try again"
+      failureTimer.restart()
+    } else {
+      syncPendingActions()
+    }
+
+    activeConnectionAction = ""
+    activeConnectionAddress = ""
+    discoveryPausedForAction = false
+
+    if (opened && adapter && adapter.enabled && !adapter.discovering) {
+      owesDiscoveryStop = true
+      adapter.discovering = true
+    }
+  }
+
   function connectDevice(device) {
     if (!device || device.connected) return
-    if (device.paired || device.bonded || device.trusted) runDeviceAction(device, "connect", "connecting")
-    else runDeviceAction(device, "pair", "connecting")
+    if (device.paired || device.bonded || device.trusted) runConnectionAction(device, "connect")
+    else runConnectionAction(device, "pair")
   }
 
   function disconnectDevice(device) {
@@ -509,7 +568,7 @@ Panel {
     interval: 1000
     repeat: true
     triggeredOnStart: true
-    running: root.opened && root.adapter !== null && root.adapter.enabled && !root.adapter.discovering
+    running: root.opened && root.adapter !== null && root.adapter.enabled && !root.adapter.discovering && !root.discoveryPausedForAction
     onTriggered: {
       root.owesDiscoveryStop = true
       root.adapter.discovering = true
@@ -561,6 +620,8 @@ Panel {
     target: root.adapter
     function onDiscoveringChanged() {
       if (!root.adapter.discovering) root.owesDiscoveryStop = false
+      if (!root.adapter.discovering && root.discoveryPausedForAction && root.queuedConnectionAction)
+        root.startQueuedConnectionAction()
     }
   }
 
@@ -582,6 +643,28 @@ Panel {
     interval: 20000
     repeat: false
     onTriggered: root.pendingActions = ({})
+  }
+
+  Process {
+    id: connectionProc
+    command: []
+    onExited: function(exitCode) { root.finishConnectionAction(exitCode) }
+  }
+
+  Timer {
+    id: connectionStartTimeout
+    // A failed StopDiscovery must not strand the row in "Connecting…". The
+    // command still gets its attempt after the adapter had a chance to settle.
+    interval: 1000
+    repeat: false
+    onTriggered: root.startQueuedConnectionAction()
+  }
+
+  Timer {
+    id: failureTimer
+    interval: 8000
+    repeat: false
+    onTriggered: root.actionFailure = ""
   }
 
   Timer {
@@ -866,11 +949,22 @@ Panel {
 
         Text {
           textFormat: Text.PlainText
-          visible: root.connectedDevices.length === 0 && root.scrollRows.length === 0
+          visible: root.connectedDevices.length === 0 && root.scrollRows.length === 0 && root.actionFailure === ""
           text: !root.adapter ? "No Bluetooth adapter"
               : !root.adapter.enabled ? "Turn Bluetooth on to scan"
               : "Scanning for devices…"
           color: Qt.darker(root.bar.foreground, 1.5)
+          font.family: root.bar.fontFamily
+          font.pixelSize: Style.font.bodySmall
+          wrapMode: Text.WordWrap
+          width: parent.width
+        }
+
+        Text {
+          textFormat: Text.PlainText
+          visible: root.actionFailure !== ""
+          text: root.actionFailure
+          color: root.bar.urgent
           font.family: root.bar.fontFamily
           font.pixelSize: Style.font.bodySmall
           wrapMode: Text.WordWrap

--- a/test/shell.d/bluetooth-test.sh
+++ b/test/shell.d/bluetooth-test.sh
@@ -28,6 +28,12 @@ assert(!/adapter\.enabled = /.test(panelSource), 'bluetooth never writes the ada
 const retryTimer = panelSource.match(/id: discoveryRetry[\s\S]*?onTriggered: \{[\s\S]*?\n {4}\}/)
 assert(retryTimer, 'bluetooth has the discovery retry timer')
 assert(/owesDiscoveryStop = true/.test(retryTimer[0]), 'bluetooth takes on the stop it owes when it starts discovery')
+assert(/!root\.discoveryPausedForAction/.test(retryTimer[0]), 'bluetooth keeps discovery stopped while pairing or connecting')
+
+assert(/adapter\.discovering = false[\s\S]*connectionStartTimeout\.restart\(\)/.test(panelSource), 'bluetooth stops discovery before starting a connection action')
+assert(/id: connectionProc[\s\S]*onExited:[\s\S]*finishConnectionAction/.test(panelSource), 'bluetooth observes connection command failures')
+assert(/showDiscoveredDevices:[^\n]*discoveryPausedForAction/.test(panelSource), 'bluetooth keeps discovered devices visible while discovery pauses for an action')
+assert(/visible: root\.actionFailure !== ""/.test(panelSource), 'bluetooth shows connection failures in the panel')
 
 // Quickshell only forwards a discovering write that differs from BlueZ's last
 // confirmed state, so a stop written in the same instant as an in-flight
@@ -156,6 +162,7 @@ cat >"$mock_bin/bluetoothctl" <<'SH'
 #!/bin/bash
 
 printf '%s\n' "$*" >>"$BLUETOOTHCTL_LOG"
+[[ ${BLUETOOTHCTL_FAIL:-} == "$1" ]] && exit 1
 [[ $1 == "power" && $2 == "on" ]] && echo yes >"$POWERED_FILE"
 [[ $1 == "list" ]] &&
   for c in ${MOCK_CONTROLLERS:-AA:BB:CC:DD:EE:FF}; do printf 'Controller %s mock\n' "$c"; done
@@ -251,6 +258,40 @@ pass "bluetooth skips the power-on delay when the adapter is already powered"
 grep -qx "connect AA:BB:CC:DD:EE:FF" "$powered_log" ||
   fail "bluetooth still connects when the adapter is already powered"
 pass "bluetooth still connects when the adapter is already powered"
+
+pair_log=$(bluetooth_run yes "$ROOT/bin/omarchy-bluetooth-device" pair AA:BB:CC:DD:EE:FF)
+grep -qx "pair AA:BB:CC:DD:EE:FF" "$pair_log" ||
+  fail "bluetooth starts pairing while the device is discoverable" "$(cat "$pair_log")"
+grep -qx "trust AA:BB:CC:DD:EE:FF" "$pair_log" ||
+  fail "bluetooth trusts a successfully paired device" "$(cat "$pair_log")"
+grep -qx "connect AA:BB:CC:DD:EE:FF" "$pair_log" ||
+  fail "bluetooth connects a successfully paired device" "$(cat "$pair_log")"
+pass "bluetooth pairs, trusts, and connects a device in order"
+
+: >"$device_tmp/log"
+echo yes >"$POWERED_FILE"
+if PATH="$mock_bin:$ROOT/bin:$PATH" BLUETOOTHCTL_LOG="$device_tmp/log" BLUETOOTHCTL_FAIL=pair \
+  "$ROOT/bin/omarchy-bluetooth-device" pair AA:BB:CC:DD:EE:FF >/dev/null 2>&1; then
+  fail "bluetooth reports a pairing failure"
+fi
+pass "bluetooth reports a pairing failure"
+
+grep -q "trust AA:BB:CC:DD:EE:FF" "$device_tmp/log" &&
+  fail "bluetooth does not trust a device after pairing fails" "$(cat "$device_tmp/log")"
+grep -q "connect AA:BB:CC:DD:EE:FF" "$device_tmp/log" &&
+  fail "bluetooth does not connect a device after pairing fails" "$(cat "$device_tmp/log")"
+pass "bluetooth stops the connection sequence after pairing fails"
+
+: >"$device_tmp/log"
+if PATH="$mock_bin:$ROOT/bin:$PATH" BLUETOOTHCTL_LOG="$device_tmp/log" BLUETOOTHCTL_FAIL=connect \
+  "$ROOT/bin/omarchy-bluetooth-device" connect AA:BB:CC:DD:EE:FF >/dev/null 2>&1; then
+  fail "bluetooth reports a connection failure"
+fi
+pass "bluetooth reports a connection failure"
+
+grep -qx "trust AA:BB:CC:DD:EE:FF" "$device_tmp/log" ||
+  fail "bluetooth trusts a known device before connecting" "$(cat "$device_tmp/log")"
+pass "bluetooth trusts a known device before connecting"
 
 # Connecting to a device while Bluetooth is off has to lift the block first —
 # BlueZ refuses to power an adapter up while one is set.


### PR DESCRIPTION
The Bluetooth panel keeps discovery active while it starts an outgoing pair or connection. On adapters where inquiry competes with connection paging, that can make the attempt time out; because `omarchy-bluetooth-device` discarded every failure status, the panel then returned to idle without explaining what happened.

This pauses panel-owned discovery before pair/connect actions, keeps the cached available-device row visible during the pause, and observes the helper process so failures produce an actionable retry message. The helper now returns failure immediately instead of continuing to trust and connect a device that did not pair.

Fixes #8614

Validation:
- `bash test/shell.d/bluetooth-test.sh`
- Loaded the checkout in the running Omarchy shell and verified the connection-failure state renders without clipping or stale busy state
- Exercised the revised helper against a real Xbox controller and an unavailable address
