### PR TITLE
Keep the KEF LSX II LT USB sink from suspending

### DIFF
--- a/config/wireplumber/wireplumber.conf.d/kef-lsx-no-suspend.conf
+++ b/config/wireplumber/wireplumber.conf.d/kef-lsx-no-suspend.conf
@@ -1,0 +1,19 @@
+## Never suspend the KEF LSX II LT USB sink.
+## The speaker's USB firmware stops answering control requests when the host
+## stops the stream after idle (usb_set_interface -110), and only a replug
+## recovers it. Keeping the stream open avoids the trigger.
+
+monitor.alsa.rules = [
+  {
+    matches = [
+      {
+        node.name = "~alsa_output.usb-KEF_LSX_II_LT.*"
+      }
+    ]
+    actions = {
+      update-props = {
+        session.suspend-timeout-seconds = 0
+      }
+    }
+  }
+]

--- a/migrations/1789130779.sh
+++ b/migrations/1789130779.sh
@@ -1,0 +1,9 @@
+echo "Keep the KEF LSX II LT USB sink from suspending"
+
+conf="wireplumber/wireplumber.conf.d/kef-lsx-no-suspend.conf"
+
+if [[ ! -f "$HOME/.config/$conf" ]]; then
+  omarchy-refresh-config "$conf"
+  # WirePlumber only reads conf.d at startup; restart it if it is running.
+  systemctl --user try-restart wireplumber.service 2>/dev/null || true
+fi


### PR DESCRIPTION
## Problem

The KEF LSX II LT's USB firmware locks up when the host stops the audio stream, which WirePlumber does about 5 s after a sink goes idle. The kernel then logs:

```
usb 3-4.3.2: 2:0: usb_set_interface failed (-110)
usb 3-4.3.2: clock source 1 is not valid, cannot use
usb 3-4.3.2: 2:2: cannot set freq 48000 (v2/v3): err -110
```

PipeWire fails to start the sink (`set_hw_params: Connection timed out`) and the speaker stays dead until it is unplugged and replugged. On one XPS 14 this hit on six days over three weeks, with up to ~1000 timeouts on the worst day. 10 of 12 episodes began with that exact "stop the interface" request. Nothing on the laptop had changed; it is the speaker's USB implementation, same family of firmware hang the kernel already works around for the older KEF X300A.

## Fix

A WirePlumber rule sets `session.suspend-timeout-seconds = 0` for the KEF node only, so the stream is never stopped and the trigger never fires. The cost is a continuous stream of silence and a negligible constant CPU load. Every other sink keeps the default idle suspend.

The migration seeds the file for existing installs (skipping users who already have one) and restarts WirePlumber if it is running, since `conf.d` is only read at startup.

## Verification

- With the rule active, the node stays `idle` after playback instead of dropping to `suspended`, the ALSA stream stays running, and no USB errors are logged.
- Running with this rule since 2026-09-04: zero lockups in a week, versus several per week before.
- `./test/all`: same result before and after the change. `test/shell.d/config-test.sh` and `test/shell.d/locate-test.sh` fail on a clean `quattro` checkout too, so they are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
