### PR TITLE
Keep agent selectors readable as provider counts grow

### DIFF
--- a/shell/plugins/agents/Panel.qml
+++ b/shell/plugins/agents/Panel.qml
@@ -459,32 +459,65 @@ Panel {
           }
 
           // ---------- Provider switch ----------
-          Row {
+          Flow {
             id: providerSwitch
             visible: root.providers.length > 1
             width: parent.width
-            spacing: Style.spacing.md
+            spacing: Style.spacing.sm
 
-            readonly property real cellWidth: root.providers.length > 0
-              ? (width - spacing * (root.providers.length - 1)) / root.providers.length
-              : 0
+            readonly property real minChipWidth: Style.space(88)
+            readonly property int maxFittingCols: Math.max(1, Math.floor((width + spacing) / (minChipWidth + spacing)))
+
+            readonly property int columns: {
+              var count = root.providers.length
+              if (count <= 1) return 1
+              var maxC = maxFittingCols
+
+              if (count <= maxC) return count
+
+              if (count === 4 && maxC >= 2) return 2
+              if (count === 8 && maxC >= 4) return 4
+
+              return Math.min(count, maxC)
+            }
+
+            readonly property real chipWidth: (columns > 0 && width > 0)
+              ? Math.floor((width - spacing * (columns - 1)) / columns)
+              : minChipWidth
 
             Repeater {
               model: root.providers
 
               Button {
+                id: providerChip
                 required property var modelData
                 required property int index
 
-                width: providerSwitch.cellWidth
-                text: modelData.providerName
+                width: providerSwitch.chipWidth
+                text: chipLabel.elidedText
+                tooltipText: modelData.providerName
+
+                TextMetrics {
+                  id: chipLabel
+                  text: providerChip.modelData.providerName
+                  font.family: providerChip.fontFamily
+                  font.pixelSize: providerChip.fontSize
+                  font.bold: providerChip.selected
+                  elide: Text.ElideRight
+                  // Reserve the same padding/borders as Button in every state.
+                  elideWidth: Math.max(0, providerChip.width
+                    - providerChip._reservedContentLeftInset
+                    - providerChip._reservedBorderRight - providerChip.rightPadding)
+                }
                 selected: index === root.providerIndex
                 hasCursor: root.cursorActive && index === root.providerIndex
                 bordered: true
                 foreground: root.foreground
                 fontFamily: root.fontFamily
                 fontSize: Style.font.bodySmall
+                horizontalPadding: Style.space(6)
                 verticalPadding: Style.spacing.controlPaddingY
+                clip: true
                 onClicked: {
                   root.cursorActive = true
                   root.selectProvider(index)

--- a/test/shell.d/agents-panel-test.sh
+++ b/test/shell.d/agents-panel-test.sh
@@ -15,3 +15,40 @@ assert(/else if \(buttonCode === Qt\.MiddleButton\) root\.selectProvider\(root\.
 assert(/else root\.toggle\(\)/.test(panelSource), 'agents left click still toggles the panel')
 assert(!/if \(buttonCode === Qt\.RightButton\) root\.refreshNow\(\)/.test(panelSource), 'agents right click no longer refreshes')
 JS
+
+run_node_test <<'JS'
+const fs = require('fs')
+const source = fs.readFileSync(root + '/shell/plugins/agents/Panel.qml', 'utf8')
+const block = source.match(/Flow\s*\{\s*id: providerSwitch([\s\S]*?)\n\s*Repeater/)[1]
+const expression = name => block.match(new RegExp('readonly property (?:real|int) ' + name + ': ([^\\n]+)'))[1]
+const columnsBody = block.match(/readonly property int columns: \{([\s\S]*?)\n\s*\}/)[1]
+const chipExpression = block.match(/readonly property real chipWidth: ([\s\S]*)$/)[1]
+const columns = new Function('root', 'maxFittingCols', columnsBody)
+function layout(count, width, scale = 1, gap) {
+  const Style = { space: px => Math.max(1, Math.round(px * scale)) }
+  const spacing = gap ?? Style.space(4)
+  const minChipWidth = eval(expression('minChipWidth'))
+  const maxFittingCols = eval(expression('maxFittingCols'))
+  const root = { providers: Array(count).fill({}) }
+  const n = columns(root, maxFittingCols)
+  const chip = new Function('columns', 'width', 'spacing', 'minChipWidth', 'return ' + chipExpression)(n, width, spacing, minChipWidth)
+  assert(n >= 1 && chip > 0, 'layout remains positive for ' + count + ' providers')
+  if (width > 0) assert(n * chip + (n - 1) * spacing <= width, 'chips fit available width for ' + count + ' providers')
+  return n
+}
+for (const [count, expected] of [[0,1],[1,1],[2,2],[3,3],[4,2],[5,3],[8,3]])
+  assert(layout(count, 352) === expected, count + ' providers use expected columns at standard width')
+assert(layout(8,480) === 4, 'eight providers balance as two rows when four fit')
+assert(layout(4,480) === 4, 'four providers stay in one row when they fit')
+assert(layout(8,90) === 1, 'narrow panel uses one column')
+layout(8,0)
+for (const scale of [0.833,1,1.333,1.833])
+  for (const width of [90,200,352,480])
+    for (const gap of [0,4,8]) layout(8,width,scale,gap)
+assert(/visible: providers.length > 0/.test(source), 'empty provider list keeps stock self-hiding behavior')
+assert(/visible: root.providers.length > 1/.test(block), 'single provider needs no selector')
+assert(/text: chipLabel.elidedText/.test(source) && /elide: Text.ElideRight/.test(source), 'provider names elide to the right')
+assert(/tooltipText: modelData.providerName/.test(source), 'tooltip retains the full provider name')
+assert(/font.bold: providerChip.selected/.test(source), 'elision measures the selected bold font')
+assert(/providerChip._reservedContentLeftInset/.test(source) && /providerChip._reservedBorderRight/.test(source), 'elision reserves button padding and borders')
+JS


### PR DESCRIPTION
With eight providers, the single selector row squeezes chips until their labels overlap. Use a width-aware Flow so selectors wrap while retaining a useful minimum width. Elide long names using the button's font and available content width, with the full name available in a tooltip. Four and eight providers use balanced rows when the available width permits.

Validation: `test/shell.d/agents-panel-test.sh` passes (layout counts 0/1/2/3/4/5/8, narrow/wide widths and spacing scales, elision and tooltip checks; empty and single-provider behavior unchanged). Full `./test/shell` run: 230 of 236 files pass; the 6 failures (bar-icon-geometry, config, launch-about, locate, snapper, unowned-system-paths) fail identically on the untouched base, so this change adds no new failures. Graphical VM acceptance was not run.
