### PR TITLE
Use system font for notifications

### DIFF
--- a/shell/plugins/notifications/components/NotificationCard.qml
+++ b/shell/plugins/notifications/components/NotificationCard.qml
@@ -169,7 +169,7 @@ BorderSurface {
           Layout.fillWidth: true
           visible: root.summary.length > 0
           text: root.summary
-          font.family: "Liberation Sans"
+          font.family: root.fontFamily.length > 0 ? root.fontFamily : Style.font.family
           color: Color.notifications.text
           font.pixelSize: Style.font.title
           font.bold: true
@@ -184,7 +184,7 @@ BorderSurface {
           visible: root.sanitizedBody.length > 0
           text: root.styledBody
           textFormat: Text.StyledText
-          font.family: "Liberation Sans"
+          font.family: root.fontFamily.length > 0 ? root.fontFamily : Style.font.family
           color: root.bodyColor
           font.pixelSize: Style.font.title
           wrapMode: Text.WordWrap


### PR DESCRIPTION
Notification summary and body were hardcoded to Liberation Sans, ignoring `omarchy font set`.

Binds both Text elements in NotificationCard to the injected bar font (the fontconfig monospace alias) with a Style.font.family fallback, matching Tray/ActiveWindow.