### PR TITLE
Show Fcitx5 input method in the keyboard layout widget

### DIFF
--- a/shell/plugins/bar/widgets/KeyboardLayout.qml
+++ b/shell/plugins/bar/widgets/KeyboardLayout.qml
@@ -12,6 +12,11 @@ BarWidget {
 
 
   property string layoutFull: ""
+  // Fcitx5 owns input-method switching independently from Hyprland's XKB
+  // layouts. For example, Korean input keeps XKB on `us`, which would normally
+  // make this widget hide as a single-layout setup.
+  property string inputMethodName: ""
+  readonly property string inputMethodLabel: KeyboardLayoutModel.inputMethodLabel(inputMethodName)
   // The keyboard the last reading spoke for, which is the one a click switches,
   // and separately the one activelayout named as being typed on. A reading
   // confirms the first is really there, so the click has a keyboard to reach
@@ -36,6 +41,7 @@ BarWidget {
   // xkb's own table rather than maintained by hand.
   property var layoutBriefs: ({})
   readonly property string layoutLabel: KeyboardLayoutModel.shortLabel(layoutFull, layoutBriefs)
+  readonly property string displayLabel: inputMethodLabel || layoutLabel
 
   // A query already in flight was started before this event, so it may read the
   // layout the switch replaced. Remember the request and re-run once it lands
@@ -98,6 +104,7 @@ BarWidget {
 
   Component.onCompleted: {
     briefsProc.running = true
+    inputMethodProc.running = true
     refresh()
   }
 
@@ -194,10 +201,31 @@ BarWidget {
     }
   }
 
+  // Fcitx5 does not emit a Hyprland layout event when its input method changes,
+  // so refresh its lightweight command-line status periodically. If Fcitx5 is
+  // unavailable, the empty result leaves the normal XKB behavior unchanged.
+  Process {
+    id: inputMethodProc
+    command: ["fcitx5-remote", "-n"]
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: root.inputMethodName = String(text || "").trim()
+    }
+  }
+
   Timer {
     id: refreshTimer
     interval: 600
     onTriggered: root.refresh()
+  }
+
+  Timer {
+    interval: 1000
+    running: true
+    repeat: true
+    onTriggered: {
+      if (!inputMethodProc.running) inputMethodProc.running = true
+    }
   }
 
   // A query that never returns would freeze the label until the shell restarts,
@@ -228,7 +256,7 @@ BarWidget {
     onTriggered: root.refresh()
   }
 
-  visible: layoutLabel !== "" && multipleLayouts
+  visible: displayLabel !== "" && (inputMethodLabel !== "" || multipleLayouts)
   implicitWidth: button.implicitWidth
   implicitHeight: button.implicitHeight
 
@@ -236,10 +264,13 @@ BarWidget {
     id: button
     anchors.fill: parent
     bar: root.bar
-    text: root.layoutLabel
+    text: root.displayLabel
     fontSize: Style.font.caption
     horizontalMargin: 6
-    tooltipText: root.layoutFull
-    onPressed: function() { root.cycleLayout() }
+    tooltipText: root.inputMethodName ? "Fcitx5: " + root.inputMethodName : root.layoutFull
+    onPressed: function() {
+      if (root.inputMethodLabel) root.bar.run("fcitx5-remote -t")
+      else root.cycleLayout()
+    }
   }
 }

--- a/shell/plugins/bar/widgets/KeyboardLayoutModel.js
+++ b/shell/plugins/bar/widgets/KeyboardLayoutModel.js
@@ -54,6 +54,16 @@ function shortLabel(description, briefs) {
   return label.substring(0, 3).toUpperCase()
 }
 
+// Fcitx5 input methods are separate from Hyprland's XKB layouts. In
+// particular, Korean uses `hangul` while the compositor remains on `us`, so
+// the regular XKB label alone cannot say which language is being typed.
+function inputMethodLabel(inputMethod) {
+  var method = String(inputMethod || "").toLowerCase()
+  if (method === "hangul") return "KO"
+  if (method === "keyboard" || method.indexOf("keyboard-") === 0) return "EN"
+  return method.substring(0, 3).toUpperCase()
+}
+
 // Hyprland's activelayout event pairs the keyboard that switched with the layout
 // it moved to. Quickshell cuts the event into that many fields, so a description
 // carrying a comma of its own stays in one piece; a binding old enough to hand
@@ -118,6 +128,7 @@ if (typeof module !== "undefined") {
   module.exports = {
     eventKeyboardName: eventKeyboardName,
     isTypedKeyboard: isTypedKeyboard,
+    inputMethodLabel: inputMethodLabel,
     layoutBriefs: layoutBriefs,
     selectKeyboard: selectKeyboard,
     shortLabel: shortLabel

--- a/test/shell.d/keyboard-layout-test.sh
+++ b/test/shell.d/keyboard-layout-test.sh
@@ -86,6 +86,11 @@ assertEqual(model.shortLabel('English (US)', {}), 'ENG', 'the label survives an 
 assertEqual(model.shortLabel('constructor', {}), 'CON', 'a description naming a built-in still falls back')
 assertEqual(model.shortLabel('', briefs), '', 'no keymap means no label')
 
+assertEqual(model.inputMethodLabel('hangul'), 'KO', 'the Hangul input method has a Korean label')
+assertEqual(model.inputMethodLabel('keyboard-us'), 'EN', 'the Fcitx keyboard input method has an English label')
+assertEqual(model.inputMethodLabel('mozc'), 'MOZ', 'other input methods retain a compact visible label')
+assertEqual(model.inputMethodLabel(''), '', 'an unavailable input method leaves the XKB label alone')
+
 // The seat as hyprctl reports it, virtual keyboards already filtered out: the
 // buttons libinput calls keyboards sit beside the one being typed on, and the
 // main flag lands on either, or on the virtual keyboard that isn't here.


### PR DESCRIPTION
Fcitx5 input methods do not change Hyprland's XKB layout. As a result, the keyboard layout widget stays hidden when using Hangul input with a single `us` XKB layout.

This change reads the active Fcitx5 input method and shows `EN` or `KO` in the bar. Clicking the widget toggles the Fcitx5 input method.

Fcitx5 with the Hangul input method is required for Korean input. The existing XKB behavior is unchanged when Fcitx5 is unavailable.

Tests:
- `./test/shell.d/keyboard-layout-test.sh`
- `bash ./test/shell.d/hyprland-keyboard-layout-test.sh`
- `./test/all`
