### PR TITLE
Detect FocalTech match-on-chip fingerprint readers

### DIFF
--- a/bin/omarchy-hw-fingerprint
+++ b/bin/omarchy-hw-fingerprint
@@ -8,7 +8,11 @@
 # ship fingerprint readers; multi-purpose vendors (e.g. Elan/STMicro, which
 # also make USB touchscreens) are left out to avoid nagging laptops with no
 # reader — those still match on the product string below when present.
-fingerprint_vendors=" 27c6 138a 06cb 08ff 1c7a 147e "
+# FocalTech (2808) belongs in the list even though it also makes touch
+# controllers: its match-on-chip readers name no function ("FocalTech FT9365
+# ESS"), so the product string can never carry them, while its touch devices
+# bind usbhid/i2c-hid and are rejected by the driver check below.
+fingerprint_vendors=" 27c6 138a 06cb 08ff 1c7a 147e 2808 "
 usb_devices_path="${OMARCHY_USB_DEVICES_PATH:-/sys/bus/usb/devices}"
 
 # libfprint drives every reader it supports from userspace over libusb, so a

--- a/test/shell.d/hw-fingerprint-test.sh
+++ b/test/shell.d/hw-fingerprint-test.sh
@@ -103,3 +103,14 @@ assert_detects "a self-named reader is detected with a driver bound"
 
 write_usb_devices '1234:5678:Generic USB Device'
 assert_rejects "a machine with no matching USB devices detects nothing"
+
+# FocalTech match-on-chip readers name no function in their product string, so
+# the vendor list is the only way to find them.
+write_usb_devices '2808:a57a:FocalTech FT9365 ESS'
+assert_detects "a FocalTech match-on-chip reader is detected by vendor"
+
+# ...and the driver check is what keeps FocalTech's touch controllers, which
+# share the vendor ID, out of the match.
+write_usb_devices '2808:a57a:FocalTech FT9365 ESS'
+bind_driver '1-0/1-0:1.0' usbhid
+assert_rejects "a FocalTech device bound to a kernel driver is rejected"


### PR DESCRIPTION
Fixes #11384.

`omarchy-hw-fingerprint` misses FocalTech match-on-chip readers, so `omarchy setup security fingerprint` aborts with "No fingerprint sensor detected." on a laptop whose reader the pinned `libfprint-git` already supports (upstream lists `2808:a57a` as "Focaltech MOC Sensors").

The reader reports `FocalTech FT9365 ESS` and misses both detection paths: `2808` is not in `fingerprint_vendors`, and the product string names no function, so none of the `fingerprint` / `biometric` / `elan:arm-m4` / `fpc ` patterns match it. The vendor ID is the only thing that can carry these readers, and the existing driver check is what keeps FocalTech's touch controllers out — they bind `usbhid`/`i2c-hid`, while a match-on-chip reader sits there driverless, exactly the shape `has_kernel_driver` already tests for.

Because the wizard bails before it installs anything, affected machines end up with no `fprintd`/`libfprint` at all, which makes it look like the sensor does not exist. The same detector also gates `setup-fingerprint.hook`, so those machines never get the post-update invitation either.

## Testing

- `test/shell.d/hw-fingerprint-test.sh` gains two cases: a driverless `2808:a57a` device is detected by vendor, and the same device with `usbhid` bound is rejected.
- On the affected laptop (ASUS ExpertBook PM3406CKA, `2808:a57a`) the patched script exits 0 against real sysfs where it previously exited 1, and `omarchy setup security fingerprint` then runs end to end: enrollment, `fprintd-verify` match, PAM stacks written, and the fingerprint accepted by both `sudo` and polkit.
- `./test/all` here: `test/shell.d/hw-fingerprint-test.sh` passes. `config-test.sh`, `snapper-test.sh` and `unowned-system-paths-test.sh` fail identically at the parent commit on this machine because they want an `omarchy-pkgs` checkout that is not present — unrelated to this change.
