### PR TITLE
Activate T3 theme on existing installs

### DIFF
--- a/migrations/1789091250.sh
+++ b/migrations/1789091250.sh
@@ -1,0 +1,4 @@
+echo "Activate the Omarchy theme for existing T3 Code installs"
+
+omarchy-pkg-present t3code-bin || exit 0
+omarchy-install-ai-t3-code


### PR DESCRIPTION
Existing T3 Code installs did not receive the Omarchy theme added in v4.0.3.

Rerun the existing idempotent T3 Code installer during migration so it publishes and activates the current Omarchy palette. Machines without T3 Code remain unchanged.

Verification:
- `bash -n migrations/1789091250.sh`
- `git diff --check`