### PR TITLE
Resolve the SDDM greeter's keyboard layout from vconsole.conf

### DIFF
--- a/default/hypr/input.lua
+++ b/default/hypr/input.lua
@@ -1,58 +1,13 @@
 -- https://wiki.hypr.land/Configuring/Basics/Variables/#input
 
-local function read_vconsole()
-  local values = {}
-  local file = io.open("/etc/vconsole.conf", "r")
-  if not file then
-    return values
-  end
-
-  for line in file:lines() do
-    local key, value = line:match("^%s*([%w_]+)%s*=%s*(.-)%s*$")
-    if key and value then
-      value = value:gsub("%s+#.*$", "")
-      value = value:gsub('^"(.*)"$', "%1")
-      value = value:gsub("^'(.*)'$", "%1")
-      values[key] = value
-    end
-  end
-
-  file:close()
-  return values
-end
-
--- Layouts that can't type Latin letters. Keep in sync with the list in
--- etc/mkinitcpio.conf.d/omarchy_hooks.conf.
-local non_latin_layouts =
-  " af am ara bd bg by et ge gr il in iq ir kg kh kz la lk mk mm mn mv np rs ru sy th tj ua "
-
-local vconsole = read_vconsole()
-
-local kb_layout = vconsole.XKBLAYOUT or "us"
-local kb_variant = vconsole.XKBVARIANT or ""
--- CapsLock is the compose key, so Caps Lock itself has to live somewhere else.
--- Both Shifts together is the usual home for it, but it's easy to hit by
--- accident while typing. The _cancel variant sets Caps Lock the same way and
--- releases it on the next lone Shift, so a misfire clears itself.
-local kb_options = "compose:caps,shift:both_capslock_cancel"
-
--- Hyprland resolves keybindings against the first entry in kb_layout, not the
--- layout that's currently active, so Omarchy's Latin-keysym bindings (SUPER + W
--- and friends) only fire when a Latin layout leads. Installing with a non-Latin
--- one would otherwise leave the desktop unusable.
-if non_latin_layouts:find(" " .. kb_layout:match("^[^,]*") .. " ", 1, true) then
-  kb_layout = "us," .. kb_layout
-  kb_variant = "," .. kb_variant
-  -- Reach the original layout with Left Alt + Right Alt.
-  kb_options = kb_options .. ",grp:alts_toggle"
-end
+local keyboard = require("default.hypr.keyboard")
 
 hl.config({
   input = {
-    kb_layout = kb_layout,
-    kb_variant = kb_variant,
+    kb_layout = keyboard.layout,
+    kb_variant = keyboard.variant,
     kb_model = "",
-    kb_options = kb_options,
+    kb_options = keyboard.options,
     kb_rules = "",
     follow_mouse = 1,
     sensitivity = 0,

--- a/default/hypr/keyboard.lua
+++ b/default/hypr/keyboard.lua
@@ -1,0 +1,57 @@
+-- Resolves the keyboard layout Omarchy should use from /etc/vconsole.conf.
+-- Both the user session (default/hypr/input.lua) and the SDDM greeter
+-- (default/sddm/hyprland.lua) import this so a password types the same way in
+-- the greeter as it does everywhere else.
+
+local function read_vconsole()
+  local values = {}
+  local file = io.open("/etc/vconsole.conf", "r")
+  if not file then
+    return values
+  end
+
+  for line in file:lines() do
+    local key, value = line:match("^%s*([%w_]+)%s*=%s*(.-)%s*$")
+    if key and value then
+      value = value:gsub("%s+#.*$", "")
+      value = value:gsub('^"(.*)"$', "%1")
+      value = value:gsub("^'(.*)'$", "%1")
+      values[key] = value
+    end
+  end
+
+  file:close()
+  return values
+end
+
+-- Layouts that can't type Latin letters. Keep in sync with the list in
+-- etc/mkinitcpio.conf.d/omarchy_hooks.conf.
+local non_latin_layouts =
+  " af am ara bd bg by et ge gr il in iq ir kg kh kz la lk mk mm mn mv np rs ru sy th tj ua "
+
+local vconsole = read_vconsole()
+
+local kb_layout = vconsole.XKBLAYOUT or "us"
+local kb_variant = vconsole.XKBVARIANT or ""
+-- CapsLock is the compose key, so Caps Lock itself has to live somewhere else.
+-- Both Shifts together is the usual home for it, but it's easy to hit by
+-- accident while typing. The _cancel variant sets Caps Lock the same way and
+-- releases it on the next lone Shift, so a misfire clears itself.
+local kb_options = "compose:caps,shift:both_capslock_cancel"
+
+-- Hyprland resolves keybindings against the first entry in kb_layout, not the
+-- layout that's currently active, so Omarchy's Latin-keysym bindings (SUPER + W
+-- and friends) only fire when a Latin layout leads. Installing with a non-Latin
+-- one would otherwise leave the desktop unusable.
+if non_latin_layouts:find(" " .. kb_layout:match("^[^,]*") .. " ", 1, true) then
+  kb_layout = "us," .. kb_layout
+  kb_variant = "," .. kb_variant
+  -- Reach the original layout with Left Alt + Right Alt.
+  kb_options = kb_options .. ",grp:alts_toggle"
+end
+
+return {
+  layout = kb_layout,
+  variant = kb_variant,
+  options = kb_options,
+}

--- a/default/sddm/hyprland.lua
+++ b/default/sddm/hyprland.lua
@@ -1,6 +1,21 @@
 -- Minimal Hyprland config for the SDDM Wayland greeter.
 -- SDDM starts the greeter itself after the compositor is ready.
+
+-- SDDM launches this config with an explicit --config, so nothing in
+-- default/hypr is loaded and Hyprland would fall back to its built-in "us"
+-- layout. The greeter is the only place a password is typed by hand, so a
+-- non-US layout there rejects correct passwords. dofile keeps this independent
+-- of package.path and $HOME, neither of which the greeter's environment sets.
+local keyboard = dofile((os.getenv("OMARCHY_PATH") or "/usr/share/omarchy") .. "/default/hypr/keyboard.lua")
+
 hl.config({
+  input = {
+    kb_layout = keyboard.layout,
+    kb_variant = keyboard.variant,
+    kb_options = keyboard.options,
+    numlock_by_default = true,
+  },
+
   misc = {
     disable_hyprland_logo = true,
     disable_splash_rendering = true,

--- a/test/shell.d/hyprland-keyboard-layout-test.sh
+++ b/test/shell.d/hyprland-keyboard-layout-test.sh
@@ -39,20 +39,60 @@ require("default.hypr.input")
 LUA
 }
 
-assert_input() {
-  local description="$1"
-  local expected="$2"
+resolved_greeter_input() {
+  OMARCHY_PATH="$ROOT" OMARCHY_VCONSOLE="${1-}" lua <<'LUA'
+local vconsole = os.getenv("OMARCHY_VCONSOLE")
+local real_open = io.open
+
+io.open = function(path, mode)
+  if path ~= "/etc/vconsole.conf" then
+    return real_open(path, mode)
+  end
+
+  if not vconsole then
+    return nil
+  end
+
+  local file = io.tmpfile()
+  file:write(vconsole)
+  file:seek("set")
+  return file
+end
+
+hl = {
+  config = function(config)
+    local input = config.input
+    print(("[%s] [%s] [%s]"):format(input.kb_layout, input.kb_variant, input.kb_options))
+  end,
+}
+
+dofile(os.getenv("OMARCHY_PATH") .. "/default/sddm/hyprland.lua")
+LUA
+}
+
+assert_resolved() {
+  local resolver="$1"
+  local description="$2"
+  local expected="$3"
   local actual
 
-  if (( $# > 2 )); then
-    actual=$(resolved_input "$3")
+  if (( $# > 3 )); then
+    actual=$("$resolver" "$4")
   else
-    actual=$(resolved_input)
+    actual=$("$resolver")
   fi
 
   [[ $actual == "$expected" ]] ||
     fail "$description" "expected: $expected"$'\n'"actual:   $actual"
   pass "$description"
+}
+
+assert_input() {
+  assert_resolved resolved_input "$@"
+}
+
+assert_greeter_input() {
+  assert_resolved resolved_greeter_input "$@"
 }
 
 base_options="compose:caps,shift:both_capslock_cancel"
@@ -73,11 +113,22 @@ XKBVARIANT=phonetic
 assert_input "non-latin layout in front gains us even when us trails" "[us,il,us] [,] [$toggle_options]" 'XKBLAYOUT=il,us
 '
 
+# The SDDM greeter is the only place a password is typed by hand, so it has to
+# resolve the same layout as the session. It gets an explicit --config, so a
+# missing input block silently leaves it on Hyprland's built-in "us".
+assert_greeter_input "greeter falls back to us without vconsole.conf" "[us] [] [$base_options]"
+assert_greeter_input "greeter follows the system layout" "[de] [deadacute] [$base_options]" 'XKBLAYOUT=de
+XKBVARIANT=deadacute
+'
+assert_greeter_input "greeter matches the session for non-latin layouts" "[us,ru] [,phonetic] [$toggle_options]" 'XKBLAYOUT=ru
+XKBVARIANT=phonetic
+'
+
 hooks_conf="$ROOT/etc/mkinitcpio.conf.d/omarchy_hooks.conf"
-input_lua="$ROOT/default/hypr/input.lua"
+keyboard_lua="$ROOT/default/hypr/keyboard.lua"
 
 hooks_layouts=$(awk -F')' '/\) ;;$/ { gsub(/[[:space:]|]+/, "\n", $1); print $1 }' "$hooks_conf" | grep '^[a-z]\+$' | sort)
-lua_layouts=$(sed -n '/^local non_latin_layouts =/,+1p' "$input_lua" | grep -o '"[^"]*"' | tr -d '"' | tr ' ' '\n' | grep '^[a-z]\+$' | sort)
+lua_layouts=$(sed -n '/^local non_latin_layouts =/,+1p' "$keyboard_lua" | grep -o '"[^"]*"' | tr -d '"' | tr ' ' '\n' | grep '^[a-z]\+$' | sort)
 
 [[ -n $hooks_layouts ]] || fail "non-latin layout list is readable from omarchy_hooks.conf"
 [[ $hooks_layouts == "$lua_layouts" ]] ||


### PR DESCRIPTION
## Problem

SDDM starts the greeter's compositor with an explicit `--config`:

```
CompositorCommand=start-hyprland -- --config /usr/share/sddm/hyprland.lua
```

so nothing under `default/hypr` is loaded, and `default/sddm/hyprland.lua` never declares an `input` block. Hyprland therefore falls back to its built-in `us` layout. Confirmed by running the current config in a headless Hyprland:

```
input:kb_layout  →  str: us    set: false
```

`set: false` — nothing sets it at all.

The greeter is the only place a password is typed by hand, so on any non-US layout it silently rejects correct passwords. Autologin makes this worse by hiding it: the first login never verifies a password, so the bug only surfaces on the first manual logout, long after install, with no error pointing at the layout.

Reported repeatedly across layouts: #6880 (AZERTY, labeled bug), #9421, #10269 (UK, identifies the autologin masking), #10454, #10842 (Colemak/Russian).

## Fix

`default/hypr/input.lua` already resolves this correctly from `/etc/vconsole.conf`. This moves that logic into a shared `default/hypr/keyboard.lua` and imports it from both the session config and the greeter, so a password types identically in both places. No behaviour change for the session.

The greeter uses `dofile` rather than `require`: its environment sets neither `package.path` nor `$HOME`, and `default/hypr/bootstrap.lua` concatenates `os.getenv("HOME")`, which would throw and take the login screen down entirely. `dofile` with the `$OMARCHY_PATH` fallback mirrors the pattern already in `config/hypr/hyprland.lua`.

The non-Latin handling comes along for free, which also covers #10842: a Russian or Colemak greeter now gets `us` prepended and `grp:alts_toggle`, matching the session.

## Tests

`test/shell.d/hyprland-keyboard-layout-test.sh` gains three greeter assertions, and its layout-list sync check now points at the shared module:

```
ok - greeter falls back to us without vconsole.conf
ok - greeter follows the system layout
ok - greeter matches the session for non-latin layouts
```

All 10 assertions pass; the greeter ones fail against the current config, so they lock the regression out.

`./test/cli` passes. On `./test/shell`, 5 files fail (`config`, `locate`, `runtime-smoke`, `snapper`, `unowned-system-paths`) — all 5 fail identically on a clean `quattro` checkout on this host, so they're unrelated.

## Verification

Beyond the unit tests, I ran the patched greeter config in a real headless Hyprland with `/etc/vconsole.conf` set to `XKBLAYOUT=de` / `XKBVARIANT=deadacute`:

```
kb_layout   str: de          set: true
kb_variant  str: deadacute   set: true
kb_options  str: compose:caps,shift:both_capslock_cancel   set: true
configerrors: (none)
```

The equivalent config has also been running as the actual greeter on my machine (German/`de`, Omarchy 4.0.3) since before this PR, and login now works with the password typed normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)