### PR TITLE
Keep existing wine when installing Lutris

### DIFF
--- a/bin/omarchy-install-gaming-lutris
+++ b/bin/omarchy-install-gaming-lutris
@@ -6,7 +6,16 @@
 set -e
 
 echo "Installing Lutris..."
-omarchy-pkg-add lutris umu-launcher wine-staging wine-mono wine-gecko winetricks python-protobuf
+
+# wine-staging conflicts with wine. If wine is already installed, keep it
+# and still install Lutris plus the rest of the stack. Replacing wine is a
+# decision for the person at the machine, not a silent --noconfirm swap.
+wine_pkg=wine-staging
+if pacman -Qq wine >/dev/null 2>&1 && ! pacman -Qq wine-staging >/dev/null 2>&1; then
+  wine_pkg=wine
+fi
+
+omarchy-pkg-add lutris umu-launcher "$wine_pkg" wine-mono wine-gecko winetricks python-protobuf
 omarchy-install-gaming-gpu-lib32
 
 # Lutris ships with `#!/usr/bin/env python3`, which resolves to mise's Python and

--- a/test/shell.d/lutris-wine-conflict-test.sh
+++ b/test/shell.d/lutris-wine-conflict-test.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+install_script="$ROOT/bin/omarchy-install-gaming-lutris"
+
+grep -F 'wine-staging' "$install_script" >/dev/null ||
+  fail "Lutris installer still prefers wine-staging when wine is not already installed"
+
+grep -F 'pacman -Qq wine' "$install_script" >/dev/null ||
+  fail "Lutris installer does not detect an existing wine package before adding wine-staging"
+
+grep -F 'wine_pkg=wine' "$install_script" >/dev/null ||
+  fail "Lutris installer does not keep existing wine instead of conflicting with wine-staging"
+
+pass "Lutris installer keeps existing wine instead of conflicting with wine-staging"


### PR DESCRIPTION
## Summary

`omarchy install gaming lutris` always `omarchy-pkg-add`s `wine-staging`. If `wine` is already installed, pacman reports an unresolvable conflict (`wine-staging` vs `wine`) and the unattended `--noconfirm` install aborts.

If `wine` is present and `wine-staging` is not, keep `wine` and still install Lutris plus the rest of the stack. Fresh installs still get `wine-staging`. Replacing wine remains a decision for the person at the machine.

Fixes #11301

## Test plan

- `bash test/shell.d/lutris-wine-conflict-test.sh`
- Reproduce: `wine` installed, no `wine-staging` → installer should not request `wine-staging`.