### PR TITLE
Withdraw the toast when the server closes its notification

### DIFF
--- a/shell/plugins/notifications/Service.qml
+++ b/shell/plugins/notifications/Service.qml
@@ -163,8 +163,15 @@ Item {
     // Guard the delete: a newer notification may have reused this originalId
     // (freedesktop replaces_id) and taken over the map slot.
     notification.closed.connect(function() {
+      // The server (usually the sender closing its own notification) is
+      // tearing this object down. Live refs must go, and so must the toast:
+      // there is no reason to keep showing a notification that no longer
+      // exists at the server. The popup file is archived (like any dismiss)
+      // so the entry appears in history, but no dismiss()/expire() call is
+      // made — the server object is already going away.
       if (service.liveRefs[snapshot.originalId] === notification)
         delete service.liveRefs[snapshot.originalId]
+      service.removePopupOnServerClose(snapshot)
     })
 
     // DND bypass rules: chat apps abuse urgency=critical to force
@@ -306,6 +313,32 @@ Item {
       // would silently kill a restored critical alert on an unrelated ping.
       if (isRestoredRow(row)) continue
       if (NotificationLogic.popupFileName(row) !== keepFileName) deletePopupFileFor(row)
+      popupModel.remove(i)
+    }
+  }
+
+  // A notification the server closed (its sender revoked it, or the daemon
+  // dropped it) takes its toast with it: keep showing a toast that no longer
+  // exists at the server would be a spec violation — the daemon advertises
+  // persistenceSupported yet ignores the sender's close and keeps drawing a
+  // notification the server has already forgotten.
+  //
+  // Unlike removePopup() there is no live server object left to interact
+  // with, so the row is archived and removed without touching liveRefs or
+  // invoking dismiss()/expire(). The snapshot's file name is the identity
+  // that survives every model/file round-trip, so a row only matches when
+  // both its originalId and its file line up with the snapshot's.
+  function removePopupOnServerClose(snapshot) {
+    var fileName = NotificationLogic.popupFileName(snapshot)
+    for (var i = popupModel.count - 1; i >= 0; i--) {
+      var row = popupModel.get(i)
+      if (!row || row.originalId !== snapshot.originalId) continue
+      if (NotificationLogic.popupFileName(row) !== fileName) continue
+      // A restored toast's old-generation id may belong to a fresh
+      // notification that happened to close — killing it here would
+      // silently murder a restored critical alert.
+      if (isRestoredRow(row)) continue
+      archivePopupFileFor(row)
       popupModel.remove(i)
     }
   }

--- a/test/shell.d/notifications-test.sh
+++ b/test/shell.d/notifications-test.sh
@@ -696,6 +696,18 @@ assert(
   'notifications service protects restored popups from new-generation id collisions'
 )
 assert(
+  /notification\.closed\.connect\(function\(\) \{[\s\S]{0,600}?service\.removePopupOnServerClose\(snapshot\)/.test(serviceQml),
+  'notifications service withdraws the toast when its server object closes'
+)
+assert(
+  /function removePopupOnServerClose\(snapshot\)[\s\S]{0,500}?if \(isRestoredRow\(row\)\) continue[\s\S]{0,200}?archivePopupFileFor\(row\)[\s\S]{0,100}?popupModel\.remove\(i\)/.test(serviceQml),
+  'notifications service archives (not deletes) the popup of a server-closed notification, past restored rows'
+)
+assert(
+  /removePopupOnServerClose\(snapshot\)[\s\S]{0,300}?if \(NotificationLogic\.popupFileName\(row\) !== fileName\) continue/.test(serviceQml),
+  'notifications service matches a server-closed notification by popup file identity, not originalId alone'
+)
+assert(
   /var ref = !restored && originalId >= 0 \? liveRefs\[originalId\] : null/.test(serviceQml),
   'notifications service never resolves a restored popup to a live server object'
 )


### PR DESCRIPTION
Withdraw the toast when the server closes its notification

Bug: When a notification is closed at the server side — the sender revokes it, or the daemon drops it — the toast stayed pinned on screen indefinitely. Omarchy advertises persistenceSupported, so a notification that no longer exists at the server must withdraw its UI, but the closed handler only released the internal live reference and never removed the popup row.

Fix: The closed handler now calls removePopupOnServerClose(snapshot), which:
- Removes the matching popupModel row, keyed on both the notification's originalId and its persisted file name, so an id-reusing replacement or an unrelated restored toast is never touched (isRestoredRow rows are skipped)
- Archives the popup file into history (same bookkeeping as a normal dismiss), so the event is still visible under recent notifications
- Makes no dismiss()/expire() call — the server object is already going away, so there's nothing to answer
Tests: Added assertions covering the handler wiring, the archive-not-delete behaviour, restored-row protection, and file-identity matching.