### PR TITLE
Show applications in the microphone tooltip

### DIFF
--- a/shell/plugins/bar/widgets/Microphone.manifest.json
+++ b/shell/plugins/bar/widgets/Microphone.manifest.json
@@ -4,7 +4,7 @@
   "name": "Microphone",
   "version": "1.0.0",
   "author": "Omarchy",
-  "description": "Mic input state and mute toggle",
+  "description": "Mic input state, active applications and mute toggle",
   "kinds": [
     "bar-widget"
   ],
@@ -13,7 +13,7 @@
   },
   "barWidget": {
     "displayName": "Microphone",
-    "description": "Mic input state and mute toggle",
+    "description": "Mic input state, active applications and mute toggle",
     "category": "Audio",
     "allowMultiple": false
   }

--- a/shell/plugins/bar/widgets/Microphone.qml
+++ b/shell/plugins/bar/widgets/Microphone.qml
@@ -7,22 +7,35 @@ BarWidget {
   id: root
   moduleName: "omarchy.microphone"
 
-
   readonly property var source: Pipewire.defaultAudioSource
   readonly property bool muted: source && source.audio ? source.audio.muted : true
   readonly property real volume: source && source.audio ? source.audio.volume : 0
   readonly property var nodes: Pipewire.nodes ? Pipewire.nodes.values : []
 
-  readonly property var activeStreams: {
+  readonly property var captureStreams: {
     var list = []
     for (var i = 0; i < nodes.length; i++) {
       var node = nodes[i]
-      if (node && node.isStream && node.isSink === false && !node.audio?.muted) list.push(node)
+      if (node && node.isStream && node.isSink === false && node.audio) list.push(node)
     }
     return list
   }
 
+  readonly property var activeStreams: captureStreams.filter(node => node.ready && !node.audio.muted)
+  readonly property var applicationNames: {
+    var names = []
+    for (var i = 0; i < activeStreams.length; i++) {
+      var name = applicationName(activeStreams[i])
+      if (names.indexOf(name) === -1) names.push(name)
+    }
+    return names.sort()
+  }
+
   readonly property bool inUse: activeStreams.length > 0 && !muted
+  readonly property string tooltipText: {
+    var status = muted ? "Microphone muted" : (inUse ? "Microphone in use" : "Microphone live")
+    return status + (applicationNames.length > 0 ? "\n" + applicationNames.join("\n") : "")
+  }
 
   visible: source !== null
   implicitWidth: button.implicitWidth
@@ -32,7 +45,22 @@ BarWidget {
     if (source && source.audio) source.audio.muted = !source.audio.muted
   }
 
-  PwObjectTracker { objects: root.source ? [root.source] : [] }
+  function applicationName(node) {
+    // PipeWire properties are only safe to read after the tracker binds the node.
+    var props = node.ready ? node.properties : {}
+    var desktopID = props["application.desktop"] || props["application.id"] || ""
+    var binary = props["application.process.binary"] || ""
+    var entry = null
+    // Re-evaluate the label when the desktop entry catalogue finishes loading.
+    if (DesktopEntries.applications.values.length > 0) {
+      if (desktopID) entry = DesktopEntries.heuristicLookup(desktopID)
+      if (!entry && binary) entry = DesktopEntries.heuristicLookup(binary)
+    }
+    // Electron apps can advertise "Chromium input"; the executable identifies the app.
+    return entry ? entry.name : (binary || props["application.name"] || node.description || node.name || "Unknown application")
+  }
+
+  PwObjectTracker { objects: root.source ? [root.source].concat(root.captureStreams) : root.captureStreams }
 
   BarIconButton {
     id: button
@@ -40,7 +68,8 @@ BarWidget {
     bar: root.bar
     text: root.muted ? "󰍭" : "󰍬"
     active: root.inUse
-    tooltipText: root.muted ? "Microphone muted" : (root.inUse ? "Microphone in use" : "Microphone live")
+    tooltipText: root.tooltipText
+    onTooltipTextChanged: if (tooltipHovered && root.bar) root.bar.showTooltip(button, tooltipText)
     onPressed: function(b) {
       if (b === Qt.MiddleButton) root.bar.run("omarchy-shell shell toggle omarchy.audio")
       else root.toggleMute()


### PR DESCRIPTION
Hovering over the microphone icon currently only says "Microphone in use". This adds the application names below the status so users can see which apps have an unmuted capture stream open.

- Track capture nodes before reading their metadata, and wait until each node is ready.
- Resolve app names through desktop entries and the process executable. This identifies Slack when its stream advertises the generic name "Chromium input".
- Sort and deduplicate the names, and refresh the tooltip while it is open when the list changes.

## Preview

<img width="159" height="102" alt="image" src="https://github.com/user-attachments/assets/616d8083-6032-44e1-af37-c470c747c96f" />

## Verification

- `PYTHONDONTWRITEBYTECODE=1 ./test/all`: passed the CLI suite and all 236 shell test files, including the bar widget contract checks. Ran with the `omarchy-pkgs` and `omarchy-iso` companion checkouts.
- The first run hit an existing test interaction: earlier tests generated `.pyc` files under `bin/__pycache__`, which `locate-test.sh` tries to read as UTF-8. Reproduced that failure on unchanged `quattro`, removed the generated cache files, and reran with bytecode generation disabled.
- Optional Kitty parser and Python DBus tray checks were skipped because their dependencies are unavailable.
- Checked the running bar with one app, two apps, duplicate streams from one app, and streams closing while the tooltip stays open.
- Checked that saved Slack stream metadata resolves to "Slack" after the desktop entry catalogue loads.
