### PR TITLE
Fix debuginfod initialization in diagnose-crash skill

### DIFF
--- a/default/agents/skills/diagnose-crash/SKILL.md
+++ b/default/agents/skills/diagnose-crash/SKILL.md
@@ -61,7 +61,7 @@ trap 'rm -f "$core"' EXIT
 coredumpctl dump <pid> --output="$core"
 DEBUGINFOD_URLS="https://debuginfod.archlinux.org" \
   gdb -q <executable> "$core" \
-  -batch -ex 'set debuginfod enabled on' -ex 'bt'
+  -batch -iex 'set debuginfod enabled on' -ex 'bt'
 ```
 
 A core is a verbatim copy of the process's memory and can hold passwords, tokens,

--- a/test/shell.d/crash-capture-test.sh
+++ b/test/shell.d/crash-capture-test.sh
@@ -378,6 +378,13 @@ grep -Fq 'omarchy-crash-mute' "$skill" ||
   fail "the diagnosis no longer names the command that mutes, so the offer it makes cannot be carried out"
 pass "the diagnosis names the command that mutes"
 
+# gdb decides on debuginfod during startup, before -ex commands run, and never
+# retries the executable lookup; only -iex enables it in time, so -ex leaves
+# the crashed program's own frames unsymbolized while libraries still resolve.
+grep -Fq -- "-iex 'set debuginfod enabled on'" "$skill" ||
+  fail "the diagnosis enables debuginfod with -ex, which runs after gdb's startup lookup and leaves the crashed executable unsymbolized"
+pass "the diagnosis enables debuginfod before gdb's startup lookup"
+
 grep -Fq 'GROUP_DESCRIPTIONS[crash]' "$ROOT/bin/omarchy" ||
   fail "the crash group has no description, so the router lists a group it cannot describe"
 pass "the crash group is described in the router"


### PR DESCRIPTION
## Summary

- Fix #11305: change the documented gdb invocation in `default/agents/skills/diagnose-crash/SKILL.md` from `-ex 'set debuginfod enabled on'` to `-iex 'set debuginfod enabled on'`.
- Add a focused assertion in `test/shell.d/crash-capture-test.sh`, next to the existing SKILL.md content check, so a regression back to `-ex` fails the suite.

## Why `-iex` instead of `-ex`

gdb asks "Enable debuginfod for this session?" during startup, **before** any `-ex` command runs, and performs the executable's debug-info lookup at that point. Under `-batch` the prompt is auto-answered `N`, so the lookup is skipped and never retried. A later `-ex 'set debuginfod enabled on'` re-enables debuginfod in time for shared-library frames, but the crashed program's own frames stay unsymbolized (`??`) — exactly the frames that matter. `-iex` runs before the startup lookup, so the executable's debug info is fetched too.

## Verification

Reproduced on gdb 17.1 against `debuginfod.ubuntu.com` with a fresh `$HOME` (cold debuginfod cache), crashing `/bin/bash` via `kill -SEGV $$`:

- Documented form (`-ex`): `Enable debuginfod for this session? (y or [n]) [answered N; input not from terminal]` appears at startup; the debuginfod client cache afterwards contains lookups for shared libraries only — `/bin/bash`'s build-id is never queried.
- Fixed form (`-iex`): no startup prompt; the executable's build-id is queried and its debug info is downloaded before the inferior runs.

Also ran:

- `bash test/shell.d/crash-capture-test.sh` — all assertions pass, including the new one.
- `git diff --check` — clean.
- `./test/shell` — this file's tests pass; unrelated pre-existing environment failures on this machine (missing `lua`, `omarchy-cmd-present`, hardware-dependent probes) are unchanged.