### PR TITLE
Open the whole folder in the image viewer

### DIFF
--- a/applications/imv.desktop
+++ b/applications/imv.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=Image Viewer
-Exec=imv %F
+Exec=imv-dir %F
 Icon=imv
 Type=Application
 MimeType=image/png;image/jpeg;image/jpg;image/gif;image/bmp;image/webp;image/tiff;image/x-xcf;image/x-portable-pixmap;image/x-xbitmap;

--- a/migrations/1789116503.sh
+++ b/migrations/1789116503.sh
@@ -1,0 +1,11 @@
+echo "Open the whole folder in the image viewer, not just the clicked file"
+
+# imv.desktop used to run `imv %F`. A file manager passes only the file that was
+# clicked, so imv got a one-image playlist and next/prev (including the arrow
+# keys) had nothing to move to. `imv-dir`, shipped with the imv package, opens
+# the containing directory and starts on the clicked file, and passes a
+# multi-file selection straight through. Refresh just that file.
+dest="$HOME/.local/share/applications/imv.desktop"
+if [[ -f $dest ]]; then
+  cp "$OMARCHY_PATH/applications/imv.desktop" "$dest"
+fi


### PR DESCRIPTION
Fixes #11292.

`applications/imv.desktop` runs `imv %F`. A file manager passes only the file you clicked, so imv is handed a one-image playlist and next/prev — the arrow keys, `[`/`]`, `n`/`p` — have nowhere to go. Up/Down still zoom, so it reads as "the arrow keys are broken" rather than "there is nothing to navigate to."

The imv package already ships `/usr/bin/imv-dir` for exactly this:

```sh
#!/bin/sh -efu
if [ $# -ge 2 ]; then
  exec imv "$@"
else
  exec imv -n "$1" "$(dirname "$1")"
fi
```

So a single image opens its whole containing folder and starts on the one that was clicked, while a multi-file selection passes straight through to `imv` unchanged. No new dependency — `imv-dir` comes from the same `imv` package already in `omarchy-base.packages`.

The migration refreshes the copy in `~/.local/share/applications/`, following the same shape as the `Docker.desktop` refresh in 1787580187.

This was reported before in #4050 and closed with "Arrow keys only work when you open multiple images at once" — true of imv as invoked, but three people followed up saying it still wasn't what they expected, and one posted a hand-rolled `sh -c` wrapper doing what `imv-dir` already does. Opening a folder's worth of images from one click is what eog, gwenview and Loupe all do.

### Testing

`./test/all`: 231 of 236 test files pass. The 5 failures (`config`, `locate`, `runtime-smoke`, `snapper`, `unowned-system-paths`) fail identically on `quattro` without this change — they want an `omarchy-pkgs` checkout or a clean graphical session.

Migration checked against temporary homes for all three states:

- no `~/.local/share/applications/imv.desktop` → no-op, exit 0
- stock `Exec=imv %F` → rewritten to `Exec=imv-dir %F`
- run again → unchanged, exit 0

Verified on the running desktop: after the change, `gio open ~/Downloads/Armero.png` launches

```
imv-wayland -n /home/elladan/Downloads/Armero.png /home/elladan/Downloads
```

and left/right walk the folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QwfWKHRhdugyEYHc28UsP1
