### PR TITLE
Document accented letters on the CapsLock compose key

### DIFF
--- a/manual/07-hotkeys.md
+++ b/manual/07-hotkeys.md
@@ -372,3 +372,21 @@ You can use `Super + Ctrl + E` to show a complete emoji picker that'll put the s
 | `CapsLock Space E` | Your email (as entered on setup)  |
 
 You can add more of your own by editing `~/.XCompose`, then running `omarchy-restart-xcompose` in the terminal to get the changes picked up.
+
+## Accents and Special Characters
+
+CapsLock is a standard [compose key](https://en.wikipedia.org/wiki/Compose_key), so the full system compose table works on the plain `us` layout too. Press the keys one after another rather than holding them: CapsLock, then the accent, then the letter. Capital letters work the same way with Shift.
+
+| Hotkey       | Result       |
+| ------------ |  ---------- |
+| `CapsLock ' E` | é (also á í ó ú)   |
+| ``CapsLock ` E`` | è (also à ì ò ù)   |
+| `CapsLock ~ N` | ñ   |
+| `CapsLock " U` | ü (also ä ë ï ö)   |
+| `CapsLock ^ E` | ê   |
+| `CapsLock , C` | ç   |
+| `CapsLock S S` | ß   |
+| `CapsLock ? ?` | ¿   |
+| `CapsLock ! !` | ¡   |
+| `CapsLock = E` | €   |
+| `CapsLock O O` | °   |

--- a/manual/34-keyboard-mouse-trackpad.md
+++ b/manual/34-keyboard-mouse-trackpad.md
@@ -37,7 +37,7 @@ o.window("(Alacritty|kitty|foot)", { scroll_touchpad = 1.5 })
 
 You can [see all the input options](https://wiki.hypr.land/Configuring/Basics/Variables/#input) on the Hyprland wiki for inputs.
 
-By default, Omarchy uses CapsLock as the compose key for [quick emojis](07-hotkeys.md#quick-emojis) and [other completions](07-hotkeys.md#quick-completions). If you'd rather use CapsLock as Caps Lock, move the compose key elsewhere by changing `compose:caps` in `kb_options`. For example, this moves the compose key to Right Alt:
+By default, Omarchy uses CapsLock as the compose key for [quick emojis](07-hotkeys.md#quick-emojis), [accents](07-hotkeys.md#accents-and-special-characters), and [other completions](07-hotkeys.md#quick-completions). If you'd rather use CapsLock as Caps Lock, move the compose key elsewhere by changing `compose:caps` in `kb_options`. For example, this moves the compose key to Right Alt:
 
 ```lua
 hl.config({

--- a/manual/45-troubleshooting.md
+++ b/manual/45-troubleshooting.md
@@ -12,7 +12,7 @@ For Spotify, you can use `Ctrl + Minus` to shrink the UI (and `Ctrl + Plus` to m
 
 ### Why isn't Caps Lock working?
 
-In Omarchy, Caps Lock has been designated to be the xcompose key. That's how you get [quick emojis](07-hotkeys.md#quick-emojis) and [other autocompletions](07-hotkeys.md#quick-completions) done. If you really miss using Caps Lock, you can remap the xcompose key to something else by editing `~/.config/hypr/input.lua`, like setting it to the right alt key:
+In Omarchy, Caps Lock has been designated to be the xcompose key. That's how you get [quick emojis](07-hotkeys.md#quick-emojis), [accented letters](07-hotkeys.md#accents-and-special-characters), and [other autocompletions](07-hotkeys.md#quick-completions) done. If you need actual caps, press both Shift keys together to turn Caps Lock on, and any single Shift press to turn it back off. If you really miss using Caps Lock, you can remap the xcompose key to something else by editing `~/.config/hypr/input.lua`, like setting it to the right alt key:
 
 ```
 hl.config({


### PR DESCRIPTION
## Summary

The hotkeys chapter documents the emoji and name/email sequences behind CapsLock, but nothing in the manual says the system compose table is loaded too. So `CapsLock ' E` → é, ``CapsLock ` E`` → è and `CapsLock ~ N` → ñ already work on the plain `us` layout, and nobody knows. Spanish, Italian, Portuguese and German users keep concluding Caps Lock is simply broken (#9560, #9392) and go hunting for a `kb_variant = "intl"` or an `~/.XCompose` override they don't need.

## Change

- `manual/07-hotkeys.md`: new **Accents and Special Characters** section after Quick Completions with a short table (acute, grave, tilde, diaeresis, circumflex, cedilla, ß, ¿ ¡, €, °). Every row was checked against the compiled table from `xkbcli compile-compose` on a stock install.
- `manual/34-keyboard-mouse-trackpad.md` and `manual/45-troubleshooting.md`: link the new section from the two places that already explain CapsLock is the compose key.
- Troubleshooting entry also says where Caps Lock itself went: both Shifts together turns it on, a single Shift turns it off (`shift:both_capslock_cancel`, the default in `default/hypr/input.lua`).

Docs only, no behavior change.

`./test/all` on this branch fails the same five `test/shell.d` files as a clean `quattro` checkout here (three need an `omarchy-pkgs` checkout, two are scripts without the executable bit plus a Quickshell geometry rounding check); none touch `manual/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018WkCkwpv7MXMNxKTryEZVG
