### PR TITLE
Install b43-firmware for BCM4322 Wi-Fi (older MacBooks)

### DIFF
--- a/install/hardware/fix-bcm43xx.sh
+++ b/install/hardware/fix-bcm43xx.sh
@@ -1,10 +1,21 @@
 # Install Wi-Fi drivers for Broadcom chips found in some MacBooks, as well as other systems:
-# - BCM4360 (2013–2015 MacBooks)
-# - BCM4331 (2012, early 2013 MacBooks)
+# - BCM4360 (2013–2015 MacBooks) / BCM4331 (2012, early 2013): proprietary STA via broadcom-wl-dkms
+# - BCM4322 (older AirPort Extreme, PCI 14e4:432b): in-tree b43 needs AUR b43-firmware
 
 pci_info=$(lspci -nn)
 
 if (echo "$pci_info" | grep -q "14e4:43a0" || echo "$pci_info" | grep -q "14e4:4331"); then
   echo "BCM4360 / BCM4331 detected"
   omarchy-pkg-add broadcom-wl-dkms linux-headers
+fi
+
+# BCM4322 (and the open b43 path) needs cut firmware that linux-firmware does not ship.
+# Without it, dmesg reports missing b43/ucode16_mimo.fw and no wlan interface appears.
+if echo "$pci_info" | grep -q "14e4:432b"; then
+  echo "BCM4322 detected (b43 firmware required)"
+  if omarchy-pkg-aur-accessible; then
+    omarchy-pkg-aur-add b43-firmware
+  else
+    echo "AUR unavailable; install b43-firmware later so BCM4322 Wi-Fi can load firmware"
+  fi
 fi

--- a/migrations/1789091260.sh
+++ b/migrations/1789091260.sh
@@ -1,0 +1,8 @@
+echo "Install b43-firmware on BCM4322 MacBooks so Wi-Fi gets a wlan interface"
+
+# Older AirPort Extreme (BCM4322) loads b43 but needs AUR firmware linux-firmware lacks.
+if omarchy-cmd-present lspci && lspci -nn | grep -q "14e4:432b"; then
+  if omarchy-pkg-aur-accessible; then
+    omarchy-pkg-aur-add b43-firmware || true
+  fi
+fi


### PR DESCRIPTION
## Summary
Older MacBooks with **Broadcom BCM4322** (PCI `14e4:432b`, Apple AirPort Extreme) load the in-tree `b43` driver but have **no Wi-Fi interface** until cut firmware is installed. `linux-firmware-broadcom` does not ship `b43/ucode16_mimo.fw`; the AUR package `b43-firmware` does.

### Symptoms (Omarchy 4.0.3, real hardware)
- dmesg: `b43-phy0 ERROR: Firmware file "b43/ucode16_mimo.fw" not found`
- NetworkManager: `WIFI-HW: missing`, no `wlan0`
- After `b43-firmware` + reload `b43`: `wlan0` appears and associates normally

### What this changes
- Extends `install/hardware/fix-bcm43xx.sh` to detect `14e4:432b` and install `b43-firmware` via `omarchy-pkg-aur-add` when the AUR is reachable
- Leaves the existing BCM4360 / BCM4331 `broadcom-wl-dkms` path unchanged
- Adds a migration so already-installed systems pick this up on update

Related but different: #1143 covered mid-2010s BCM4360-style chips, not BCM4322.

## Test plan
- [ ] BCM4322 machine: install/update yields `b43-firmware` installed and `wlan0` usable
- [ ] BCM4360/4331 machine: still gets `broadcom-wl-dkms` only (no regression)
- [ ] Machine without those PCI IDs: no Broadcom Wi-Fi packages added
- [ ] AUR unreachable: install continues with a clear message (no hard abort beyond existing helper behavior)