### PR TITLE
Silence Claude auth nag when local API usage exists

### DIFF
--- a/bin/omarchy-agent-usage-claude
+++ b/bin/omarchy-agent-usage-claude
@@ -791,7 +791,7 @@ def usable_cached_limits(cached: dict[str, Any]) -> list[dict[str, Any]]:
   return [entry for entry in entries if isinstance(entry, dict) and limit_window_open(entry, now)]
 
 
-def collect_limits(access_token: str, expires_at_ms: int, force: bool) -> dict[str, Any]:
+def collect_limits(access_token: str, expires_at_ms: int, force: bool, has_local_stats: bool = False) -> dict[str, Any]:
   result = {"limits": [], "usageStatusText": "", "authHelpText": AUTH_HELP}
 
   # A panel that is opened and shut repeatedly must not turn into a request
@@ -806,18 +806,27 @@ def collect_limits(access_token: str, expires_at_ms: int, force: bool) -> dict[s
   # enough finds the saved token lapsed. Say so — an empty limits list with
   # nothing else set hides the whole section and explains nothing — and keep
   # showing the last numbers whose window has not since reset.
+  #
+  # An API-key user never has an OAuth token, so a missing (or lapsed) token
+  # alongside local usage and no cached limits is not a signed-out
+  # subscription — it is expected. Stay silent there, the way the Codex
+  # collector does when its RPC yields no windows: local stats still show,
+  # with no auth nag. Keep warning whenever cached limits exist (they are
+  # stale and need explaining) or when there is nothing local to show.
   if access_token == "":
     result["limits"] = fallback
-    result["usageStatusText"] = "Waiting for auth"
+    if not has_local_stats or fallback:
+      result["usageStatusText"] = "Waiting for auth"
     return result
   if expires_at_ms > 0 and expires_at_ms <= time.time() * 1000:
     result["limits"] = fallback
-    result["usageStatusText"] = "Sign-in expired"
-    result["authHelpText"] = (
-      "Claude Code's saved sign-in expired"
-      + (" — showing the last known limits." if fallback else ".")
-      + " Start Claude Code, or run `claude auth login`, to refresh it."
-    )
+    if not has_local_stats or fallback:
+      result["usageStatusText"] = "Sign-in expired"
+      result["authHelpText"] = (
+        "Claude Code's saved sign-in expired"
+        + (" — showing the last known limits." if fallback else ".")
+        + " Start Claude Code, or run `claude auth login`, to refresh it."
+      )
     return result
 
   # --force is a person asking for fresh numbers, so it skips the reuse window
@@ -880,7 +889,7 @@ def main() -> int:
     stats = merge_stats(stats, opencode)
 
   access_token, expires_at_ms, plan = oauth_login(claude_dir)
-  limits = collect_limits(access_token, expires_at_ms, args.force)
+  limits = collect_limits(access_token, expires_at_ms, args.force, has_local_stats=number(stats.get("totalPrompts")) > 0)
 
   record = {
     "schemaVersion": 1,

--- a/bin/omarchy-agent-usage-claude
+++ b/bin/omarchy-agent-usage-claude
@@ -603,6 +603,32 @@ def plan_label(tier: str, subscription: str) -> str:
   return ""
 
 
+API_TIER_LABEL = "API Platform"
+
+
+def opencode_auth_path() -> Path:
+  data_home = Path(os.environ.get("XDG_DATA_HOME") or (Path.home() / ".local" / "share"))
+  return data_home / "opencode" / "auth.json"
+
+
+# An Anthropic API-key user never holds an OAuth token, so without an explicit
+# signal they are indistinguishable from a signed-out subscriber. The key
+# itself is that signal: a set ANTHROPIC_API_KEY, or an anthropic entry in
+# opencode's auth store. Only the key's presence is read — never its value —
+# and nothing secret travels into the printed record.
+def has_anthropic_api_key() -> bool:
+  if str(os.environ.get("ANTHROPIC_API_KEY") or "").strip():
+    return True
+  try:
+    data = json.loads(opencode_auth_path().read_text(encoding="utf-8"))
+  except Exception:
+    return False
+  entry = data.get("anthropic") if isinstance(data, dict) else None
+  if not isinstance(entry, dict):
+    return False
+  return str(entry.get("key") or "").strip() != ""
+
+
 def parse_utilization(value: Any) -> float:
   try:
     return float(str(value).strip().replace("%", ""))
@@ -891,6 +917,17 @@ def main() -> int:
   access_token, expires_at_ms, plan = oauth_login(claude_dir)
   limits = collect_limits(access_token, expires_at_ms, args.force, has_local_stats=number(stats.get("totalPrompts")) > 0)
 
+  # API billing has no subscription windows, so a key holder without a live
+  # OAuth token is labelled as such instead of falling through to the panel's
+  # "Subscription" default — and any stale cached subscription windows are
+  # dropped rather than shown under that label. A holder of both (mixed
+  # usage) keeps the subscription record: a live token means this branch
+  # never runs.
+  tier = plan
+  if (access_token == "" or (expires_at_ms > 0 and expires_at_ms <= time.time() * 1000)) and has_anthropic_api_key():
+    tier = API_TIER_LABEL
+    limits = {"limits": [], "usageStatusText": "", "authHelpText": AUTH_HELP}
+
   record = {
     "schemaVersion": 1,
     "id": AGENT_ID,
@@ -898,7 +935,7 @@ def main() -> int:
     "updatedAt": dt.datetime.now(dt.timezone.utc).isoformat(),
     "ready": number(stats.get("totalPrompts")) > 0 or len(limits["limits"]) > 0,
     "hasLocalStats": True,
-    "tierLabel": plan,
+    "tierLabel": tier,
     "usageStatusText": limits["usageStatusText"],
     "authHelpText": limits["authHelpText"],
     "limits": limits["limits"],

--- a/bin/omarchy-agent-usage-codex
+++ b/bin/omarchy-agent-usage-codex
@@ -28,6 +28,30 @@ from pathlib import Path
 AGENT_ID = "codex"
 AGENT_NAME = "Codex"
 AUTH_HELP = "Run `codex login` to authenticate."
+API_TIER_LABEL = "API Platform"
+
+
+def opencode_auth_path():
+  data_home = Path(os.environ.get("XDG_DATA_HOME") or (Path.home() / ".local" / "share"))
+  return data_home / "opencode" / "auth.json"
+
+
+# An OpenAI API-key user never logs the Codex CLI in, so without an explicit
+# signal they are indistinguishable from a signed-out subscriber. The key
+# itself is that signal: a set OPENAI_API_KEY, or an openai entry in
+# opencode's auth store. Only the key's presence is read — never its value —
+# and nothing secret travels into the printed record.
+def has_openai_api_key():
+  if str(os.environ.get("OPENAI_API_KEY") or "").strip():
+    return True
+  try:
+    data = json.loads(opencode_auth_path().read_text(encoding="utf-8"))
+  except Exception:
+    return False
+  entry = data.get("openai") if isinstance(data, dict) else None
+  if not isinstance(entry, dict):
+    return False
+  return str(entry.get("key") or "").strip() != ""
 
 # A scan this recent is only reused to dedup concurrent collector runs (the
 # update command backgrounds one per agent while the panel refreshes on its
@@ -585,6 +609,17 @@ def main():
   max_age = 0 if args.force else (LIMITS_ONLY_REUSE_SECONDS if args.limits_only else SCAN_REUSE_SECONDS)
   stats = cached_local_stats(max_age)
   rpc = fetch_codex_rpc()
+
+  # API billing has no subscription windows, so a key holder whose RPC yields
+  # no plan is labelled as such instead of falling through to the panel's
+  # "Subscription" default. Local stats silence a failed probe the same way:
+  # subscription windows are irrelevant to API billing. A holder of both
+  # (mixed usage) keeps the subscription record: a plan in the RPC answer
+  # means this branch never runs.
+  if not rpc.get("tierLabel") and has_openai_api_key():
+    rpc["tierLabel"] = API_TIER_LABEL
+    if number(stats.get("totalPrompts")) > 0:
+      rpc["usageStatusText"] = ""
 
   record = {
     "schemaVersion": 1,

--- a/test/shell.d/agent-usage-claude-limits-test.sh
+++ b/test/shell.d/agent-usage-claude-limits-test.sh
@@ -80,7 +80,7 @@ CACHE_HOME=$(mktemp -d)
 trap 'rm -rf "$CACHE_HOME"' EXIT
 
 collect_limits() {
-  COLLECTOR="$ROOT/bin/omarchy-agent-usage-claude" TOKEN="$1" EXPIRES_AT="$2" CACHED="$3" \
+  COLLECTOR="$ROOT/bin/omarchy-agent-usage-claude" TOKEN="$1" EXPIRES_AT="$2" CACHED="$3" HAS_LOCAL="${4:-false}" \
     XDG_CACHE_HOME="$CACHE_HOME" python3 - <<'PY'
 import importlib.machinery, importlib.util, json, os, pathlib
 
@@ -100,7 +100,7 @@ def unreachable(request, timeout=None):
   raise OSError("no route to host")
 
 collector.urllib.request.urlopen = unreachable
-print(json.dumps(collector.collect_limits(os.environ["TOKEN"], int(os.environ["EXPIRES_AT"]), False)))
+print(json.dumps(collector.collect_limits(os.environ["TOKEN"], int(os.environ["EXPIRES_AT"]), False, has_local_stats=os.environ["HAS_LOCAL"] == "true")))
 PY
 }
 
@@ -145,6 +145,20 @@ signed_out=$(collect_limits "" 0 "$cache")
 [[ $(jq -c '[.limits[].label]' <<<"$signed_out") == '["Weekly (7-day)"]' ]] ||
   fail "Claude collector serves open cached windows without a token" "$signed_out"
 pass "Claude collector serves open cached windows without a token"
+
+# An API-key user has local usage but never an OAuth token, so there are no
+# cached limits to explain: the collector stays silent instead of nagging for
+# a login, the way the Codex collector does when its RPC yields no windows.
+api_user=$(collect_limits "" 0 "" true)
+[[ $(jq -r '.usageStatusText' <<<"$api_user") == "" && $(jq -c '.limits' <<<"$api_user") == "[]" ]] ||
+  fail "Claude collector stays silent for API usage without cached limits" "$api_user"
+pass "Claude collector stays silent for API usage without cached limits"
+
+# ... unless stale cached limits exist: they still need explaining.
+api_stale=$(collect_limits "" 0 "$cache" true)
+[[ $(jq -r '.usageStatusText' <<<"$api_stale") == "Waiting for auth" ]] ||
+  fail "Claude collector still explains stale cached limits when local usage exists" "$api_stale"
+pass "Claude collector still explains stale cached limits when local usage exists"
 
 # A live token that cannot reach the endpoint keeps the old contract: the open
 # window stands in, and the shell is asked to retry sooner than its interval.

--- a/test/shell.d/agent-usage-claude-scanner-test.sh
+++ b/test/shell.d/agent-usage-claude-scanner-test.sh
@@ -29,9 +29,16 @@ pass "Claude collector counts each API message once"
   fail "Claude collector keeps mutually exclusive token categories" "$result"
 pass "Claude collector keeps mutually exclusive token categories"
 
-[[ $(jq -r '.id + "/" + .usageStatusText' <<<"$result") == "claude/Waiting for auth" ]] ||
-  fail "Claude collector identifies itself and reports missing auth" "$result"
-pass "Claude collector identifies itself and reports missing auth"
+[[ $(jq -r '.id' <<<"$result") == "claude" ]] ||
+  fail "Claude collector identifies itself" "$result"
+pass "Claude collector identifies itself"
+
+# An API-key user has local usage but never an OAuth token: no cached limits
+# to explain, so the collector stays silent instead of nagging for a login —
+# the way the Codex collector does when its RPC yields no windows.
+[[ $(jq -r '.usageStatusText' <<<"$result") == "" ]] ||
+  fail "Claude collector stays silent for API usage without cached limits" "$result"
+pass "Claude collector stays silent for API usage without cached limits"
 
 # A machine with no transcripts and no stats-cache still gets today's counts
 # from history.jsonl alone.

--- a/test/shell.d/agent-usage-claude-scanner-test.sh
+++ b/test/shell.d/agent-usage-claude-scanner-test.sh
@@ -110,10 +110,69 @@ pass "Claude collector counts Anthropic usage, reasoning included, from opencode
   fail "Claude collector ignores prefix-colliding providers, user messages, and malformed rows" "$result"
 pass "Claude collector ignores prefix-colliding providers, user messages, and malformed rows"
 
+# An Anthropic API-key holder without an OAuth token is labelled as such
+# instead of falling through to the panel's "Subscription" default — with no
+# auth nag and no stale subscription windows.
+API_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME" "$HISTORY_HOME" "$OPENCODE_HOME" "$API_HOME"' EXIT
+mkdir -p "$API_HOME/.local/share/opencode"
+
+python3 - "$API_HOME/.local/share/opencode/opencode.db" <<'PY'
+import json
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+db = Path(sys.argv[1])
+db.parent.mkdir(parents=True, exist_ok=True)
+conn = sqlite3.connect(db)
+conn.execute("CREATE TABLE message (id text PRIMARY KEY, session_id text NOT NULL, time_created integer NOT NULL, time_updated integer NOT NULL, data text NOT NULL)")
+now_ms = int(time.time() * 1000)
+conn.execute("INSERT INTO message VALUES ('msg_1', 'ses_1', ?, ?, ?)", (now_ms, now_ms, json.dumps({
+  "role": "assistant",
+  "providerID": "anthropic",
+  "modelID": "claude-opus-5",
+  "tokens": {"input": 100, "output": 50},
+  "time": {"created": now_ms},
+})))
+conn.commit()
+conn.close()
+PY
+
+cat >"$API_HOME/.local/share/opencode/auth.json" <<'EOF'
+{"anthropic": {"type": "api", "key": "sk-test"}}
+EOF
+
+result=$(env -u ANTHROPIC_API_KEY HOME="$API_HOME" XDG_CACHE_HOME="$API_HOME/.cache" XDG_DATA_HOME="$API_HOME/.local/share" \
+  "$ROOT/bin/omarchy-agent-usage-claude" --force)
+
+[[ $(jq -r '.tierLabel' <<<"$result") == "API Platform" ]] ||
+  fail "Claude collector labels an opencode API-key holder as API Platform" "$result"
+[[ $(jq -r '.usageStatusText' <<<"$result") == "" && $(jq -c '.limits' <<<"$result") == "[]" ]] ||
+  fail "Claude collector stays silent with no subscription windows for API usage" "$result"
+pass "Claude collector labels opencode API-key usage as API Platform"
+
+# The same label applies when the key arrives via the environment rather than
+# opencode's auth store.
+ENV_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME" "$HISTORY_HOME" "$OPENCODE_HOME" "$API_HOME" "$ENV_HOME"' EXIT
+mkdir -p "$ENV_HOME/.claude/projects/example"
+cat >"$ENV_HOME/.claude/projects/example/session.jsonl" <<EOF
+{"timestamp":"$timestamp","type":"assistant","sessionId":"session-1","uuid":"event-1","message":{"id":"message-1","role":"assistant","model":"claude-test","usage":{"input_tokens":10,"output_tokens":5}}}
+EOF
+
+result=$(ANTHROPIC_API_KEY="sk-test" HOME="$ENV_HOME" XDG_CACHE_HOME="$ENV_HOME/.cache" XDG_DATA_HOME="$ENV_HOME/.local/share" \
+  "$ROOT/bin/omarchy-agent-usage-claude" --force)
+
+[[ $(jq -r '.tierLabel' <<<"$result") == "API Platform" && $(jq -r '.usageStatusText' <<<"$result") == "" ]] ||
+  fail "Claude collector labels an ANTHROPIC_API_KEY holder as API Platform" "$result"
+pass "Claude collector labels ANTHROPIC_API_KEY usage as API Platform"
+
 # Pi and omp can both spend a Claude subscription without writing native
 # Claude Code transcripts. Their compatible JSONL sessions must be included.
 PI_HOME=$(mktemp -d)
-trap 'rm -rf "$TEST_HOME" "$HISTORY_HOME" "$OPENCODE_HOME" "$PI_HOME"' EXIT
+trap 'rm -rf "$TEST_HOME" "$HISTORY_HOME" "$OPENCODE_HOME" "$API_HOME" "$ENV_HOME" "$PI_HOME"' EXIT
 mkdir -p "$PI_HOME/.pi/agent/sessions/project" "$PI_HOME/.omp/agent/sessions/project"
 
 cat >"$PI_HOME/.pi/agent/sessions/project/pi.jsonl" <<EOF

--- a/test/shell.d/agent-usage-codex-scanner-test.sh
+++ b/test/shell.d/agent-usage-codex-scanner-test.sh
@@ -142,6 +142,50 @@ pass "Codex collector counts OpenAI usage, reasoning included, from opencode ses
   fail "Codex collector ignores prefix-colliding providers, user messages, and malformed rows" "$result"
 pass "Codex collector ignores prefix-colliding providers, user messages, and malformed rows"
 
+# An OpenAI API-key holder whose RPC yields no plan is labelled as such
+# instead of falling through to the panel's "Subscription" default — with no
+# auth nag over local stats.
+API_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME" "$PI_HOME" "$OPENCODE_HOME" "$API_HOME"' EXIT
+mkdir -p "$API_HOME/bin"
+cp "$TEST_HOME/bin/codex" "$API_HOME/bin/codex"
+
+python3 - "$API_HOME/.local/share/opencode/opencode.db" <<'PY'
+import json
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+db = Path(sys.argv[1])
+db.parent.mkdir(parents=True, exist_ok=True)
+conn = sqlite3.connect(db)
+conn.execute("CREATE TABLE message (id text PRIMARY KEY, session_id text NOT NULL, time_created integer NOT NULL, time_updated integer NOT NULL, data text NOT NULL)")
+now_ms = int(time.time() * 1000)
+conn.execute("INSERT INTO message VALUES ('msg_1', 'ses_1', ?, ?, ?)", (now_ms, now_ms, json.dumps({
+  "role": "assistant",
+  "providerID": "openai",
+  "modelID": "gpt-test",
+  "tokens": {"input": 80, "output": 40},
+  "time": {"created": now_ms},
+})))
+conn.commit()
+conn.close()
+PY
+
+cat >"$API_HOME/.local/share/opencode/auth.json" <<'EOF'
+{"openai": {"type": "api", "key": "sk-test"}}
+EOF
+
+result=$(env -u OPENAI_API_KEY HOME="$API_HOME" CODEX_HOME="$API_HOME/.codex" XDG_DATA_HOME="$API_HOME/.local/share" \
+  PATH="$API_HOME/bin:$PATH" "$ROOT/bin/omarchy-agent-usage-codex")
+
+[[ $(jq -r '.tierLabel' <<<"$result") == "API Platform" ]] ||
+  fail "Codex collector labels an OpenAI API-key holder as API Platform" "$result"
+[[ $(jq -r '.usageStatusText' <<<"$result") == "" ]] ||
+  fail "Codex collector stays silent for API usage with local stats" "$result"
+pass "Codex collector labels OpenAI API-key usage as API Platform"
+
 # A warm cache makes --limits-only cheap: local stats come from the last scan
 # instead of another walk over the opencode database, and --force bypasses it.
 CACHE_HOME=$(mktemp -d)


### PR DESCRIPTION
Anthropic API-key users (e.g. via opencode provider `anthropic`) have local usage but never an OAuth token, so `omarchy-agent-usage-claude` permanently reported `Waiting for auth` / `Run \`claude auth login\`` even though the Codex collector stays silent in the same situation (empty `usageStatusText`, local stats shown).

Pass local-usage state into `collect_limits()` and only set `Waiting for auth` / `Sign-in expired` when there is nothing local to show or when cached limit windows exist (stale limits still need explaining). API users with usage and no cached limits now get `usageStatusText == ""`, matching Codex, so the panel hides the warning box.

Tests:
- Updated `agent-usage-claude-scanner-test.sh` expectation (local usage + no OAuth + no cache => silent).
- Extended `agent-usage-claude-limits-test.sh` with API-user cases (silent without cache, still warns with stale cache).
- `agent-usage-claude-limits/scanner`, `codex-scanner`, `fireworks-scanner`, `update`, `agents-panel` pass; `test/cli` passes. 4 unrelated `test/shell` failures (config/locate/snapper/unowned-paths, missing omarchy-pkgs checkout) reproduce on clean tree.