### PR TITLE
Fix DaVinci Resolve Download Manager focus lock

### DIFF
--- a/default/hypr/apps/davinci-resolve.lua
+++ b/default/hypr/apps/davinci-resolve.lua
@@ -11,4 +11,4 @@ o.window(".*[Rr]esolve.*", {
 
 o.window({ class = ".*[Rr]esolve.*", title = "^DaVinci Resolve( Studio)? - .+$" }, { fullscreen = true })
 -- Resolve exposes the Voiceover panel under the generic "Dialog" title.
-o.window({ class = ".*[Rr]esolve.*", title = "^(DaVinci Resolve( Studio)? - .+|Project Manager|Preferences|Find Directory|Dialog)$" }, { stay_focused = false })
+o.window({ class = ".*[Rr]esolve.*", title = "^(DaVinci Resolve( Studio)? - .+|Project Manager|Preferences|Find Directory|Dialog|Download Manager)$" }, { stay_focused = false })


### PR DESCRIPTION
Resolve's Extras Download Manager traps focus, so I can't switch to another application while it stays open. Add its exact window title to the existing focus exceptions so downloads can run while I work elsewhere.

Fixes #11268.

Verified on DaVinci Resolve Studio 21.1: adding the equivalent local rule and reloading Hyprland allowed switching away from the Download Manager. `hyprctl configerrors`, `luac -p default/hypr/apps/davinci-resolve.lua`, and `git diff --check` passed.
