### PR TITLE
Inhibit idle for fullscreen Steam games, not just the Steam client

### DIFF
--- a/default/hypr/apps/steam.lua
+++ b/default/hypr/apps/steam.lua
@@ -2,3 +2,8 @@ o.window("steam", { float = true, idle_inhibit = "fullscreen" })
 o.window({ class = "steam", title = "Steam" }, { center = true, size = { 1100, 700 } })
 o.window("steam.*", { tag = "-default-opacity", opacity = "1 1" })
 o.window({ class = "steam", title = "Friends List" }, { size = { 460, 800 } })
+
+-- Games run as steam_app_<appid>. Gamepad input goes straight to the game and
+-- never through the compositor, so a fullscreen game played on a controller
+-- looks idle and the screensaver/lock fire mid-game.
+o.window("steam_app_.*", { idle_inhibit = "fullscreen" })


### PR DESCRIPTION
Closes the gap described in #11271.

## Problem

`default/hypr/apps/steam.lua` sets `idle_inhibit = "fullscreen"` for class `steam` — the Steam client / Big Picture. Games don't run under that class; they run as `steam_app_<appid>`, so the rule never applies to the window that's actually fullscreen during play.

Gamepad input goes from Steam Input straight to the game via SDL and never passes through the compositor, so a fullscreen game played on a controller looks completely idle to Hyprland. `idle.screensaver` fires over the match at 150 s, `idle.lock` at 300 s. Steam's own inhibit and gamemode's `inhibit_screensaver` don't help — both use the `org.freedesktop.ScreenSaver` D-Bus interface, which Hyprland doesn't implement.

## Change

One rule added next to the existing client rule:

```lua
o.window("steam_app_.*", { idle_inhibit = "fullscreen" })
```

- Separate line rather than widening the existing one, because that one also sets `float = true`, which games must not get.
- Unanchored pattern to match the file's existing idiom (`"steam.*"` on the opacity line). Hyprland matches rule regexes against the whole class, so `steam_app_.*` is a full match; verified against a throwaway window that the unanchored form does produce an inhibitor.
- Scoped to `fullscreen` so a windowed or alt-tabbed game returns to normal idle behaviour.
- The idle service already honours inhibitors (`respectInhibitors: true` in `shell/plugins/services/idle/Service.qml`), so nothing else changes.

## Verification

Omarchy 4.0.3-1, Hyprland 0.56.2, NVIDIA 610.57.04. Rule applied, Proton/XWayland game relaunched, `hyprctl -j clients` polled:

```
23:13:35  steam_app_3468650  fullscreen=0  inhibitingIdle=False   (window mapped)
23:13:37  steam_app_3468650  fullscreen=2  inhibitingIdle=True    (fullscreen → inhibitor on)
23:30:19  (game closed)
```

Seventeen minutes on controller only, no screensaver. Without the rule the same session produced the screensaver at 150 s with `inhibitingIdle=False`.

## Tests

`./test/all`: 231 of 236 test files pass. The five that fail (`config`, `locate`, `snapper`, `unowned-system-paths`, `update-lock` under `test/shell.d/`) fail identically on untouched `quattro` in this environment, so they're pre-existing and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U1r4YEdkmTPPJUYHB5eqTG
