### PR TITLE
fix(foot): use foot-direct terminfo for 24-bit truecolor support

### DIFF
--- a/config/foot/foot.ini
+++ b/config/foot/foot.ini
@@ -1,6 +1,6 @@
 [main]
 include=~/.local/state/omarchy/current/theme/foot.ini
-term=xterm-256color
+term=foot-direct
 font=JetBrainsMono Nerd Font:size=9
 pad=14x14
 initial-window-mode=windowed


### PR DESCRIPTION
### Problem

  When opening Emacs / Doom Emacs in terminal mode (emacsclient -t / ec) inside Foot, the entire editor background turns blue andcolors are distorted.

  This happens because config/foot/foot.ini overrides term=xterm-256color. Unlike Neovim (which checks $COLORTERM), GNU Emacs strictly checks the terminfo database for $TERM. Seeing only 256 colors, it downgrades and rounds dark RGB backgrounds (like #0b0d11) to ANSI Color 17 (Navy Blue).

  ### Fix

  Set term=foot-direct in config/foot/foot.ini.

  This enables native 24-bit Truecolor in Foot's terminfo, fixing the blue background in Emacs and ensuring proper color fidelity across all terminfo-aware CLI/TUI applications (like btop, htop, delta, etc.) with zero color degradation.