### PR TITLE
Fix Bash learning link

### DIFF
--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -47,7 +47,7 @@
   "learn.hyprland": {"icon":"","label":"Hyprland","action":"omarchy-launch-webapp 'https://wiki.hypr.land/'"},
   "learn.arch": {"icon":"󰣇","label":"Arch","action":"omarchy-launch-webapp 'https://wiki.archlinux.org/title/Main_page'"},
   "learn.neovim": {"icon":"","label":"Neovim","action":"omarchy-launch-webapp 'https://www.lazyvim.org/keymaps'"},
-  "learn.bash": {"icon":"󱆃","label":"Bash","action":"omarchy-launch-webapp 'https://devhints.io/bash'"},
+  "learn.bash": {"icon":"󱆃","label":"Bash","action":"omarchy-launch-webapp 'https://github.com/rstacruz/cheatsheets/blob/master/bash.md'"},
   "learn.tmux-keybindings": {"icon":"","label":"Tmux","action":"omarchy-menu-tmux-keybindings"},
   "learn.herdr-keybindings": {"icon":"","label":"Herdr","action":"omarchy-menu-herdr-keybindings"},
   "learn.community": {"icon":"󰙯","label":"Community","action":"omarchy-launch-discord-community"},


### PR DESCRIPTION
Learn → Bash currently opens devhints.io/bash, which fails to load. Point the menu entry to the same Bash cheatsheet in its author's GitHub repository.

Fixes #11183.

Validation:
- Reproduced the old link's connection error in the desktop browser and verified the replacement opens through the menu action. The replacement also returns HTTP 200.
- Menu and menu-guard tests, CLI suite, and `git diff --check` passed.
- Ran `./test/all`: 230 of 236 shell test files passed. All six failures reproduce on unchanged upstream: bar icon geometry, About animation, three checks requiring the absent `omarchy-pkgs` checkout, and the locate test reading bytecode generated by an earlier collector test as UTF-8.
