### PR TITLE
Software brightness fallback when DRM backlight is missing

### DIFF
--- a/bin/omarchy-brightness-display
+++ b/bin/omarchy-brightness-display
@@ -52,7 +52,13 @@ if (( $# == 0 )); then
     exit
   fi
 
-  device="$(omarchy-hw-display)" || exit 1
+  if ! device="$(omarchy-hw-display)"; then
+    if monitor_is_internal; then
+      omarchy-brightness-display-soft get
+      exit
+    fi
+    exit 1
+  fi
   backlight_brightness "$device"
   exit
 fi
@@ -86,8 +92,20 @@ elif use_ddc_display; then
   brightness="$(omarchy-brightness-display-ddc "$monitor" "$step")" || exit 1
   (( no_osd )) || omarchy-osd -i brightness -p "$brightness"
 else
-  # Current device highlighted
-  device="$(omarchy-hw-display)" || exit 1
+  # Current device highlighted. When the kernel exposes no DRM backlight
+  # (notably older Apple + nouveau systems where GMUX is detected but never
+  # binds), fall back to software brightness on internal panels.
+  if ! device="$(omarchy-hw-display)"; then
+    if monitor_is_internal; then
+      if (( no_osd )); then
+        omarchy-brightness-display-soft --no-osd "$step"
+      else
+        omarchy-brightness-display-soft "$step"
+      fi
+      exit
+    fi
+    exit 1
+  fi
 
   # Current brightness percentage
   current=$(backlight_brightness "$device") || exit 1

--- a/bin/omarchy-brightness-display-soft
+++ b/bin/omarchy-brightness-display-soft
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+# omarchy:summary=Adjust software display brightness via Hyprland screen shader when no DRM backlight exists.
+# omarchy:args=[--no-osd] <+N%|N%-|N%|get>
+# omarchy:examples=omarchy brightness display soft +5% | omarchy brightness display soft 50% | omarchy brightness display soft get
+# omarchy:hidden=true
+
+# Used on older Apple/NVIDIA systems where nouveau skips registering a backlight
+# after detecting Apple GMUX, but apple_gmux never binds — leaving no
+# /sys/class/backlight device. Keyboard backlight is unrelated and still works.
+
+no_osd=0
+if [[ ${1:-} == --no-osd ]]; then
+  no_osd=1
+  shift
+fi
+
+step="${1:-}"
+[[ -n $step ]] || {
+  echo "usage: omarchy-brightness-display-soft [--no-osd] <+N%|N%-|N%|get>" >&2
+  exit 1
+}
+
+state_dir="${XDG_STATE_HOME:-$HOME/.local/state}/omarchy"
+shader_dir="$HOME/.config/hypr/shaders"
+shader="$shader_dir/omarchy-brightness.frag"
+state_file="$state_dir/display-brightness"
+looknfeel="$HOME/.config/hypr/looknfeel.lua"
+
+mkdir -p "$state_dir" "$shader_dir"
+
+min_g=15
+max_g=100
+
+current=100
+if [[ -f $state_file ]]; then
+  current="$(tr -d '[:space:]' <"$state_file")"
+fi
+[[ $current =~ ^[0-9]+$ ]] || current=100
+
+clamp() {
+  local v="$1"
+  ((v < min_g)) && v=$min_g
+  ((v > max_g)) && v=$max_g
+  printf '%s\n' "$v"
+}
+
+if [[ $step =~ ^\+([0-9]+)%$ ]]; then
+  target=$(clamp $((current + BASH_REMATCH[1])))
+elif [[ $step =~ ^([0-9]+)%-$ ]]; then
+  target=$(clamp $((current - BASH_REMATCH[1])))
+elif [[ $step =~ ^([0-9]+)%$ ]]; then
+  target=$(clamp "${BASH_REMATCH[1]}")
+elif [[ $step == get ]]; then
+  printf '%s\n' "$current"
+  exit 0
+else
+  echo "unsupported step: $step" >&2
+  exit 1
+fi
+
+mult="$(awk -v p="$target" 'BEGIN { printf "%.2f", p / 100 }')"
+
+cat >"$shader" <<SHADER
+#version 300 es
+
+precision highp float;
+in vec2 v_texcoord;
+uniform sampler2D tex;
+
+layout(location = 0) out vec4 fragColor;
+void main() {
+    vec4 c = texture(tex, v_texcoord);
+    fragColor = vec4(c.rgb * ${mult}, c.a);
+}
+SHADER
+
+printf '%s\n' "$target" >"$state_file"
+
+# Ensure Hyprland loads this shader (same pattern as nouveau cursor looknfeel append).
+if [[ -f $looknfeel ]] && ! grep -q 'omarchy-brightness.frag' "$looknfeel"; then
+  cat >>"$looknfeel" <<'LUA'
+
+-- Software brightness when the kernel exposes no DRM backlight (e.g. nouveau +
+-- Apple GMUX detected but unbound). Driven by omarchy-brightness-display-soft.
+hl.config({
+  decoration = {
+    screen_shader = os.getenv("HOME") .. "/.config/hypr/shaders/omarchy-brightness.frag",
+  },
+})
+LUA
+fi
+
+hyprctl reload >/dev/null 2>&1 || true
+
+((no_osd)) || omarchy-osd -i brightness -p "$target" || true
+printf '%s\n' "$target"


### PR DESCRIPTION
## Summary
On some older Apple notebooks with **NVIDIA + nouveau**, Fn brightness keys do nothing because there is **no** `/sys/class/backlight` device.

### Kernel symptoms (Omarchy 4.0.3, GeForce 9400M / LVDS-1)
- `nouveau: Apple GMUX detected: not registering Nouveau backlight interface`
- `apple_gmux: gmux device not present`
- `omarchy-hw-display` fails → `omarchy-brightness-display` exits
- Keyboard backlight (`smc::kbd_backlight`) still works via `omarchy-brightness-keyboard`

### What we tried on real hardware
- hyprsunset gamma / CTM: **no visible change** on this GPU
- Hyprland `decoration.screen_shader` with **`#version 300 es`** (matching Hyprland’s own passthru shader): **visible** dim/brighten
- Older GLSL 100 shaders fail with: `error linking program: all shaders must use same shading language version`

### What this changes
- Adds `omarchy-brightness-display-soft` to drive a per-user GLES3 screen shader multiplier (15–100%)
- `omarchy-brightness-display` falls back to that helper **only** when the focused output is internal (`LVDS`/`eDP`/`DSI`) and no DRM backlight exists
- Existing brightnessctl / DDC / Apple Studio Display paths are unchanged

## Test plan
- [ ] Machine with normal backlight: existing brightnessctl path unchanged
- [ ] Machine with empty `/sys/class/backlight` (nouveau GMUX gap): Fn brightness keys visibly change the panel; OSD updates
- [ ] Keyboard backlight keys still work
- [ ] Shader uses `#version 300 es` and does not show link errors
- [ ] External monitors still use DDC path when applicable