### PR TITLE
Store zed as the canonical default editor name

### DIFF
--- a/bin/omarchy-default-editor
+++ b/bin/omarchy-default-editor
@@ -13,9 +13,13 @@ fi
 editor_file="$HOME/.local/state/omarchy/defaults/editor"
 
 if (($# == 0)); then
+  editor=""
   if [[ -f $editor_file ]]; then
     read -r editor <"$editor_file"
   fi
+
+  # Older state files stored "zeditor"; the binary Arch ships is "zed".
+  [[ $editor == "zeditor" ]] && editor="zed"
 
   [[ -n $editor ]] && echo "$editor" || echo "nvim"
   exit 0
@@ -24,7 +28,7 @@ fi
 case "$1" in
 code) selection="code"; editor="code"; name="VSCode"; glyph= ;;
 cursor) selection="cursor"; editor="cursor"; name="Cursor"; glyph= ;;
-zed | zeditor) selection="zed"; editor="zeditor"; name="Zed"; glyph= ;;
+zed | zeditor) selection="zed"; editor="zed"; name="Zed"; glyph= ;;
 sublime_text) selection="sublime_text"; editor="sublime_text"; name="Sublime Text"; glyph= ;;
 helix) selection="helix"; editor="helix"; name="Helix"; glyph= ;;
 vim) selection="vim"; editor="vim"; name="Vim"; glyph= ;;

--- a/bin/omarchy-launch-editor
+++ b/bin/omarchy-launch-editor
@@ -18,6 +18,9 @@ else
   editor="nvim"
 fi
 
+# Older state files stored "zeditor"; the binary Arch ships is "zed".
+[[ $editor == "zeditor" ]] && editor="zed"
+
 omarchy-cmd-present "$editor" || editor="nvim"
 
 case "${editor##*/}" in

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -166,7 +166,7 @@
   "setup.default.editor.neovim": {"icon":"","label":"Neovim","checked":"[[ \"$(omarchy-default-editor)\" == \"nvim\" ]]","action":"omarchy-default-editor nvim"},
   "setup.default.editor.vscode": {"icon":"","label":"VSCode","checked":"[[ \"$(omarchy-default-editor)\" == \"code\" ]]","action":"omarchy-default-editor code"},
   "setup.default.editor.cursor": {"icon":"","iconFont":"omarchy","label":"Cursor","checked":"[[ \"$(omarchy-default-editor)\" == \"cursor\" ]]","action":"omarchy-default-editor cursor"},
-  "setup.default.editor.zed": {"icon":"","label":"Zed","checked":"[[ \"$(omarchy-default-editor)\" == \"zeditor\" ]]","action":"omarchy-default-editor zed"},
+  "setup.default.editor.zed": {"icon":"","label":"Zed","checked":"[[ \"$(omarchy-default-editor)\" == \"zed\" ]]","action":"omarchy-default-editor zed"},
   "setup.default.editor.sublime": {"icon":"","label":"Sublime Text","checked":"[[ \"$(omarchy-default-editor)\" == \"sublime_text\" ]]","action":"omarchy-default-editor sublime_text"},
   "setup.default.editor.helix": {"icon":"","label":"Helix","checked":"[[ \"$(omarchy-default-editor)\" == \"helix\" ]]","action":"omarchy-default-editor helix"},
   "setup.default.editor.vim": {"icon":"","label":"Vim","checked":"[[ \"$(omarchy-default-editor)\" == \"vim\" ]]","action":"omarchy-default-editor vim"},

--- a/test/shell.d/default-apps-test.sh
+++ b/test/shell.d/default-apps-test.sh
@@ -96,7 +96,7 @@ omarchy-install-editor-*)
   printf 'editor:%s\n' "$editor" >>"$OMARCHY_TEST_INSTALL_LOG"
   case $editor in
   vscode) command=code ;;
-  zed) command=zeditor ;;
+  zed) command=zed ;;
   helix) command=helix ;;
   emacs) command=emacs ;;
   esac
@@ -168,7 +168,7 @@ terminal_cases=(
 editor_cases=(
   'code code editor:vscode'
   'cursor cursor pkg:cursor-bin'
-  'zed zeditor editor:zed'
+  'zed zed editor:zed'
   'sublime_text sublime_text pkg:sublime-text-4'
   'helix helix editor:helix'
   'vim vim pkg:vim'
@@ -312,3 +312,8 @@ if OMARCHY_TEST_INSTALL_FAIL=true omarchy-default-editor --install vim >"$test_t
 fi
 [[ $(omarchy-default-editor) == "$previous_editor" ]] || fail "failed installation preserves the default"
 pass "failed installation preserves the current default"
+
+mkdir -p "$test_home/.local/state/omarchy/defaults"
+printf 'zeditor\n' >"$test_home/.local/state/omarchy/defaults/editor"
+[[ $(omarchy-default-editor) == "zed" ]] || fail "legacy zeditor default resolves to zed"
+pass "legacy zeditor default resolves to zed"


### PR DESCRIPTION
Fixes #11326.

The Arch packages ship the binary as `zed`, but `omarchy-default-editor` stored `zeditor` as the canonical name. Since `zeditor` never exists on PATH, every Zed-default user fell through to the nvim fallback in `omarchy-launch-editor` (and tripped the missing-binary reinstall path in the setter).

- Setter now stores `zed`; `zeditor` is still accepted as input for compatibility.
- Getter and launcher normalize legacy `zeditor` state files to `zed`, so existing installs heal without re-selecting.
- Menu `checked` compares against `zed`.
- Test mock now reflects what `omarchy-install-editor-zed` really provides (`zed`), plus a legacy-state assertion.

Verified: `test/shell.d/default-apps-test.sh` 12/12 pass, `./test/cli` green, menu tests green, and an end-to-end run with a stub `zed` on PATH shows store → read → launch all resolving to `zed` instead of nvim.