### PR TITLE
Clamp idle timeouts to the int32 millisecond range

### DIFF
--- a/shell/plugins/services/idle/IdleModel.js
+++ b/shell/plugins/services/idle/IdleModel.js
@@ -1,7 +1,11 @@
 function secondsFromConfig(value, fallback) {
   var n = Number(value)
   if (!isFinite(n) || n < 0) return fallback
-  return Math.floor(n)
+  // QML Timer.interval is a 32-bit signed int in milliseconds, so clamp to
+  // the largest whole seconds that survive the seconds-to-ms conversion.
+  // Anything larger (e.g. a lock timeout meant as "never") overflowed into a
+  // negative interval, which Qt clamps to 1ms and spams the log forever.
+  return Math.min(Math.floor(n), 2147483)
 }
 
 function eventParts(event, count) {

--- a/test/shell.d/idle-test.sh
+++ b/test/shell.d/idle-test.sh
@@ -10,6 +10,9 @@ const idle = requireFromRoot('shell/plugins/services/idle/IdleModel.js')
 assertEqual(idle.secondsFromConfig('42.9', 10), 42, 'idle floors configured seconds')
 assertEqual(idle.secondsFromConfig('-1', 10), 10, 'idle rejects negative seconds')
 assertEqual(idle.secondsFromConfig('nope', 10), 10, 'idle rejects invalid seconds')
+assertEqual(idle.secondsFromConfig(999999999, 300), 2147483, 'idle clamps seconds to the int32 millisecond range')
+assertEqual(idle.secondsFromConfig(2147483, 300), 2147483, 'idle keeps the largest safe seconds value')
+assertEqual(idle.secondsFromConfig(2147484, 300), 2147483, 'idle clamps just past the largest safe seconds value')
 
 assertDeepEqual(idle.eventParts({ data: 'a,b,c' }, 2), ['a', 'b', 'c'], 'idle parses raw event data')
 assertDeepEqual(


### PR DESCRIPTION
Fixes #11329.

secondsFromConfig had no upper bound, so a large idle.lock (e.g. 999999999, used as effectively-never) overflowed QML Timer.interval (32-bit signed ms) into a negative number. Qt clamps that to 1ms and the timer free-runs, spamming QBasicTimer warnings at ~1kHz (~1GB/session) and filling /run/user tmpfs.

- IdleModel.secondsFromConfig now clamps to 2147483s (floor(2^31-1 / 1000), ~24.8 days): the largest value that survives the seconds-to-ms conversion. This is the single choke point for both the lock and screensaver timers. A 24-day timeout preserves the effectively-never intent with zero behavior change for sane values.
- Tests: 3 new assertions in idle-test.sh (clamp, boundary keep, boundary+1 clamp).

Verified for real on MacBookPro11,5, not just mocks. Repro: screensaver 10 + lock 999999999, restart shell, stay idle 2 min: fresh log grew 0 to 9.8MB with 82,885 QBasicTimer warnings and climbing. Then the same one-line clamp applied to the installed copy, same repro: full window, 0 warnings, ~6KB log, no spurious lock. Installed file restored byte-identical afterwards (checksum-verified) and stock config (150/300) put back.