### PR TITLE
Paste clipboard history with Ctrl+V outside terminals

### DIFF
--- a/bin/omarchy-clipboard-paste-file
+++ b/bin/omarchy-clipboard-paste-file
@@ -30,4 +30,4 @@ if [[ $copy_only == "true" ]]; then
 fi
 
 sleep 0.15
-wtype -M shift -k Insert -m shift 2>/dev/null || true
+omarchy-clipboard-paste-keystroke

--- a/bin/omarchy-clipboard-paste-keystroke
+++ b/bin/omarchy-clipboard-paste-keystroke
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# omarchy:summary=Send the paste keystroke the focused window understands
+# omarchy:group=clipboard
+# omarchy:hidden=true
+
+# Terminals paste with Shift+Insert because Ctrl+V is a control character
+# there. Everything else gets Ctrl+V: Firefox ignores a synthetic Shift+Insert,
+# so the clipboard manager pasted nothing into it. Mirrors the terminal check
+# behind SUPER+V in default/hypr/bindings/clipboard.lua.
+if hyprctl activewindow -j 2>/dev/null | jq -e '(.tags // []) | map(rtrimstr("*")) | index("terminal")' >/dev/null; then
+  wtype -M shift -k Insert -m shift 2>/dev/null || true
+else
+  wtype -M ctrl -k v -m ctrl 2>/dev/null || true
+fi

--- a/bin/omarchy-clipboard-paste-text
+++ b/bin/omarchy-clipboard-paste-text
@@ -2,19 +2,21 @@
 
 # omarchy:summary=Copy text to the clipboard and type or paste it
 # omarchy:group=clipboard
-# omarchy:args=[--shift-insert] [--copy-only] [--history-index <index>|<text>]
-# omarchy:examples=omarchy clipboard paste text "hello" | omarchy clipboard paste text --shift-insert "hello"
+# omarchy:args=[--paste] [--copy-only] [--history-index <index>|<text>]
+# omarchy:examples=omarchy clipboard paste text "hello" | omarchy clipboard paste text --paste "hello"
 # omarchy:hidden=true
 
-use_shift_insert=false
+# --paste sends the paste keystroke instead of typing the text. History entries
+# always paste this way so multi-line and large blocks arrive intact.
+use_paste_keystroke=false
 copy_only=false
 history_index=""
 text=""
 
 while (( $# > 0 )); do
   case "$1" in
-    --shift-insert)
-      use_shift_insert=true
+    --paste)
+      use_paste_keystroke=true
       shift
       ;;
     --copy-only)
@@ -42,7 +44,7 @@ copy_history_entry() {
 if [[ -n $history_index ]]; then
   copy_history_entry
   if [[ $copy_only != "true" ]]; then
-    use_shift_insert=true
+    use_paste_keystroke=true
   fi
 else
   text=${1:-}
@@ -56,8 +58,8 @@ fi
 
 sleep 0.15
 
-if [[ $use_shift_insert == "true" ]]; then
-  wtype -M shift -k Insert -m shift 2>/dev/null || true
+if [[ $use_paste_keystroke == "true" ]]; then
+  omarchy-clipboard-paste-keystroke
 else
   wtype "$text" 2>/dev/null || true
 fi

--- a/shell/plugins/clipboard/Clipboard.qml
+++ b/shell/plugins/clipboard/Clipboard.qml
@@ -218,7 +218,7 @@ Item {
     if (row.entryType === "image") {
       Quickshell.execDetached([root.omarchyPath + "/bin/omarchy-clipboard-paste-file", row.mime, row.path])
     } else if (row.fullText) {
-      Quickshell.execDetached([root.omarchyPath + "/bin/omarchy-clipboard-paste-text", "--shift-insert", "--history-index", String(row.historyIndex)])
+      Quickshell.execDetached([root.omarchyPath + "/bin/omarchy-clipboard-paste-text", "--paste", "--history-index", String(row.historyIndex)])
     }
   }
 

--- a/test/shell.d/clipboard-test.sh
+++ b/test/shell.d/clipboard-test.sh
@@ -266,6 +266,12 @@ cat >"$TMPDIR/bin/wtype" <<'SH'
 printf '%s\n' "$*" >"$WTYPE_OUT"
 SH
 
+cat >"$TMPDIR/bin/hyprctl" <<'SH'
+#!/bin/bash
+[[ $1 == "activewindow" && $2 == "-j" ]] || exit 1
+printf '{"class":"%s","tags":%s}\n' "${HYPRCTL_CLASS:-foot}" "${HYPRCTL_TAGS:-[]}"
+SH
+
 cat >"$TMPDIR/bin/omarchy-launch-browser" <<'SH'
 #!/bin/bash
 printf '%s\n' "$*" >"$BROWSER_OUT"
@@ -282,7 +288,7 @@ cat >"$TMPDIR/bin/tensaku-edit" <<'SH'
 printf '%s\n' "$*" >"$TENSAKU_OUT"
 SH
 
-chmod +x "$TMPDIR/bin/wl-copy" "$TMPDIR/bin/wl-paste" "$TMPDIR/bin/wtype" "$TMPDIR/bin/omarchy-launch-browser" "$TMPDIR/bin/omarchy-launch-editor" "$TMPDIR/bin/tensaku-edit"
+chmod +x "$TMPDIR/bin/wl-copy" "$TMPDIR/bin/wl-paste" "$TMPDIR/bin/wtype" "$TMPDIR/bin/hyprctl" "$TMPDIR/bin/omarchy-launch-browser" "$TMPDIR/bin/omarchy-launch-editor" "$TMPDIR/bin/tensaku-edit"
 
 capture_output=$(XDG_RUNTIME_DIR="$TMPDIR" XDG_STATE_HOME="$TMPDIR/state" PATH="$TMPDIR/bin:$PATH" "$ROOT/shell/plugins/clipboard/capture.sh")
 [[ $capture_output == '{"type":"text","text":"terminal copy"}' ]] || fail "clipboard capture records normal text events"
@@ -465,14 +471,31 @@ pass "clipboard watcher dies with its owner via pdeathsig"
 
 jq -n --arg text "$(printf 'large block line 1\nlarge block line 2\n')" '[{type:"text", text:"ignored"}, {type:"text", text:$text}]' >"$TMPDIR/home/.local/state/omarchy/clipboard-history.json"
 
-WL_COPY_OUT="$TMPDIR/copied" WTYPE_OUT="$TMPDIR/wtype" HOME="$TMPDIR/home" PATH="$TMPDIR/bin:$PATH" \
-  "$ROOT/bin/omarchy-clipboard-paste-text" --shift-insert --history-index 1
+WL_COPY_OUT="$TMPDIR/copied" WTYPE_OUT="$TMPDIR/wtype" HOME="$TMPDIR/home" PATH="$TMPDIR/bin:$ROOT/bin:$PATH" \
+  HYPRCTL_TAGS='["default-opacity*","terminal*"]' \
+  "$ROOT/bin/omarchy-clipboard-paste-text" --paste --history-index 1
 
 [[ $(<"$TMPDIR/copied") == "$(printf 'large block line 1\nlarge block line 2')" ]] || fail "clipboard paste helper copies history entry text"
 pass "clipboard paste helper copies history entry text"
 
-[[ $(<"$TMPDIR/wtype") == "-M shift -k Insert -m shift" ]] || fail "clipboard paste helper pastes history entries with shift insert"
-pass "clipboard paste helper pastes history entries with shift insert"
+[[ $(<"$TMPDIR/wtype") == "-M shift -k Insert -m shift" ]] || fail "clipboard paste helper pastes into terminals with shift insert"
+pass "clipboard paste helper pastes into terminals with shift insert"
+
+rm -f "$TMPDIR/wtype"
+WL_COPY_OUT="$TMPDIR/copied" WTYPE_OUT="$TMPDIR/wtype" HOME="$TMPDIR/home" PATH="$TMPDIR/bin:$ROOT/bin:$PATH" \
+  HYPRCTL_CLASS=firefox HYPRCTL_TAGS='["default-opacity*","firefox-based-browser*"]' \
+  "$ROOT/bin/omarchy-clipboard-paste-text" --paste --history-index 1
+
+[[ $(<"$TMPDIR/wtype") == "-M ctrl -k v -m ctrl" ]] || fail "clipboard paste helper pastes into other windows with ctrl v"
+pass "clipboard paste helper pastes into other windows with ctrl v"
+
+rm -f "$TMPDIR/wtype"
+WL_COPY_OUT="$TMPDIR/copied" WTYPE_OUT="$TMPDIR/wtype" HOME="$TMPDIR/home" PATH="$TMPDIR/bin:$ROOT/bin:$PATH" \
+  HYPRCTL_TAGS='[]' \
+  "$ROOT/bin/omarchy-clipboard-paste-text" --paste --history-index 1
+
+[[ $(<"$TMPDIR/wtype") == "-M ctrl -k v -m ctrl" ]] || fail "clipboard paste helper pastes into untagged windows with ctrl v"
+pass "clipboard paste helper pastes into untagged windows with ctrl v"
 
 rm -f "$TMPDIR/wtype"
 WL_COPY_OUT="$TMPDIR/copied" WTYPE_OUT="$TMPDIR/wtype" HOME="$TMPDIR/home" PATH="$TMPDIR/bin:$PATH" \
@@ -494,6 +517,14 @@ pass "clipboard file paste helper copy-only copies file content"
 
 [[ ! -e "$TMPDIR/wtype" ]] || fail "clipboard file paste helper copy-only skips paste keystroke"
 pass "clipboard file paste helper copy-only skips paste keystroke"
+
+rm -f "$TMPDIR/wtype"
+WL_COPY_OUT="$TMPDIR/copied" WTYPE_OUT="$TMPDIR/wtype" PATH="$TMPDIR/bin:$ROOT/bin:$PATH" \
+  HYPRCTL_CLASS=firefox HYPRCTL_TAGS='["firefox-based-browser*"]' \
+  "$ROOT/bin/omarchy-clipboard-paste-file" image/png "$TMPDIR/image.png"
+
+[[ $(<"$TMPDIR/wtype") == "-M ctrl -k v -m ctrl" ]] || fail "clipboard file paste helper pastes into other windows with ctrl v"
+pass "clipboard file paste helper pastes into other windows with ctrl v"
 
 jq -n --arg url 'https://example.com/docs' --arg text "$(printf 'plain text\nsecond line')" --arg image "$TMPDIR/image.png" \
   '[{type:"text", text:$url}, {type:"text", text:$text}, {type:"image", mime:"image/png", path:$image}]' >"$TMPDIR/home/.local/state/omarchy/clipboard-history.json"


### PR DESCRIPTION
## Problem

Pressing Enter in the clipboard manager copies the entry and sends `Shift+Insert` through `wtype`. Terminals and GTK apps paste on that, Firefox does not, so in Firefox the panel closes and nothing appears. Same for the image paste helper.

Reproduced on 4.0.3 with a page whose textarea mirrors its content into the window title: synthetic `Shift+Insert` left it unchanged, synthetic `Ctrl+V` pasted. The same `Shift+Insert` pastes fine into foot.

## Fix

New hidden `omarchy-clipboard-paste-keystroke` sends the chord the focused window understands, using the same terminal check as the `SUPER+V` binding in `default/hypr/bindings/clipboard.lua`:

- window tagged `terminal` gets `Shift+Insert`, since `Ctrl+V` is a control character there
- everything else gets `Ctrl+V`

`omarchy-clipboard-paste-text` and `omarchy-clipboard-paste-file` both call it. The `--shift-insert` flag on paste-text is renamed to `--paste`, since it no longer means Shift+Insert. `Clipboard.qml` is the only caller and is updated.

## Testing

- `test/shell.d/clipboard-test.sh` stubs `hyprctl activewindow -j` and covers terminal, browser and untagged windows for both helpers.
- `./test/shell`: only `locate-test.sh` and `snapper-test.sh` fail, both on the missing `omarchy-iso` checkout, unrelated.
- Live on Hyprland 0.56.2: history entry pastes into foot and into a Firefox textarea.
