### PR TITLE
Sync the pacman databases before the first package install

### DIFF
--- a/bin/omarchy-pkg-add
+++ b/bin/omarchy-pkg-add
@@ -6,6 +6,8 @@
 # omarchy:requires-sudo=true
 
 if omarchy-pkg-missing "$@"; then
+  omarchy-pkg-db-sync
+
   if (( EUID == 0 )); then
     pacman -S --noconfirm --needed "$@" || exit 1
   else

--- a/bin/omarchy-pkg-aur-add
+++ b/bin/omarchy-pkg-aur-add
@@ -4,6 +4,7 @@
 # omarchy:args=<packages...>
 
 if omarchy-pkg-missing "$@"; then
+  omarchy-pkg-db-sync
   yay -S --noconfirm --needed "$@" || exit 1
 fi
 

--- a/bin/omarchy-pkg-db-sync
+++ b/bin/omarchy-pkg-db-sync
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# omarchy:summary=Download the package databases for any configured repository that has never been synced.
+# omarchy:hidden=true
+# omarchy:requires-sudo=true
+
+# The ISO installs the entire system from the bundled [offline] repository, and
+# install/post-install/pacman.sh then swaps /etc/pacman.conf over to the Omarchy
+# mirrors. Those repositories land on the new machine with no database behind
+# them, so the first `pacman -S` fails with "target not found" -- installing a
+# browser on a freshly booted machine takes that path before anything has ever
+# run `omarchy update`. Wanting a package is exactly the moment those databases
+# have to exist, so the package helpers come through here first.
+
+sync_dir="$(pacman-conf DBPath)"
+sync_dir="${sync_dir%/}/sync"
+
+unsynced=0
+while IFS= read -r repo; do
+  if [[ ! -f $sync_dir/$repo.db ]]; then
+    unsynced=1
+    break
+  fi
+done < <(pacman-conf --repo-list)
+
+if (( unsynced )); then
+  # A failed sync is not fatal here. The install that follows raises its own
+  # error, and someone still offline should hear about the package they asked
+  # for rather than about the database behind it.
+  if (( EUID == 0 )); then
+    pacman -Sy --noconfirm || true
+  else
+    sudo pacman -Sy --noconfirm || true
+  fi
+fi
+
+exit 0

--- a/install/post-install/pacman.sh
+++ b/install/post-install/pacman.sh
@@ -11,3 +11,10 @@ if [[ -f $OMARCHY_PATH/etc-overrides/cups-cups-files.conf && -f /etc/cups/cups-f
 fi
 
 source "$OMARCHY_INSTALL/hardware/pacman.sh"
+
+# The target installed every package from the ISO's bundled [offline] repository,
+# so the repositories configured just above arrive without a database and the
+# first `pacman -S` on the new machine would fail with "target not found". Sync
+# them here when the installer has a network; machines installed offline pick
+# this up from the package helpers on first use instead.
+omarchy-pkg-db-sync

--- a/test/shell.d/pkg-db-sync-test.sh
+++ b/test/shell.d/pkg-db-sync-test.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+# The ISO installs offline and post-install/pacman.sh then repoints pacman at
+# the Omarchy mirrors, so a freshly installed machine has no database for the
+# repositories it is configured to install from. Every package helper has to
+# close that gap before it reaches for a package that only exists in one of
+# them.
+grep -q 'omarchy-pkg-db-sync' "$ROOT/bin/omarchy-pkg-add" ||
+  fail "installing an Arch package syncs repositories that have never been synced"
+grep -q 'omarchy-pkg-db-sync' "$ROOT/bin/omarchy-pkg-aur-add" ||
+  fail "installing an AUR package syncs repositories that have never been synced"
+
+pass "the package helpers sync unsynced repositories before installing"
+
+grep -q 'omarchy-pkg-db-sync' "$ROOT/install/post-install/pacman.sh" ||
+  fail "the installer syncs the mirrors it just configured"
+
+pass "a fresh install leaves the configured repositories synced"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+sync_dir="$test_tmp/db/sync"
+mkdir -p "$mock_bin" "$sync_dir"
+
+cat >"$mock_bin/pacman-conf" <<'SH'
+#!/bin/bash
+case "$1" in
+  DBPath) printf '%s/\n' "$OMARCHY_DB_TEST_DBPATH" ;;
+  --repo-list) printf '%s\n' core extra multilib omarchy ;;
+  *) exit 2 ;;
+esac
+SH
+cat >"$mock_bin/pacman" <<'SH'
+#!/bin/bash
+printf 'pacman\t%s\n' "$*" >>"$OMARCHY_DB_TEST_LOG"
+exit "${OMARCHY_DB_TEST_SYNC_STATUS:-0}"
+SH
+cat >"$mock_bin/sudo" <<'SH'
+#!/bin/bash
+printf 'sudo\t%s\n' "$*" >>"$OMARCHY_DB_TEST_LOG"
+exec "$@"
+SH
+chmod +x "$mock_bin"/*
+
+log="$test_tmp/actions.log"
+export OMARCHY_DB_TEST_LOG="$log"
+export OMARCHY_DB_TEST_DBPATH="$test_tmp/db"
+
+run_db_sync() {
+  PATH="$mock_bin:$PATH" bash "$ROOT/bin/omarchy-pkg-db-sync"
+}
+
+# A machine straight off the ISO: the offline repository it installed from is
+# gone from pacman.conf and nothing has replaced it.
+: >"$log"
+printf 'offline\n' >"$sync_dir/offline.db"
+run_db_sync || fail "the sync runs on a machine that has never synced"
+grep -qxF $'pacman\t-Sy --noconfirm' "$log" ||
+  fail "a repository without a database is downloaded"
+
+pass "a machine installed from the offline repository syncs on first use"
+
+# Once every configured repository has one, syncing again is somebody else's
+# job -- omarchy update owns the -Syu that keeps them current.
+: >"$log"
+for repo in core extra multilib omarchy; do
+  printf '%s\n' "$repo" >"$sync_dir/$repo.db"
+done
+run_db_sync || fail "the sync succeeds when every repository has a database"
+[[ ! -s $log ]] || fail "a fully synced machine downloads nothing"
+
+pass "an already synced machine is left alone"
+
+# Offline, the sync cannot succeed. The install behind it still has to run so
+# the user hears about the package they asked for, not the database.
+: >"$log"
+rm -f "$sync_dir/extra.db"
+OMARCHY_DB_TEST_SYNC_STATUS=1 run_db_sync ||
+  fail "a failed sync does not abort the install that follows it"
+grep -qxF $'pacman\t-Sy --noconfirm' "$log" ||
+  fail "the sync was attempted before giving up on it"
+
+pass "a sync that cannot reach the mirrors does not swallow the install"


### PR DESCRIPTION
I haven't verified any of the code in this PR, but this a bug I encountered on my first boot

---

The ISO installs the whole system from its bundled [offline] repository, and install/post-install/pacman.sh then points /etc/pacman.conf at the Omarchy mirrors. Those repositories arrive on the new machine with no database behind them, so the first `pacman -S` fails:

  error: target not found: firefox

That is the path a freshly booted machine takes to install a browser -- firefox is not in the offline closure -- and nothing syncs those databases before the first `omarchy update`, which is the very thing the user has not run yet.

Sync any configured repository that has never been synced, at the two moments it matters: the end of the installer's pacman setup, for a machine installed with a network, and the package helpers themselves, for one installed offline that only reaches a network on first boot. A sync that cannot reach the mirrors is not fatal, so an offline machine still hears about the package it asked for rather than the database behind it.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>