### PR TITLE
Disable USB autosuspend for the enrolled fingerprint reader

### DIFF
--- a/bin/omarchy-hw-fingerprint
+++ b/bin/omarchy-hw-fingerprint
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # omarchy:summary=Returns true when a fingerprint reader is present
+# omarchy:args=[--device-path]
 # omarchy:hidden=true
 
 # Detect straight from sysfs so this works before fprintd/usbutils are
@@ -10,6 +11,19 @@
 # reader — those still match on the product string below when present.
 fingerprint_vendors=" 27c6 138a 06cb 08ff 1c7a 147e "
 usb_devices_path="${OMARCHY_USB_DEVICES_PATH:-/sys/bus/usb/devices}"
+
+# --device-path prints the matched device's sysfs directory instead of
+# staying silent, so a caller that needs to read the device's own attributes
+# (idVendor, idProduct, power/control, ...) does not have to re-implement this
+# detection to get there. Plain callers (the menu's `when`, the setup script's
+# `if !`) only look at the exit status, so this stays opt-in.
+print_path=false
+[[ "${1:-}" == "--device-path" ]] && print_path=true
+
+report_match() {
+  "$print_path" && printf '%s\n' "$1"
+  exit 0
+}
 
 # libfprint drives every reader it supports from userspace over libusb, so a
 # real reader sits there with no kernel driver bound to any of its interfaces.
@@ -43,13 +57,14 @@ for dev in "$usb_devices_path"/*; do
     # the list above on purpose (Elan also makes touchscreens), so without these
     # they match nothing. FPC leads the string on every reader on record, and
     # three letters are little to match on, so require the prefix.
-    [[ $product == *fingerprint* || $product == *biometric* || $product == *elan:arm-m4* || $product == "fpc "* ]] && exit 0
+    [[ $product == *fingerprint* || $product == *biometric* || $product == *elan:arm-m4* || $product == "fpc "* ]] && report_match "$dev"
   fi
 
   if [[ -r $dev/idVendor ]]; then
     vendor=$(<"$dev/idVendor")
-    [[ $fingerprint_vendors == *" $vendor "* ]] &&
-      ! has_kernel_driver "$dev" && exit 0
+    if [[ $fingerprint_vendors == *" $vendor "* ]] && ! has_kernel_driver "$dev"; then
+      report_match "$dev"
+    fi
   fi
 done
 

--- a/bin/omarchy-remove-security-fingerprint
+++ b/bin/omarchy-remove-security-fingerprint
@@ -27,11 +27,21 @@ remove_lock_fingerprint_pam() {
   fi
 }
 
+remove_usb_autosuspend_rule() {
+  local rule="${OMARCHY_FINGERPRINT_UDEV_RULE_PATH:-/etc/udev/rules.d/90-omarchy-fingerprint-no-autosuspend.rules}"
+
+  if [[ -f $rule ]]; then
+    echo "Removing fingerprint USB autosuspend override..."
+    sudo rm -f "$rule"
+  fi
+}
+
 
 echo -e "\e[32mRemoving fingerprint scanner from authentication.\n\e[0m"
 
 remove_pam_config
 remove_lock_fingerprint_pam
+remove_usb_autosuspend_rule
 
 echo "Removing fingerprint packages..."
 omarchy-pkg-drop fprintd libfprint libfprint-git

--- a/bin/omarchy-setup-security-fingerprint
+++ b/bin/omarchy-setup-security-fingerprint
@@ -65,6 +65,36 @@ account    include                     system-local-login
 EOF
 }
 
+# Many USB fingerprint readers (Goodix's included) come back from USB
+# autosuspend in a state libfprint can't re-claim, so verifying fails on every
+# lock screen after the first suspend/resume until the device is replugged or
+# fprintd restarted. Pin the enrolled reader's own power/control to "on" so it
+# is never asked to autosuspend in the first place.
+disable_usb_autosuspend() {
+  local rule="${OMARCHY_FINGERPRINT_UDEV_RULE_PATH:-/etc/udev/rules.d/90-omarchy-fingerprint-no-autosuspend.rules}"
+  local dev vendor product
+
+  # The detector only understands USB readers found under sysfs; anything it
+  # can't point back at a device (not found, or found some other way) skips
+  # this hardening step. PAM is already configured either way.
+  dev=$(omarchy-hw-fingerprint --device-path) || return 0
+  [[ -r "$dev/idVendor" && -r "$dev/idProduct" ]] || return 0
+
+  vendor=$(<"$dev/idVendor")
+  product=$(<"$dev/idProduct")
+
+  echo "Disabling USB autosuspend for the fingerprint reader..."
+  sudo tee "$rule" >/dev/null <<EOF
+ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="$vendor", ATTR{idProduct}=="$product", TEST=="power/control", ATTR{power/control}="on"
+EOF
+
+  # Apply to the device already plugged in, so today's session benefits
+  # without a reboot or a replug.
+  if [[ -e "$dev/power/control" ]]; then
+    echo on | sudo tee "$dev/power/control" >/dev/null
+  fi
+}
+
 
 echo -e "\e[32mSetting up fingerprint scanner for authentication.\n\e[0m"
 
@@ -100,6 +130,7 @@ if sudo fprintd-enroll "$USER"; then
     # pam_fprintd with nothing to match.
     setup_pam_config
     setup_lock_fingerprint_pam
+    disable_usb_autosuspend
     echo -e "\e[32m\nPerfect! Fingerprint authentication is now configured.\e[0m"
     echo "You can use your fingerprint for sudo, polkit, and lock screen (Super + Ctrl + L)."
   else

--- a/migrations/1789133955.sh
+++ b/migrations/1789133955.sh
@@ -1,0 +1,31 @@
+echo "Disable USB autosuspend for existing fingerprint lock-screen setups"
+
+# omarchy-setup-security-fingerprint now writes this rule itself, but a
+# machine that ran it before this migration existed never got one. Left as-is,
+# the reader comes back from USB autosuspend in a state libfprint can't
+# re-claim, so lock-screen fingerprint auth quietly stops working after the
+# first suspend/resume until the device is replugged or fprintd restarted.
+rule="${OMARCHY_FINGERPRINT_UDEV_RULE_PATH:-/etc/udev/rules.d/90-omarchy-fingerprint-no-autosuspend.rules}"
+lock_pam="${OMARCHY_LOCK_FINGERPRINT_PAM_PATH:-/etc/pam.d/omarchy-lock-fingerprint}"
+
+# Only machines that already opted into lock-screen fingerprint auth need the
+# backfill; a fresh setup run writes the rule itself, and a rule already on
+# disk (from either) means there is nothing left to do.
+if [[ -f $lock_pam ]] && [[ ! -f $rule ]]; then
+  dev=$(omarchy-hw-fingerprint --device-path) || dev=""
+
+  if [[ -n $dev && -r "$dev/idVendor" && -r "$dev/idProduct" ]]; then
+    vendor=$(<"$dev/idVendor")
+    product=$(<"$dev/idProduct")
+
+    sudo tee "$rule" >/dev/null <<EOF
+ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="$vendor", ATTR{idProduct}=="$product", TEST=="power/control", ATTR{power/control}="on"
+EOF
+
+    # Apply to the device already plugged in, so this machine benefits without
+    # waiting for a reboot or a replug.
+    if [[ -e "$dev/power/control" ]]; then
+      echo on | sudo tee "$dev/power/control" >/dev/null
+    fi
+  fi
+fi

--- a/test/shell.d/fingerprint-remove-usb-autosuspend-test.sh
+++ b/test/shell.d/fingerprint-remove-usb-autosuspend-test.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+#
+# Removing fingerprint auth has to take the autosuspend override with it --
+# leaving it behind after the PAM stacks are gone would keep re-enabling
+# power/control=on for a device fingerprint auth no longer uses.
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+scratch=$(mktemp -d)
+trap 'rm -rf "$scratch"' EXIT
+mkdir -p "$scratch/bin"
+export CALL_LOG="$scratch/calls"
+export OMARCHY_FINGERPRINT_UDEV_RULE_PATH="$scratch/fingerprint-no-autosuspend.rules"
+export PATH="$scratch/bin:$ROOT/bin:$PATH"
+
+# remove_pam_config (sed -i) and remove_lock_fingerprint_pam (rm) touch real,
+# hardcoded /etc/pam.d paths -- no host authentication file may be touched by
+# this test. Block any call naming one, whatever the command; let everything
+# else (the scratch-path rm for the autosuspend rule) through to the real tool.
+cat > "$scratch/bin/sudo" <<STUB
+#!/bin/bash
+for arg in "\$@"; do
+  case "\$arg" in
+    /etc/pam.d/*)
+      echo "blocked-real-write:\$arg" >> "$CALL_LOG"
+      exit 0
+      ;;
+  esac
+done
+exec "\$@"
+STUB
+cat > "$scratch/bin/pacman" <<'STUB'
+#!/bin/bash
+case "$1" in
+  -Qq) ;; # no installed packages, so omarchy-pkg-drop has nothing to remove
+  *) printf 'pacman %s\n' "$*" >> "$CALL_LOG"; exit 99 ;;
+esac
+STUB
+chmod +x "$scratch/bin/"*
+
+echo 'ACTION=="add"' > "$OMARCHY_FINGERPRINT_UDEV_RULE_PATH"
+
+"$ROOT/bin/omarchy-remove-security-fingerprint" > "$scratch/output" 2>&1 ||
+  fail "removal completes" "$(cat "$scratch/output")"
+
+[[ ! -f $OMARCHY_FINGERPRINT_UDEV_RULE_PATH ]] || fail "removal deletes the autosuspend rule"
+pass "removal deletes the autosuspend rule"
+
+# A machine that never had the rule (fingerprint set up before this hardening
+# step existed, or never had a matched USB reader) must not error on removal.
+"$ROOT/bin/omarchy-remove-security-fingerprint" > "$scratch/output" 2>&1 ||
+  fail "removal completes with no rule already present" "$(cat "$scratch/output")"
+pass "removal is a no-op when no autosuspend rule exists"

--- a/test/shell.d/fingerprint-usb-autosuspend-migration-test.sh
+++ b/test/shell.d/fingerprint-usb-autosuspend-migration-test.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+#
+# Backfills the USB-autosuspend override onto machines that configured
+# lock-screen fingerprint auth before omarchy-setup-security-fingerprint
+# started writing it itself.
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+migration="$ROOT/migrations/1789133955.sh"
+scratch=$(mktemp -d)
+trap 'rm -rf "$scratch"' EXIT
+mkdir -p "$scratch/bin" "$scratch/devices/1-0/power"
+export CALL_LOG="$scratch/calls"
+export OMARCHY_USB_DEVICES_PATH="$scratch/devices"
+export OMARCHY_FINGERPRINT_UDEV_RULE_PATH="$scratch/fingerprint-no-autosuspend.rules"
+export OMARCHY_LOCK_FINGERPRINT_PAM_PATH="$scratch/omarchy-lock-fingerprint"
+export PATH="$scratch/bin:$ROOT/bin:$PATH"
+
+printf '%s\n' 27c6 >"$scratch/devices/1-0/idVendor"
+printf '%s\n' 609c >"$scratch/devices/1-0/idProduct"
+printf '%s\n' "Goodix Fingerprint USB Device" >"$scratch/devices/1-0/product"
+printf '%s\n' auto >"$scratch/devices/1-0/power/control"
+
+cat > "$scratch/bin/sudo" <<'STUB'
+#!/bin/bash
+case "$1" in
+  tee) shift; exec tee "$@" ;;
+  *) echo "Unexpected privileged call: $*" >> "$CALL_LOG"; exit 99 ;;
+esac
+STUB
+chmod +x "$scratch/bin/"*
+
+run_migration() {
+  : > "$CALL_LOG"
+  OMARCHY_PATH="$ROOT" bash -euo pipefail "$migration"
+}
+
+# A machine that never configured lock-screen fingerprint auth has nothing to
+# backfill; the real setup command writes the rule for anyone who does.
+run_migration
+[[ ! -f $OMARCHY_FINGERPRINT_UDEV_RULE_PATH ]] || fail "a machine without lock-screen fingerprint auth gets no rule"
+[[ -z $(<"$CALL_LOG") ]] || fail "a machine without lock-screen fingerprint auth makes no privileged calls"
+pass "a machine without lock-screen fingerprint auth is left alone"
+
+touch "$OMARCHY_LOCK_FINGERPRINT_PAM_PATH"
+run_migration
+
+[[ -f $OMARCHY_FINGERPRINT_UDEV_RULE_PATH ]] || fail "an existing fingerprint lock-screen setup gets the rule backfilled"
+grep -qx 'ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="27c6", ATTR{idProduct}=="609c", TEST=="power/control", ATTR{power/control}="on"' \
+  "$OMARCHY_FINGERPRINT_UDEV_RULE_PATH" || fail "the backfilled rule names the detected reader's own IDs" "$(cat "$OMARCHY_FINGERPRINT_UDEV_RULE_PATH")"
+pass "an existing fingerprint lock-screen setup gets the rule backfilled"
+
+[[ $(<"$scratch/devices/1-0/power/control") == "on" ]] ||
+  fail "the backfill switches off autosuspend on the currently plugged-in reader"
+pass "the backfill switches off autosuspend on the currently plugged-in reader"
+
+run_migration
+[[ -z $(<"$CALL_LOG") ]] || fail "a rerun with the rule already in place makes no privileged calls" "$(cat "$CALL_LOG")"
+pass "a rerun with the rule already in place makes no privileged calls"
+
+# A reader matched only by product string carries no idVendor/idProduct
+# guarantee; the migration must skip it rather than write a broken rule.
+rm -rf "$scratch/devices"/*
+mkdir -p "$scratch/devices/1-0"
+printf '%s\n' "FPC Sensor Controller L:0002 FW:25.26.23.14" >"$scratch/devices/1-0/product"
+rm -f "$OMARCHY_FINGERPRINT_UDEV_RULE_PATH"
+run_migration
+[[ ! -f $OMARCHY_FINGERPRINT_UDEV_RULE_PATH ]] || fail "no rule is backfilled when the matched device has no idVendor/idProduct"
+pass "no rule is backfilled when the matched device has no idVendor/idProduct"

--- a/test/shell.d/fingerprint-usb-autosuspend-test.sh
+++ b/test/shell.d/fingerprint-usb-autosuspend-test.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+#
+# Goodix (and other) USB fingerprint readers commonly come back from USB
+# autosuspend in a state libfprint can't re-claim, breaking lock-screen
+# fingerprint auth after every suspend/resume. A successful setup run has to
+# pin the enrolled reader's own power/control to "on" so it never autosuspends.
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+scratch=$(mktemp -d)
+trap 'rm -rf "$scratch"' EXIT
+mkdir -p "$scratch/bin" "$scratch/devices/1-0/power"
+export CALL_LOG="$scratch/calls"
+export OMARCHY_USB_DEVICES_PATH="$scratch/devices"
+export OMARCHY_FINGERPRINT_UDEV_RULE_PATH="$scratch/fingerprint-no-autosuspend.rules"
+export PATH="$scratch/bin:$ROOT/bin:$PATH"
+
+printf '%s\n' 27c6 >"$scratch/devices/1-0/idVendor"
+printf '%s\n' 609c >"$scratch/devices/1-0/idProduct"
+printf '%s\n' "Goodix Fingerprint USB Device" >"$scratch/devices/1-0/product"
+printf '%s\n' auto >"$scratch/devices/1-0/power/control"
+
+# setup_pam_config and setup_lock_fingerprint_pam write to real, hardcoded
+# /etc/pam.d paths -- no host authentication file may be touched by this test.
+# Swallow exactly those writes (consume stdin, report success) and let every
+# other `sudo tee` -- the rule and power/control paths, both under $scratch --
+# through to the real tee.
+cat > "$scratch/bin/sudo" <<STUB
+#!/bin/bash
+case "\$1" in
+  pacman | fprintd-enroll) exec "\$@" ;;
+  tee)
+    shift
+    for path in "\$@"; do
+      case "\$path" in
+        /etc/pam.d/*)
+          cat >/dev/null
+          echo "blocked-real-write:\$path" >> "$CALL_LOG"
+          exit 0
+          ;;
+      esac
+    done
+    exec tee "\$@"
+    ;;
+  *) echo "Unexpected privileged call: \$*" >> "$CALL_LOG"; exit 99 ;;
+esac
+STUB
+cat > "$scratch/bin/pacman" <<'STUB'
+#!/bin/bash
+case "$1" in
+  -Q) exit 0 ;;
+  *) printf 'pacman %s\n' "$*" >> "$CALL_LOG"; exit 99 ;;
+esac
+STUB
+cat > "$scratch/bin/fprintd-enroll" <<'STUB'
+#!/bin/bash
+echo enroll >> "$CALL_LOG"
+exit 0
+STUB
+cat > "$scratch/bin/fprintd-verify" <<'STUB'
+#!/bin/bash
+echo verify >> "$CALL_LOG"
+exit 0
+STUB
+chmod +x "$scratch/bin/"*
+
+: > "$CALL_LOG"
+"$ROOT/bin/omarchy-setup-security-fingerprint" > "$scratch/output" 2>&1 ||
+  fail "a successful enrollment completes" "$(cat "$scratch/output")"
+
+[[ -f $OMARCHY_FINGERPRINT_UDEV_RULE_PATH ]] || fail "a successful setup writes the autosuspend rule"
+pass "a successful setup writes the autosuspend rule"
+
+grep -qx 'ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="27c6", ATTR{idProduct}=="609c", TEST=="power/control", ATTR{power/control}="on"' \
+  "$OMARCHY_FINGERPRINT_UDEV_RULE_PATH" ||
+  fail "the rule names the enrolled reader's own vendor and product IDs" "$(cat "$OMARCHY_FINGERPRINT_UDEV_RULE_PATH")"
+pass "the rule names the enrolled reader's own vendor and product IDs"
+
+[[ $(<"$scratch/devices/1-0/power/control") == "on" ]] ||
+  fail "the currently plugged-in reader is switched off autosuspend immediately"
+pass "the currently plugged-in reader is switched off autosuspend immediately"
+
+# A reader matched purely by its self-reported product string (the FPC/Elan
+# branches in omarchy-hw-fingerprint) has no idVendor/idProduct guarantee.
+# That must not fail the whole setup over this hardening step -- PAM is
+# already configured by the time disable_usb_autosuspend runs.
+rm -rf "$scratch/devices"/*
+mkdir -p "$scratch/devices/1-0"
+printf '%s\n' "FPC Sensor Controller L:0002 FW:25.26.23.14" >"$scratch/devices/1-0/product"
+: > "$CALL_LOG"
+rm -f "$OMARCHY_FINGERPRINT_UDEV_RULE_PATH"
+"$ROOT/bin/omarchy-setup-security-fingerprint" > "$scratch/output" 2>&1 ||
+  fail "setup still completes when the matched device has no idVendor/idProduct" "$(cat "$scratch/output")"
+[[ ! -f $OMARCHY_FINGERPRINT_UDEV_RULE_PATH ]] || fail "no rule is written when the matched device has no idVendor/idProduct"
+pass "setup completes with no autosuspend rule when the matched device has no idVendor/idProduct"

--- a/test/shell.d/hw-fingerprint-test.sh
+++ b/test/shell.d/hw-fingerprint-test.sh
@@ -103,3 +103,16 @@ assert_detects "a self-named reader is detected with a driver bound"
 
 write_usb_devices '1234:5678:Generic USB Device'
 assert_rejects "a machine with no matching USB devices detects nothing"
+
+hw_fingerprint_path() {
+  OMARCHY_USB_DEVICES_PATH="$tmp_dir/devices" "$ROOT/bin/omarchy-hw-fingerprint" --device-path
+}
+
+write_usb_devices '1234:5678:Goodix Fingerprint USB Device'
+output=$(hw_fingerprint_path) || fail "--device-path still detects the reader"
+[[ $output == "$tmp_dir/devices/1-0" ]] || fail "--device-path prints the matched device's own sysfs directory" "got: $output"
+pass "--device-path prints the matched device's own sysfs directory"
+
+output=$(hw_fingerprint) || fail "plain invocation still detects the reader"
+[[ -z $output ]] || fail "plain invocation stays silent" "got: $output"
+pass "plain invocation prints nothing, only --device-path does"


### PR DESCRIPTION
## Summary
- Many USB fingerprint readers (Goodix's included) come back from USB autosuspend in a state libfprint can't re-claim, so lock-screen fingerprint auth silently stops working after the first suspend/resume until the reader is replugged or `fprintd` is restarted.
- `omarchy-setup-security-fingerprint` now pins the enrolled reader's own `power/control` to `on` via a udev rule scoped to its exact vendor/product ID, applies it immediately to the plugged-in device, and `omarchy-remove-security-fingerprint` cleans it up.
- A migration (`1789133955.sh`) backfills the rule for machines that already configured lock-screen fingerprint auth before this existed.
- `omarchy-hw-fingerprint` gains an opt-in `--device-path` flag so the setup script and migration can read the matched device's own sysfs attributes without re-implementing detection. Existing callers (`if !`, the menu's `when`) only look at exit status and are unaffected.

## Why
Confirmed on a Goodix `27c6:609c` reader: `power/control` defaulted to `auto`, and fingerprint auth on the new Quickshell lock screen failed on every wake from suspend until autosuspend was disabled for that device. This is a generic Linux/libfprint quirk with certain USB readers, not something specific to the lock-screen rewrite, but the setup command that promises "fingerprint for sudo, polkit, and lock screen" currently leaves users to debug it themselves.

## Test plan
- [x] `test/shell.d/hw-fingerprint-test.sh` — extended for `--device-path`
- [x] `test/shell.d/fingerprint-usb-autosuspend-test.sh` — new, covers the setup script's rule-writing and immediate apply, and the no-op path when a matched device has no idVendor/idProduct
- [x] `test/shell.d/fingerprint-remove-usb-autosuspend-test.sh` — new, covers rule removal and idempotency
- [x] `test/shell.d/fingerprint-usb-autosuspend-migration-test.sh` — new, covers the backfill migration end to end
- [x] Manually reproduced and fixed on real hardware (Goodix `27c6:609c`): fingerprint lock-screen auth failed after every suspend/resume with `power/control=auto`, and survived suspend/resume cleanly after the udev rule was applied.
- [x] Full `test/shell` suite run; no new failures (5 pre-existing, unrelated failures reproduce identically on `quattro` without this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166c78NhxRWV6b99kE66XDy