### PR TITLE
Power off pre-T2 Apple Macs after writing the hibernate image

### DIFF
--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -42,6 +42,7 @@ run_logged "$OMARCHY_INSTALL/hardware/apple/fix-spi-keyboard.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-suspend-nvme.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-t2.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-brcmfmac-supplicant.sh"
+run_logged "$OMARCHY_INSTALL/hardware/apple/fix-pre-t2-hibernate.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/lenovo/fix-yoga-pro7-bass-speakers.sh"
 

--- a/install/hardware/apple/fix-pre-t2-hibernate.sh
+++ b/install/hardware/apple/fix-pre-t2-hibernate.sh
@@ -1,0 +1,28 @@
+# Hibernate on pre-T2 Apple Macs writes the image but then reboots instead of
+# powering off: systemd tries the platform (ACPI S4) mode first, which fails
+# on this hardware, while the shutdown power-off path works fine. Kernel docs
+# recommend shutdown mode for machines whose platform S4 handling is broken,
+# and resume still works from the swap signature on next boot.
+# References:
+# https://docs.kernel.org/power/basic-pm-debugging.html
+# https://wiki.archlinux.org/title/Power_management/Suspend_and_hibernate
+dmi_vendor="${OMARCHY_DMI_VENDOR:-/sys/class/dmi/id/sys_vendor}"
+hibernate_conf="${OMARCHY_HIBERNATE_MODE_CONF:-/etc/systemd/sleep.conf.d/hibernatemode.conf}"
+
+sys_vendor="$(cat "$dmi_vendor" 2>/dev/null || true)"
+
+# Every T2 Mac carries the T2 PCI ID (same probe as fix-t2.sh); its absence on
+# Apple hardware means a pre-T2 Intel Mac.
+if [[ $sys_vendor == Apple* ]] && ! lspci -nn 2>/dev/null | grep -q "106b:180[12]"; then
+  echo "Detected pre-T2 Apple Mac; switching hibernation to shutdown mode"
+
+  if [[ -f $hibernate_conf ]] && grep -qx 'HibernateMode=shutdown' "$hibernate_conf"; then
+    echo "Hibernation is already in shutdown mode"
+  else
+    sudo mkdir -p "$(dirname "$hibernate_conf")"
+    sudo tee "$hibernate_conf" >/dev/null <<'EOF'
+[Sleep]
+HibernateMode=shutdown
+EOF
+  fi
+fi

--- a/migrations/1789095456.sh
+++ b/migrations/1789095456.sh
@@ -1,0 +1,8 @@
+echo "Switch pre-T2 Apple Mac hibernation to shutdown mode"
+
+# Hibernate on pre-T2 Apple Macs writes the image but then reboots instead of
+# powering off: systemd tries the platform (ACPI S4) mode first, which fails
+# on this hardware. HibernateMode=shutdown uses the working power-off path
+# instead, and resume still works from the swap signature on next boot.
+# See install/hardware/apple/fix-pre-t2-hibernate.sh.
+source "$OMARCHY_PATH/install/hardware/apple/fix-pre-t2-hibernate.sh"

--- a/test/shell.d/apple-pre-t2-hibernate-test.sh
+++ b/test/shell.d/apple-pre-t2-hibernate-test.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+leaf="$ROOT/install/hardware/apple/fix-pre-t2-hibernate.sh"
+all="$ROOT/install/hardware/all.sh"
+migration="$ROOT/migrations/1789095456.sh"
+
+grep -Fq 'apple/fix-pre-t2-hibernate.sh' "$all" ||
+  fail "the pre-T2 hibernate quirk runs during hardware setup"
+pass "the pre-T2 hibernate quirk runs during hardware setup"
+
+grep -Fq 'HibernateMode=shutdown' "$leaf" ||
+  fail "the quirk installs HibernateMode=shutdown"
+grep -Fq '106b:180[12]' "$leaf" ||
+  fail "the quirk tells T2 Macs apart from pre-T2 Macs"
+pass "the quirk targets pre-T2 Apple hardware"
+
+grep -Fq 'fix-pre-t2-hibernate.sh' "$migration" ||
+  fail "the migration applies the pre-T2 hibernate quirk" "$migration"
+pass "the migration applies the pre-T2 hibernate quirk"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+calls="$test_tmp/calls.log"
+conf="$test_tmp/etc/systemd/sleep.conf.d/hibernatemode.conf"
+mkdir -p "$stub_bin" "$test_tmp/dmi"
+
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+
+printf 'sudo' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+"$@"
+SH
+
+cat >"$stub_bin/lspci" <<'SH'
+#!/bin/bash
+
+if (( ${T2_HARDWARE:-0} == 1 )); then
+  echo '01:00.0 Bridge [0680]: Apple Inc. T2 Security Chip [106b:1801]'
+else
+  echo '02:00.0 SATA controller [0106]: Samsung AHCI SSD [144d:a801]'
+fi
+SH
+
+chmod +x "$stub_bin"/*
+
+run_leaf() {
+  local vendor="$1" t2="${2:-0}" keep="${3:-0}"
+  if (( keep == 0 )); then
+    rm -rf "$test_tmp/etc"
+    mkdir -p "$test_tmp/etc"
+  fi
+  printf '%s' "$vendor" >"$test_tmp/dmi/sys_vendor"
+  : >"$calls"
+
+  OMARCHY_DMI_VENDOR="$test_tmp/dmi/sys_vendor" \
+    OMARCHY_HIBERNATE_MODE_CONF="$conf" \
+    T2_HARDWARE="$t2" \
+    PATH="$stub_bin:$PATH" TEST_LOG="$calls" \
+    bash -eE -o pipefail "$leaf" </dev/null
+}
+
+run_leaf "Apple Inc." 0 >/dev/null
+[[ -f $conf ]] || fail "a pre-T2 Mac gets the hibernate drop-in"
+grep -qx 'HibernateMode=shutdown' "$conf" ||
+  fail "the drop-in switches hibernation to shutdown mode" "$(cat "$conf")"
+pass "a pre-T2 Mac gets the hibernate drop-in"
+
+before=$(<"$conf")
+: >"$calls"
+run_leaf "Apple Inc." 0 1 >/dev/null
+[[ $(<"$conf") == "$before" ]] || fail "a second run leaves the drop-in alone"
+grep -q 'tee' "$calls" &&
+  fail "an already-configured install escalates nothing" "$(cat "$calls")"
+pass "a second run leaves the drop-in alone"
+
+run_leaf "Apple Inc." 1 >/dev/null
+[[ ! -f $conf ]] || fail "a T2 Mac is left alone"
+[[ ! -s $calls ]] || fail "a T2 Mac escalates nothing" "$(cat "$calls")"
+pass "a T2 Mac is left alone"
+
+run_leaf "LENOVO" 0 >/dev/null
+[[ ! -f $conf ]] || fail "non-Apple hardware is left alone"
+[[ ! -s $calls ]] || fail "non-Apple hardware escalates nothing" "$(cat "$calls")"
+pass "non-Apple hardware is left alone"
+
+run_leaf "Apple Computer, Inc." 0 >/dev/null
+[[ -f $conf ]] || fail "the older Apple vendor string is recognized"
+pass "the older Apple vendor string is recognized"
+
+rm -rf "$test_tmp/etc"
+mkdir -p "$test_tmp/etc"
+printf '%s' "Apple Inc." >"$test_tmp/dmi/sys_vendor"
+: >"$calls"
+OMARCHY_PATH="$ROOT" \
+  OMARCHY_DMI_VENDOR="$test_tmp/dmi/sys_vendor" \
+  OMARCHY_HIBERNATE_MODE_CONF="$conf" \
+  T2_HARDWARE=0 \
+  PATH="$stub_bin:$PATH" TEST_LOG="$calls" \
+  bash -euo pipefail "$migration" >/dev/null
+[[ -f $conf ]] || fail "the migration installs the drop-in on a pre-T2 Mac"
+pass "the migration installs the drop-in on a pre-T2 Mac"


### PR DESCRIPTION
Fixes #10038.

Hibernate on pre-T2 Intel Macs writes the image but then reboots instead of powering off: systemd tries the platform (ACPI S4) mode first, which fails on this hardware, while the shutdown power-off path works fine. Kernel docs recommend shutdown mode for exactly this case, and resume still works from the swap signature on next boot.

- install/hardware/apple/fix-pre-t2-hibernate.sh: gated on Apple DMI vendor plus absence of the T2 PCI ID (same probe as fix-t2.sh), writes /etc/systemd/sleep.conf.d/hibernatemode.conf with HibernateMode=shutdown. Same drop-in path and content as the open ThinkBook PR #8017, so the two converge harmlessly.
- Wired into install/hardware/all.sh alongside the other Apple quirks.
- migrations/1789095456.sh sources the leaf so existing installs heal on omarchy update (idempotent, per-user safe).
- test/shell.d/apple-pre-t2-hibernate-test.sh: 9/9 pass.

Verified on MacBookPro11,5 (Apple Inc., no T2, /sys/power/disk defaults to [platform]): the real DMI+lspci gate fires, the drop-in lands, systemd-analyze cat-config shows HibernateMode=shutdown, and a second run no-ops. Live hibernate cycle not run here: this machine has no resume= target configured yet, so a real cycle could not restore the session.