### PR TITLE
Detect the Apple bcm5974 trackpad

### DIFF
--- a/bin/omarchy-hw-touchpad
+++ b/bin/omarchy-hw-touchpad
@@ -2,5 +2,7 @@
 
 # omarchy:summary=Print the detected Hyprland touchpad or trackpad device name
 
-device=$(hyprctl devices -j | jq -r '[.mice[] | .name | select(test("touchpad|trackpad"; "i"))] | first // empty')
+# Hyprland reports most touchpads under a name containing touchpad/trackpad,
+# but Apple's bcm5974 driver reports the bare driver name, so match that too.
+device=$(hyprctl devices -j | jq -r '[.mice[] | .name | select(test("touchpad|trackpad|bcm5974"; "i"))] | first // empty')
 [[ -n $device ]] && echo "$device"

--- a/test/shell.d/hw-touchpad-test.sh
+++ b/test/shell.d/hw-touchpad-test.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command jq
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+mkdir -p "$stub_bin"
+
+# Stub only hyprctl: the real jq pipeline in omarchy-hw-touchpad runs
+# unmodified against canned device lists.
+cat >"$stub_bin/hyprctl" <<'SH'
+#!/bin/bash
+cat "$HYPRCTL_DEVICES"
+SH
+chmod +x "$stub_bin/hyprctl"
+
+detect() {
+  PATH="$stub_bin:$ROOT/bin:$PATH" HYPRCTL_DEVICES="$1" "$ROOT/bin/omarchy-hw-touchpad"
+}
+
+devices="$test_tmp/devices.json"
+
+# The MacBookPro11,5 layout: the trackpad reports the bare bcm5974 driver
+# name next to an unrelated Broadcom Bluetooth controller that must not win.
+cat >"$devices" <<'JSON'
+{"mice": [{"name": "bcm5974"}, {"name": "broadcom-corp.-bluetooth-usb-host-controller-1"}]}
+JSON
+[[ $(detect "$devices") == "bcm5974" ]] ||
+  fail "detection finds the bcm5974 trackpad without matching the Bluetooth controller"
+pass "detection finds the bcm5974 trackpad"
+
+cat >"$devices" <<'JSON'
+{"mice": [{"name": "broadcom-corp.-bluetooth-usb-host-controller-1"}, {"name": "bcm5974"}]}
+JSON
+[[ $(detect "$devices") == "bcm5974" ]] ||
+  fail "detection skips non-trackpad devices regardless of order"
+pass "detection skips non-trackpad devices"
+
+cat >"$devices" <<'JSON'
+{"mice": [{"name": "elan-touchpad"}, {"name": "Logitech USB Mouse"}]}
+JSON
+[[ $(detect "$devices") == "elan-touchpad" ]] ||
+  fail "detection still matches classic touchpad names"
+pass "detection still matches classic touchpad names"
+
+cat >"$devices" <<'JSON'
+{"mice": [{"name": "Apple Internal Trackpad"}]}
+JSON
+[[ $(detect "$devices") == "Apple Internal Trackpad" ]] ||
+  fail "detection still matches trackpad names"
+pass "detection still matches trackpad names"
+
+cat >"$devices" <<'JSON'
+{"mice": [{"name": "Logitech USB Mouse"}]}
+JSON
+set +e
+output=$(detect "$devices")
+status=$?
+set -e
+(( status != 0 )) || fail "detection errors when no touchpad exists"
+[[ -z $output ]] || fail "detection prints nothing when no touchpad exists"
+pass "detection errors when no touchpad exists"


### PR DESCRIPTION
Fixes #9190.

omarchy-hw-touchpad only matched names containing touchpad/trackpad, but Apple's bcm5974 driver reports the bare driver name to Hyprland, so every command chained through detection (omarchy toggle touchpad) failed with No touchpad device found on these Macs. The pattern now also matches bcm5974. Kept deliberately tight: a bare broadcom match would catch the unrelated Bluetooth USB host controller that sits next to it in .mice[] (Hyprland exposes no device-type field there, so name matching is the only signal).

- bin/omarchy-hw-touchpad: pattern touchpad|trackpad|bcm5974 (case-insensitive).
- test/shell.d/hw-touchpad-test.sh (5/5): exact MacBookPro11,5 layout (bcm5974 + BT controller, both orders), classic names preserved, empty + error when nothing matches.

Verified for real on MacBookPro11,5, where Hyprland lists the trackpad as bcm5974:
- Before: omarchy hw touchpad rc=1, toggle off -> No touchpad device found.
- After: hw touchpad prints bcm5974; physical roundtrip by the reporter: toggle off showed the disabled notice and the pointer froze on trackpad input, toggle on showed the enabled notice and control returned; no-arg flip-flop disables/enables cleanly.
- Full toggle-input-device suite, ./test/cli, and bin-style suites green.