### PR TITLE
Drop tzdata aliases from the timezone pickers

### DIFF
--- a/bin/omarchy-menu-timezone
+++ b/bin/omarchy-menu-timezone
@@ -6,7 +6,13 @@
 
 set -e
 
-timezone=$(timedatectl list-timezones | omarchy-menu-select "Set timezone" -- --width 520 --maxheight 520) || exit 1
+# `timedatectl list-timezones` builds its list from tzdata.zi, which carries the
+# backward-compatibility links alongside the zones they point at, so the picker
+# offered Asia/Ashkhabad right under Asia/Ashgabat. zone.tab is one row per
+# country per zone and holds none of those obsolete aliases; UTC is not in it.
+timezones=$({ echo UTC; awk '!/^#/ && NF { print $3 }' /usr/share/zoneinfo/zone.tab; } | sort)
+
+timezone=$(omarchy-menu-select "Set timezone" -- --width 520 --maxheight 520 <<<"$timezones") || exit 1
 sudo timedatectl set-timezone "$timezone"
 omarchy-shell -q omarchy.clock refresh
 omarchy-notification-send "Timezone is now set to $timezone"

--- a/install/provisioning/setup-form.sh
+++ b/install/provisioning/setup-form.sh
@@ -166,6 +166,14 @@ omarchy_prompt_hostname() {
   done
 }
 
+# `timedatectl list-timezones` builds its list from tzdata.zi, which carries the
+# backward-compatibility links alongside the zones they point at, so the picker
+# offered Asia/Ashkhabad right under Asia/Ashgabat. zone.tab is one row per
+# country per zone and holds none of those obsolete aliases; UTC is not in it.
+omarchy_timezones() {
+  { echo UTC; awk '!/^#/ && NF { print $3 }' /usr/share/zoneinfo/zone.tab; } | sort
+}
+
 # A fresh machine often hasn't joined a network yet, so the geo guess fails
 # often; guard it or a `set -e` caller dies before the filter fallback.
 omarchy_prompt_timezone() {
@@ -173,9 +181,9 @@ omarchy_prompt_timezone() {
   guess=$(tzupdate -p 2>/dev/null) || guess=""
 
   if [[ -n $guess ]]; then
-    timezone=$(timedatectl list-timezones | gum choose --height 10 --selected "$guess" --header "Timezone") && status=0 || status=$?
+    timezone=$(omarchy_timezones | gum choose --height 10 --selected "$guess" --header "Timezone") && status=0 || status=$?
   else
-    timezone=$(timedatectl list-timezones | gum filter --height 10 --header "Timezone") && status=0 || status=$?
+    timezone=$(omarchy_timezones | gum filter --height 10 --header "Timezone") && status=0 || status=$?
   fi
   ((status == 0)) || return $status
 

--- a/test/shell.d/setup-form-test.sh
+++ b/test/shell.d/setup-form-test.sh
@@ -216,6 +216,8 @@ assert_status 0 "timezone prompt accepts the geo guess"
 [[ $(field timezone) == "Europe/Copenhagen" ]] || fail "timezone prompt keeps the chosen timezone"
 grep -qF -- '--selected Europe/Copenhagen' "$GUM_ARGS" || fail "timezone prompt preselects the geo guess"
 grep -qF UTC "$tmp_dir/stdin.1" || fail "timezone prompt offers the system timezone list"
+grep -qFx Asia/Ashgabat "$tmp_dir/stdin.1" || fail "timezone prompt offers the canonical zone"
+! grep -qFx Asia/Ashkhabad "$tmp_dir/stdin.1" || fail "timezone prompt drops tzdata backward-compatibility aliases"
 pass "timezone prompt preselects the geo guess when one is available"
 
 # An unnetworked first boot has no guess, and the fallback has to survive `set -e`

--- a/test/shell.d/timezone-test.sh
+++ b/test/shell.d/timezone-test.sh
@@ -19,6 +19,12 @@ grep -F '%wheel ALL=(root) NOPASSWD: /usr/bin/timedatectl ^set-timezone [A-Za-z0
 grep -F 'sudo timedatectl set-timezone "$timezone"' "$timezone_menu" >/dev/null ||
   fail "timezone menu uses the passwordless sudoers timedatectl rule"
 
+grep -F '/usr/share/zoneinfo/zone.tab' "$timezone_menu" >/dev/null ||
+  fail "timezone menu lists zones from zone.tab"
+
+! grep -F 'timedatectl list-timezones |' "$timezone_menu" >/dev/null ||
+  fail "timezone menu does not list tzdata backward-compatibility aliases"
+
 ! grep -F 'pkexec timedatectl set-timezone "$timezone"' "$timezone_menu" >/dev/null ||
   fail "timezone menu does not wrap timedatectl in pkexec"
 


### PR DESCRIPTION
Picking a timezone shows near-duplicates: `Asia/Ashkhabad` right under `Asia/Ashgabat`, `Asia/Calcutta` under `Asia/Kolkata`, and so on.

Both pickers list `timedatectl list-timezones`. Since systemd v249 that list comes from `/usr/share/zoneinfo/tzdata.zi` and includes `L` (Link) records as well as `Z` (Zone) ones, so all 257 backward-compatibility aliases land next to the real zones — about 600 entries where ~420 are meaningful.

Read `/usr/share/zoneinfo/zone.tab` instead: one row per country per distinct zone, no obsolete aliases, and unlike `zone1970.tab` it still lists `Europe/Oslo`, `Europe/Stockholm` and the other zones tzdata has since merged into links. `UTC` is added back explicitly since `zone.tab` omits it and the setup form falls back to it.

Applied in both places that ask — `install/provisioning/setup-form.sh` (ISO configurator and first-boot owner setup) and `bin/omarchy-menu-timezone`.

Tests: `setup-form-test.sh` asserts the piped list offers `Asia/Ashgabat` and not `Asia/Ashkhabad`; `timezone-test.sh` pins the menu to `zone.tab`. Both pass. `./test/cli` fails the same pre-existing `hardware group` assertion with and without this change (run on macOS).