### PR TITLE
Install the pre-T2 FaceTime HD camera driver and firmware

### DIFF
--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -42,6 +42,7 @@ run_logged "$OMARCHY_INSTALL/hardware/apple/fix-spi-keyboard.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-suspend-nvme.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-t2.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-brcmfmac-supplicant.sh"
+run_logged "$OMARCHY_INSTALL/hardware/apple/fix-facetimehd.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/lenovo/fix-yoga-pro7-bass-speakers.sh"
 

--- a/install/hardware/apple/fix-facetimehd.sh
+++ b/install/hardware/apple/fix-facetimehd.sh
@@ -1,0 +1,23 @@
+# Pre-T2 Macs' built-in FaceTime HD camera (Broadcom 1570) has no in-tree
+# driver: the PCI function sits driverless and no /dev/video exists. The
+# out-of-tree bcwc_pcie driver (AUR facetimehd-dkms-git) plus Apple's camera
+# firmware (AUR facetimehd-firmware) bring up /dev/video0 at 1280x720.
+# Verified on MacBookPro11,5: modprobe facetimehd, three frames captured.
+dmi_vendor="${OMARCHY_DMI_VENDOR:-/sys/class/dmi/id/sys_vendor}"
+sys_vendor="$(cat "$dmi_vendor" 2>/dev/null || true)"
+
+if [[ $sys_vendor == Apple* ]] && lspci -nn | grep -E "14e4:1570" >/dev/null; then
+  echo "Detected pre-T2 FaceTime HD camera; installing its driver and firmware"
+
+  omarchy-pkg-aur-add facetimehd-firmware facetimehd-dkms-git ||
+    echo "Warning: could not install the FaceTime HD camera packages" >&2
+
+  # Best-effort on a live session so the camera works without a reboot. The
+  # driver's PCI alias binds it automatically on boot. Never fatal, following
+  # fix-synaptic-touchpad.sh: an optional camera must not halt hardware setup,
+  # and install chroots cannot load modules for the target kernel anyway.
+  if modprobe -qn facetimehd 2>/dev/null; then
+    modprobe facetimehd 2>/dev/null ||
+      echo "Warning: could not load facetimehd (takes effect after reboot)" >&2
+  fi
+fi

--- a/migrations/1789095456.sh
+++ b/migrations/1789095456.sh
@@ -1,0 +1,6 @@
+echo "Install the pre-T2 FaceTime HD camera driver and firmware"
+
+# Pre-T2 Macs' built-in camera (Broadcom 1570) has no in-tree driver, so it
+# sits driverless with no /dev/video. See
+# install/hardware/apple/fix-facetimehd.sh.
+source "$OMARCHY_PATH/install/hardware/apple/fix-facetimehd.sh"

--- a/test/shell.d/apple-facetimehd-test.sh
+++ b/test/shell.d/apple-facetimehd-test.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+leaf="$ROOT/install/hardware/apple/fix-facetimehd.sh"
+all="$ROOT/install/hardware/all.sh"
+migration="$ROOT/migrations/1789095456.sh"
+
+grep -Fq 'apple/fix-facetimehd.sh' "$all" ||
+  fail "the FaceTime HD quirk runs during hardware setup"
+pass "the FaceTime HD quirk runs during hardware setup"
+
+grep -Fq 'fix-facetimehd.sh' "$migration" ||
+  fail "the migration applies the FaceTime HD quirk" "$migration"
+pass "the migration applies the FaceTime HD quirk"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+calls="$test_tmp/calls.log"
+mkdir -p "$stub_bin" "$test_tmp/dmi"
+
+cat >"$stub_bin/lspci" <<'SH'
+#!/bin/bash
+
+if (( ${FACETIMEHD_HARDWARE:-0} == 1 )); then
+  echo '05:00.0 Multimedia controller [0480]: Broadcom Inc. and subsidiaries 720p FaceTime HD Camera [14e4:1570]'
+else
+  echo '00:02.0 VGA compatible controller [0300]: Intel Corporation HD Graphics [8086:0d26]'
+fi
+SH
+
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+
+printf 'sudo' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+"$@"
+SH
+
+cat >"$stub_bin/omarchy-pkg-aur-add" <<'SH'
+#!/bin/bash
+
+printf 'pkg-aur-add %s\n' "$*" >>"$TEST_LOG"
+(( ${PKG_FAIL:-0} == 0 ))
+SH
+
+cat >"$stub_bin/modprobe" <<'SH'
+#!/bin/bash
+
+printf 'modprobe' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+(( ${MODPROBE_FAIL:-0} == 0 ))
+SH
+
+chmod +x "$stub_bin"/*
+
+run_leaf() {
+  local vendor="$1" camera="${2:-0}" pkg_fail="${3:-0}"
+  printf '%s' "$vendor" >"$test_tmp/dmi/sys_vendor"
+  : >"$calls"
+
+  OMARCHY_DMI_VENDOR="$test_tmp/dmi/sys_vendor" \
+    FACETIMEHD_HARDWARE="$camera" PKG_FAIL="$pkg_fail" \
+    PATH="$stub_bin:$PATH" TEST_LOG="$calls" \
+    bash -eE -o pipefail -c 'source "$1"' bash "$leaf" </dev/null
+}
+
+run_leaf "Apple Inc." 1 >/dev/null
+grep -Fq 'pkg-aur-add facetimehd-firmware facetimehd-dkms-git' "$calls" ||
+  fail "a pre-T2 Mac with the camera installs driver and firmware" "$(cat "$calls")"
+grep -Fq $'modprobe\tfacetimehd' "$calls" ||
+  fail "a live session loads the driver without a reboot" "$(cat "$calls")"
+pass "a pre-T2 Mac with the camera installs driver and firmware"
+
+run_leaf "Apple Inc." 0 >/dev/null
+[[ ! -s $calls ]] || fail "an Apple machine without the camera is left alone" "$(cat "$calls")"
+pass "an Apple machine without the camera is left alone"
+
+run_leaf "LENOVO" 0 >/dev/null
+[[ ! -s $calls ]] || fail "non-Apple hardware is left alone" "$(cat "$calls")"
+pass "non-Apple hardware is left alone"
+
+run_leaf "Apple Computer, Inc." 1 >/dev/null
+grep -Fq 'pkg-aur-add facetimehd-firmware facetimehd-dkms-git' "$calls" ||
+  fail "the older Apple vendor string is recognized"
+pass "the older Apple vendor string is recognized"
+
+# A failed package install warns instead of aborting hardware setup.
+set +e
+run_leaf "Apple Inc." 1 1 >/dev/null
+status=$?
+set -e
+(( status == 0 )) || fail "a failed package install does not abort hardware setup"
+grep -Fq $'modprobe\t-qn\tfacetimehd' "$calls" ||
+  fail "a failed install still probes for a live load" "$(cat "$calls")"
+pass "a failed package install warns instead of aborting"
+
+run_migration() {
+  local vendor="$1" camera="${2:-0}"
+  printf '%s' "$vendor" >"$test_tmp/dmi/sys_vendor"
+  : >"$calls"
+
+  OMARCHY_PATH="$ROOT" \
+    OMARCHY_DMI_VENDOR="$test_tmp/dmi/sys_vendor" \
+    FACETIMEHD_HARDWARE="$camera" \
+    PATH="$stub_bin:$PATH" TEST_LOG="$calls" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+run_migration "Apple Inc." 1
+grep -Fq 'pkg-aur-add facetimehd-firmware facetimehd-dkms-git' "$calls" ||
+  fail "the migration installs driver and firmware on a pre-T2 Mac with the camera"
+pass "the migration installs driver and firmware on a pre-T2 Mac with the camera"
+
+run_migration "LENOVO" 0
+[[ ! -s $calls ]] || fail "the migration leaves other hardware alone" "$(cat "$calls")"
+pass "the migration leaves other hardware alone"


### PR DESCRIPTION
Fixes #11373.

Pre-T2 Macs' built-in FaceTime HD camera (Broadcom 1570) has no in-tree driver: the PCI function sits driverless, no /dev/video exists, and Omarchy references the stack nowhere. This adds install/hardware/apple/fix-facetimehd.sh (gated on Apple DMI + 14e4:1570), wired into all.sh, plus migration 1789095456.sh sourcing the leaf for existing installs. It installs facetimehd-firmware + facetimehd-dkms-git via omarchy-pkg-aur-add and best-effort modprobes on live sessions (PCI alias binds it at boot). Never fatal, following fix-synaptic-touchpad.sh: failed installs warn, chroot modprobe mismatches stay quiet.

Proven on MacBookPro11,5, not just mocked: Apple's firmware CDN served the download (hashes OK), DKMS built clean against 7.2.3-arch1-3, modprobe created /dev/video0 reporting 1280x720@30, and three frames captured (varied sizes, live sensor). live leaf re-run no-ops cleanly with the camera up.

Tests: test/shell.d/apple-facetimehd-test.sh 9/9 (gating incl. older Apple vendor string, non-clobber paths, failed-install warning path, migration). ./test/cli green.