### PR TITLE
power: color battery indicator by charge state

### DIFF
--- a/shell/plugins/panels/power/Model.js
+++ b/shell/plugins/panels/power/Model.js
@@ -49,6 +49,16 @@ function batteryFraction(device) {
   return device && device.isPresent ? Math.max(0, Math.min(1, device.percentage)) : 0
 }
 
+// Below 20% — drives the red tint on the indicator.
+function batteryIsLow(device) {
+  return !!(device && device.isPresent) && batteryFraction(device) < 0.2
+}
+
+// Below 5% — additionally surfaces the exclamation mark.
+function batteryIsCritical(device) {
+  return !!(device && device.isPresent) && batteryFraction(device) < 0.05
+}
+
 function chargeThresholdActive(device, onBattery, states) {
   var d = device || {}
   var s = states || {}
@@ -97,6 +107,8 @@ if (typeof module !== "undefined") {
     parseProfiles: parseProfiles,
     profileIcon: profileIcon,
     batteryFraction: batteryFraction,
+    batteryIsLow: batteryIsLow,
+    batteryIsCritical: batteryIsCritical,
     chargeThresholdActive: chargeThresholdActive,
     batteryIcon: batteryIcon,
     modeLabel: modeLabel

--- a/shell/plugins/panels/power/Panel.qml
+++ b/shell/plugins/panels/power/Panel.qml
@@ -49,7 +49,8 @@ Panel {
 
   function batteryIcon() {
     var device = UPower.displayDevice
-    return Model.batteryIcon(device, root.discharging, upowerStates())
+    var icon = Model.batteryIcon(device, root.discharging, upowerStates())
+    return root.batteryCritical ? icon + "!" : icon
   }
 
   function modeLabel() {
@@ -87,7 +88,25 @@ Panel {
     return d && d.isPresent && !UPower.onBattery && !root.batteryFlowIdle
   }
 
-  readonly property color batteryFillColor: {
+  // Percentage-only thresholds — independent of charge state, so these stay
+  // true even while charging (e.g. a device plugged in at 3% is still
+  // "critical" until it climbs back over 5%).
+  readonly property bool batteryLow: Model.batteryIsLow(UPower.displayDevice)
+  readonly property bool batteryCritical: Model.batteryIsCritical(UPower.displayDevice)
+
+  // Colors for the low/critical/charging indicator states. These are
+  // literal values rather than theme tokens because Color.qml lives outside
+  // this plugin — swap in e.g. Color.error / Color.success here if this
+  // shell's palette exposes semantic colors under those (or similar) names.
+  readonly property color batteryLowColor: "#e5484d"
+  readonly property color batteryChargingColor: "#30a46c"
+
+  // Shared color for every visual battery indicator (bar icon, panel hero
+  // icon, progress bar fill). Charging wins over low-battery red — a
+  // battery recovering from 3% is good news, not an alarm.
+  readonly property color batteryIndicatorColor: {
+    if (root.charging) return root.batteryChargingColor
+    if (root.batteryLow) return root.batteryLowColor
     return root.bar ? root.bar.foreground : Color.foreground
   }
 
@@ -280,6 +299,7 @@ Panel {
     text: root.showPercentage && !vertical
       ? Math.round(root.batteryFraction * 100) + "% " + root.batteryIcon()
       : root.batteryIcon()
+    foreground: root.batteryIndicatorColor
     slotSize: Style.bar.iconSlot * (root.showPercentage && !vertical ? 2 : 1)
     tooltipText: ""
     onPressed: function(b) {
@@ -325,9 +345,8 @@ Panel {
 
           Text {
             id: heroIcon
-            textFormat: Text.PlainText
             text: root.batteryIcon()
-            color: root.bar.foreground
+            color: root.batteryIndicatorColor
             font.family: root.bar.fontFamily
             font.pixelSize: Style.font.display
             anchors.left: parent.left
@@ -357,7 +376,6 @@ Panel {
 
             Text {
               id: heroStatus
-              textFormat: Text.PlainText
               text: root.heroStatusText.toUpperCase()
               color: Qt.darker(root.bar.foreground, 1.4)
               font.family: root.bar.fontFamily
@@ -371,7 +389,6 @@ Panel {
 
           Text {
             id: heroPercent
-            textFormat: Text.PlainText
             text: root.batteryInfo.percentage || "—"
             color: root.bar.foreground
             font.family: root.bar.fontFamily
@@ -402,7 +419,7 @@ Panel {
             anchors.verticalCenter: barTrack.verticalCenter
             height: barTrack.height
             radius: barTrack.radius
-            color: root.batteryFillColor
+            color: root.batteryIndicatorColor
             width: Math.max(barTrack.height, barTrack.width * root.batteryFraction)
 
             Behavior on width { NumberAnimation { duration: 320; easing.type: Easing.OutCubic } }
@@ -520,7 +537,6 @@ Panel {
   }
 
   component InfoLabel: Text {
-    textFormat: Text.PlainText
     color: root.bar.foreground
     opacity: 0.6
     font.family: root.bar.fontFamily
@@ -528,7 +544,6 @@ Panel {
   }
 
   component InfoValue: Text {
-    textFormat: Text.PlainText
     color: root.bar.foreground
     font.family: root.bar.fontFamily
     font.pixelSize: Style.font.bodySmall


### PR DESCRIPTION
## Omarchy Power

Bar widget showing battery, power profile, and system stats. Backed by
`UPower` for battery state and a handful of `omarchy-*` shell commands for
profiles and system stats.

## Files

| File | Role |
| --- | --- |
| `manifest.json` | Plugin/widget declaration (`bar-widget`, entry point `Panel.qml`). |
| `Panel.qml` | UI: bar icon, popup panel (hero icon, progress bar, stats, power-profile picker). |
| `Model.js` | Pure, framework-free helper functions used by `Panel.qml`. Kept separate so the logic is testable without a running shell. |

## Battery indicator states

The battery is drawn in three places that all share one color: the bar
icon, the panel's hero icon, and the progress bar fill.

| State | Condition | Appearance |
| --- | --- | --- |
| Normal | ≥ 20% charge, not charging | Theme foreground color |
| Low | < 20% charge | Red (`batteryLowColor`) |
| Critical | < 5% charge | Red, plus a `!` appended to the battery glyph |
| Charging | Actively charging (see below) | Green (`batteryChargingColor`) |

Notes on precedence:

- **Charging wins over low/critical color.** A battery recovering from 3%
  is good news, not an alarm, so the green tint takes priority over red
  whenever `root.charging` is true. "Charging" here already excludes
  `FullyCharged` and an active charge-threshold hold (`batteryFlowIdle`),
  matching the rest of the file's existing `charging` property.
- **The `!` mark is percentage-only.** It's driven purely by
  `batteryIsCritical` (< 5%), independent of charge state — so it can
  still show up while charging back from a very low percentage.

The threshold checks live in `Model.js` as `batteryIsLow(device)` and
`batteryIsCritical(device)`, following the file's existing style of thin,
pure wrappers around `batteryFraction`. `Panel.qml` exposes them as
`batteryLow` / `batteryCritical`, and combines them with `charging` into a
single `batteryIndicatorColor` property that every visual battery element
binds to.

## Testing without draining the battery

To visually check the low/critical states without waiting for a real
laptop to discharge, temporarily hardcode the two state properties in
`Panel.qml`

### < 20% charge:
<img width="510" height="358" alt="screenshot-2026-09-11_11-58-44" src="https://github.com/user-attachments/assets/184768f4-d96c-422e-ae2c-6971dbeca011" />

### < 5% charge:
<img width="517" height="370" alt="screenshot-2026-09-11_11-58-26" src="https://github.com/user-attachments/assets/659311a7-a65c-4c39-9b8b-6156d6c9d83e" />

### Actively charging (see below):
<img width="528" height="370" alt="screenshot-2026-09-11_11-58-08" src="https://github.com/user-attachments/assets/516b70de-6f4e-427a-9672-f19be52f6b58" />

