### PR TITLE
Add background switcher across all themes

### DIFF
--- a/bin/omarchy-theme-bg-switcher-all
+++ b/bin/omarchy-theme-bg-switcher-all
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# omarchy:summary=Open the background switcher across every theme
+# omarchy:group=theme
+# omarchy:name=bg-switcher-all
+
+current_background=$(readlink -f "$HOME/.local/state/omarchy/current/background" 2>/dev/null)
+
+dirs=()
+for d in \
+  "$HOME/.config/omarchy/themes"/*/backgrounds \
+  "$OMARCHY_PATH/themes"/*/backgrounds \
+  "$HOME/.config/omarchy/backgrounds"/*; do
+  [[ -d $d ]] && dirs+=("$d")
+done
+
+omarchy-menu-images --selected "$current_background" "${dirs[@]}"

--- a/default/hypr/bindings/utilities.lua
+++ b/default/hypr/bindings/utilities.lua
@@ -15,6 +15,7 @@ o.bind("XF86Calculator", "Calculator", "omacalc")
 
 o.bind_toggle("SUPER + SHIFT + SPACE", "Toggle top bar", "bar")
 o.bind("SUPER + CTRL + SPACE", "Background switcher", "omarchy-menu toggle background")
+o.bind("SUPER + CTRL + ALT + SPACE", "All backgrounds", "omarchy-menu toggle style.background-all")
 o.bind("SUPER + SHIFT + CTRL + SPACE", "Theme menu", "omarchy-menu toggle theme")
 o.bind("SUPER + BACKSPACE", "Toggle window transparency", "omarchy-hyprland-window-transparency-toggle")
 o.bind("SUPER + SHIFT + BACKSPACE", "Toggle window gaps", "omarchy-hyprland-window-gaps-toggle")

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -103,6 +103,7 @@
   // Style
   "style.theme": {"icon":"󰸌","label":"Theme","aliases":["theme","themes"],"action":"theme=$(omarchy-theme-switcher); [[ -n $theme ]] && omarchy-theme-set \"$theme\""},
   "style.background": {"icon":"","label":"Background","aliases":["background","wallpaper"],"action":"background=$(omarchy-theme-bg-switcher); [[ -n $background ]] && omarchy-theme-bg-set \"$background\""},
+  "style.background-all": {"icon":"","label":"All Backgrounds","action":"background=$(omarchy-theme-bg-switcher-all); [[ -n $background ]] && omarchy-theme-bg-set \"$background\""},
   "style.unlock": {"icon":"󰟵","label":"Unlock","aliases":["unlock"],"action":"unlock=$(omarchy-plymouth-switcher); if [[ $unlock == default ]]; then omarchy-launch-floating-terminal-with-presentation omarchy-plymouth-reset; elif [[ -n $unlock ]]; then omarchy-launch-floating-terminal-with-presentation \"omarchy-plymouth-set-by-theme $(printf %q \"$unlock\")\"; fi"},
   "style.font": {"icon":"","label":"Font","provider":"fonts"},
   "style.bar": {"icon":"󰍜","label":"Menu Bar"},


### PR DESCRIPTION
## Summary
- Adds `omarchy-theme-bg-switcher-all` (`omarchy theme bg-switcher-all`), which opens the existing generic image picker over every theme's `backgrounds/` folder at once (user themes, stock themes, and the per-theme user-override folder), instead of just the current theme.
- New menu entry `style.background-all` ("All Backgrounds"), same apply path as the existing background switcher (`omarchy-theme-bg-set`).
- New default bind `SUPER+CTRL+ALT+SPACE` next to the existing `SUPER+CTRL+SPACE` (current-theme-only) switcher.

No changes needed to `omarchy-menu-images` or `omarchy-theme-bg-set` — both already generic enough to support this. Theme discovery is passive: any theme with a `backgrounds/` folder under either theme root is picked up automatically, no registration step.

## Test plan
- [x] `./test/all` — no new failures (4 pre-existing `test/shell` failures on `master`/this branch alike, unrelated: missing local `omarchy-pkgs` checkout, `locate`/`snapper`/`unowned-system-paths` suites)
- [x] `bash -n bin/omarchy-theme-bg-switcher-all`
- [x] Verified end-to-end on a live Omarchy install (ported this from a user-space version first): opens with backgrounds from multiple themes shown together, selecting one applies it and updates `omarchy theme bg current`
- [x] `hyprctl configerrors` clean after adding the bind