### PR TITLE
Give cloned menus their application library

### DIFF
--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -347,8 +347,14 @@ ShellRoot {
   }
 
   function manifestHasKind(manifest, kind) {
-    return !!manifest && Array.isArray(manifest.kinds)
-      && manifest.kinds.indexOf(kind) !== -1
+    // Panel, overlay, and menu manifests reach their loader through an
+    // Instantiator model, which hands nested arrays back as QV4 sequence
+    // wrappers rather than JS arrays. Array.isArray() rejects those, and a
+    // menu that fails this check is handed no application library, so its
+    // Apps submenu comes up empty.
+    var kinds = manifest ? manifest.kinds : null
+    return !!kinds && typeof kinds.indexOf === "function"
+      && kinds.indexOf(kind) !== -1
   }
 
   function pluginHasBarCapabilities(manifest) {


### PR DESCRIPTION
Closes #11282.

`manifestHasKind()` required a real JS array: `Array.isArray(manifest.kinds)`. Panel, overlay, and menu plugins are instantiated from `panelEntries` through an `Instantiator` model, and nested arrays come back from that model as QV4 sequence wrappers instead of JS arrays — `Array.isArray()` is false for them while `String(kinds)` and `kinds.indexOf("menu")` still work.

A cloned menu therefore failed the `menu` check in `createScopedPluginShell()`, was handed `appLibrary: null`, and `Menu.qml`'s `mergeAppRows()` returned at `if (!root.appLibrary) return`, leaving the Apps submenu empty with nothing in the log to explain it. First-party menus never reach the check because `pluginShellFor()` early-returns the host shell for `manifest.__isFirstParty`, which is why this only shows up once the menu is cloned (or shipped by a third party).

The fix accepts any array-like `kinds` list.

## Verification

- Minimal reproduction in an isolated Quickshell: a manifest passed through an `Instantiator` model reports `[object V4Sequence]` for `kinds`, `Array.isArray(...) === false`, `kinds.indexOf("menu") !== -1`. With this change the kind check returns true for it; a manifest read straight from `installedPlugins` still returns true, and `"service"` / `null` still return false.
- Live shell (Omarchy 4.0.3, cloned `sfk.menu`, `omarchy.menu` disabled): `omarchy-shell shell call sfk.menu mergeAppRows` left `childCount("apps")` at 0 before the change; loading the same `Menu.qml` in an isolated Quickshell with a working `appLibrary` injected gives 73 rows, so the menu code itself is fine once the library is handed over.
- `./test/all` on this machine: 3349 assertions pass. The two failures I see locally (`bar-icon-geometry-test.sh`, `launch-about-test.sh`) fail identically on the unmodified tree here, so they are environment-specific rather than caused by this change.

I checked the other `Array.isArray(manifest.kinds)` call sites in `shell.qml` (`isBarOptionManifest`, `isBarWidgetPanelPlugin`, `ensureService`, `_syncServices`, `computePanelEntries`, `listPlugins`); they all read manifests straight from `installedPlugins` or the live config, so this was the only one reached with a model-delivered manifest.

Before/after captures of the Apps submenu are attached to #11282. Happy to fold this into a different shape (for example a helper that also normalizes the manifest at the loader) if you prefer.
