### PR TITLE
Make nouveau software-cursor fix reliable at install time

### DIFF
--- a/install/user/hardware/fix-nouveau-cursor.sh
+++ b/install/user/hardware/fix-nouveau-cursor.sh
@@ -1,20 +1,57 @@
-# Disable hardware cursors when the nouveau driver is in use.
+# Disable hardware cursors when the machine will stay on nouveau.
 #
 # The nouveau DRM driver does not display the hardware cursor plane on many
 # older NVIDIA GPUs, leaving the mouse pointer invisible under Hyprland.
 # Skip the fix when the proprietary driver was configured: supported GPUs can
 # still use nouveau during installation before switching drivers on reboot.
+#
+# Detection must not rely only on `lspci -k`: during install/chroot, lspci often
+# cannot load libkmod ("Unable to load libkmod resources") and silently omits
+# "Kernel driver in use", so the old check no-oped on first boot for outdated
+# NVIDIA hardware — a show-stopper when trying Omarchy.
 nvidia_config="${OMARCHY_NVIDIA_MODPROBE_CONFIG:-/etc/modprobe.d/nvidia.conf}"
+omarchy_path="${OMARCHY_PATH:-/usr/share/omarchy}"
 
-if [[ ! -f $nvidia_config ]] &&
-  omarchy-cmd-present lspci &&
-  LC_ALL=C lspci -k | grep -qi 'Kernel driver in use: nouveau'; then
+using_or_stuck_on_nouveau() {
+  # Already bound in this boot (live ISO / first session).
+  [[ -d /sys/module/nouveau ]] && return 0
+  lsmod 2>/dev/null | awk '{ print $1 }' | grep -qx nouveau && return 0
+
+  # Prefer lspci -k when libkmod works.
+  if omarchy-cmd-present lspci &&
+    LC_ALL=C lspci -k 2>/dev/null | grep -qi 'Kernel driver in use: nouveau'; then
+    return 0
+  fi
+
+  # Install-time fallback: nvidia.sh already ran and only writes nvidia.conf when
+  # a proprietary driver will take over. An NVIDIA display device with no
+  # nvidia.conf means this GPU stays on nouveau after reboot.
+  if omarchy-cmd-present lspci &&
+    LC_ALL=C lspci 2>/dev/null | grep -qiE 'VGA compatible controller: NVIDIA|3D controller: NVIDIA'; then
+    return 0
+  fi
+
+  return 1
+}
+
+if [[ ! -f $nvidia_config ]] && using_or_stuck_on_nouveau; then
   looknfeel="$HOME/.config/hypr/looknfeel.lua"
+  mkdir -p "$(dirname "$looknfeel")"
 
-  if [[ -f $looknfeel ]] && ! grep -q 'no_hardware_cursors' "$looknfeel"; then
-    echo "Detected nouveau driver. Forcing software cursors so the mouse pointer stays visible."
+  # hyprland.lua always require()'s hypr.looknfeel. Seed the packaged stub if
+  # user finalization ran before configs were copied, or the file was removed.
+  if [[ ! -f $looknfeel ]]; then
+    if [[ -f $omarchy_path/config/hypr/looknfeel.lua ]]; then
+      cp "$omarchy_path/config/hypr/looknfeel.lua" "$looknfeel"
+    else
+      printf '%s\n' "-- User look and feel overrides." >"$looknfeel"
+    fi
+  fi
 
-    cat >>"$looknfeel" <<'EOF'
+  if ! grep -q 'no_hardware_cursors' "$looknfeel"; then
+    echo "Detected nouveau / unsupported NVIDIA GPU. Forcing software cursors so the mouse pointer stays visible."
+
+    cat >>"$looknfeel" <<'LUA'
 
 -- nouveau does not display the hardware cursor plane on many older NVIDIA GPUs,
 -- leaving the pointer invisible on the physical display. Render it in software.
@@ -23,6 +60,6 @@ hl.config({
     no_hardware_cursors = true,
   },
 })
-EOF
+LUA
   fi
 fi

--- a/migrations/1789128800.sh
+++ b/migrations/1789128800.sh
@@ -1,0 +1,6 @@
+echo "Force software cursors on nouveau when install-time detection missed them"
+
+# Older fix-nouveau-cursor.sh required `lspci -k` ("Kernel driver in use: nouveau")
+# and an existing ~/.config/hypr/looknfeel.lua. Install/chroot often cannot load
+# libkmod, so first boot kept an invisible pointer on outdated NVIDIA GPUs.
+source "$OMARCHY_PATH/install/user/hardware/fix-nouveau-cursor.sh"

--- a/test/shell.d/nouveau-cursor-test.sh
+++ b/test/shell.d/nouveau-cursor-test.sh
@@ -7,42 +7,106 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 test_tmp=$(mktemp -d)
 trap 'rm -rf "$test_tmp"' EXIT
 
-mkdir -p "$test_tmp/bin" "$test_tmp/home/.config/hypr"
+mkdir -p "$test_tmp/bin" "$test_tmp/home/.config/hypr" "$test_tmp/omarchy/config/hypr"
+# Packaged stub used when seeding a missing looknfeel.
+printf '%s\n' '-- Packaged looknfeel stub' >"$test_tmp/omarchy/config/hypr/looknfeel.lua"
+
+# Default fake lspci: -k is blind (install/chroot libkmod failure), plain lspci
+# still reports an NVIDIA VGA device.
 cat >"$test_tmp/bin/lspci" <<'SH'
 #!/bin/bash
-printf '%s\n' "Kernel driver in use: ${TEST_VIDEO_DRIVER:-nouveau}"
+if [[ ${1:-} == -k ]]; then
+  # Simulate install-time libkmod failure: no "Kernel driver in use" lines.
+  printf '%s\n' "03:00.0 VGA compatible controller: NVIDIA Corporation C79 [GeForce 9400M] (rev b1)" >&2
+  echo "lspci: Unable to load libkmod resources: error -2" >&2
+  exit 0
+fi
+printf '%s\n' "03:00.0 VGA compatible controller: NVIDIA Corporation C79 [GeForce 9400M] (rev b1)"
 SH
 chmod +x "$test_tmp/bin/lspci"
+
+# Hide real module/sysfs signals so tests exercise the lspci fallback path.
+cat >"$test_tmp/bin/lsmod" <<'SH'
+#!/bin/bash
+exit 0
+SH
+chmod +x "$test_tmp/bin/lsmod"
 
 looknfeel="$test_tmp/home/.config/hypr/looknfeel.lua"
 printf '%s\n' '-- User look and feel' >"$looknfeel"
 
 run_fix() {
+  # Optionally shadow /sys/module/nouveau by not creating it under a fake root;
+  # the script checks the real /sys/module/nouveau. Skip that path by relying on
+  # machines/CI without nouveau loaded, and cover it separately if present.
   HOME="$test_tmp/home" \
     PATH="$test_tmp/bin:$ROOT/bin:$PATH" \
+    OMARCHY_PATH="$test_tmp/omarchy" \
     OMARCHY_NVIDIA_MODPROBE_CONFIG="$test_tmp/nvidia.conf" \
-    TEST_VIDEO_DRIVER="${1:-nouveau}" \
     bash -euo pipefail -c 'source "$ROOT/install/user/hardware/fix-nouveau-cursor.sh"'
 }
 
 run_fix >/dev/null
 grep -F 'no_hardware_cursors = true' "$looknfeel" >/dev/null
-pass "nouveau hardware setup enables software cursors"
+pass "nouveau hardware setup enables software cursors when lspci -k is blind"
 
 run_fix >/dev/null
 (( $(grep -c 'no_hardware_cursors = true' "$looknfeel") == 1 )) || fail "nouveau cursor setup is idempotent"
 pass "nouveau cursor setup is idempotent"
 
+# Missing looknfeel: seed packaged stub then append.
+rm -f "$looknfeel"
+run_fix >/dev/null
+[[ -f $looknfeel ]] || fail "looknfeel is created when missing"
+grep -F -- '-- Packaged looknfeel stub' "$looknfeel" >/dev/null
+grep -F 'no_hardware_cursors = true' "$looknfeel" >/dev/null
+pass "nouveau cursor setup seeds missing looknfeel.lua"
+
+# Non-NVIDIA lspci output should not apply the fix.
 printf '%s\n' '-- User look and feel' >"$looknfeel"
-run_fix i915 >/dev/null
+cat >"$test_tmp/bin/lspci" <<'SH'
+#!/bin/bash
+if [[ ${1:-} == -k ]]; then
+  printf '%s\n' "00:02.0 VGA compatible controller: Intel Corporation Device
+Kernel driver in use: i915"
+  exit 0
+fi
+printf '%s\n' "00:02.0 VGA compatible controller: Intel Corporation Device"
+SH
+chmod +x "$test_tmp/bin/lspci"
+run_fix >/dev/null
 if grep -q 'no_hardware_cursors' "$looknfeel"; then
   fail "nouveau cursor setup ignores other video drivers"
 fi
 pass "nouveau cursor setup ignores other video drivers"
 
+# Proprietary NVIDIA path: nvidia.conf present even if lspci shows NVIDIA.
+printf '%s\n' '-- User look and feel' >"$looknfeel"
+cat >"$test_tmp/bin/lspci" <<'SH'
+#!/bin/bash
+printf '%s\n' "01:00.0 VGA compatible controller: NVIDIA Corporation Device"
+SH
+chmod +x "$test_tmp/bin/lspci"
 touch "$test_tmp/nvidia.conf"
 run_fix >/dev/null
 if grep -q 'no_hardware_cursors' "$looknfeel"; then
   fail "nouveau cursor setup skips proprietary NVIDIA installs"
 fi
 pass "nouveau cursor setup skips proprietary NVIDIA installs"
+
+# Classic happy path: lspci -k reports nouveau.
+rm -f "$test_tmp/nvidia.conf"
+printf '%s\n' '-- User look and feel' >"$looknfeel"
+cat >"$test_tmp/bin/lspci" <<'SH'
+#!/bin/bash
+if [[ ${1:-} == -k ]]; then
+  printf '%s\n' "03:00.0 VGA compatible controller: NVIDIA Corporation Device
+	Kernel driver in use: nouveau"
+  exit 0
+fi
+printf '%s\n' "03:00.0 VGA compatible controller: NVIDIA Corporation Device"
+SH
+chmod +x "$test_tmp/bin/lspci"
+run_fix >/dev/null
+grep -F 'no_hardware_cursors = true' "$looknfeel" >/dev/null
+pass "nouveau cursor setup still honors lspci -k when available"


### PR DESCRIPTION
## Summary
On older NVIDIA GPUs stuck on **nouveau** (e.g. GeForce 9400M), Hyprland’s hardware cursor plane never shows, so the mouse pointer is **invisible** — a brutal first-run experience.

Omarchy already ships `install/user/hardware/fix-nouveau-cursor.sh` to set `cursor.no_hardware_cursors = true`, but on a real Omarchy **4.0.3** install it ran and **silently did nothing**.

### What failed on real hardware
Install log between start/complete of the script:

```text
lspci: Unable to load libkmod resources: error -2
```

No `Detected nouveau…` line. Root causes:

1. **Detection depended on `lspci -k`** matching `Kernel driver in use: nouveau`. During install/chroot, libkmod often fails and that line is omitted.
2. **Append required an existing** `~/.config/hypr/looknfeel.lua`. If that user file isn’t there yet, the script no-ops even when nouveau is detected.

### What this changes
- Detect nouveau / “stuck on nouveau” via `/sys/module/nouveau`, `lsmod`, `lspci -k` when it works, and a fallback: **NVIDIA VGA/3D present and no** `/etc/modprobe.d/nvidia.conf` (after `nvidia.sh` already decided there is no proprietary driver)
- Still **skip** when proprietary NVIDIA was configured (`nvidia.conf` present)
- **Create/seed** `~/.config/hypr/looknfeel.lua` from the packaged stub when missing, then append the software-cursor override
- Migration re-runs the fix for installs that already missed it
- Expand shell tests for the blind-`lspci -k` path, missing looknfeel, idempotency, Intel ignore, and proprietary skip

## Test plan
- [ ] `bash test/shell.d/nouveau-cursor-test.sh` passes
- [ ] Fresh install on unsupported NVIDIA (nouveau-only): first Hyprland session has a visible pointer; looknfeel contains `no_hardware_cursors = true`
- [ ] Supported NVIDIA path that writes `nvidia.conf`: software-cursor override is **not** added
- [ ] Intel/AMD machine: looknfeel unchanged
- [ ] Existing nouveau machine that missed the fix: migration applies it once and is idempotent