### PR TITLE
Use a generic icon when webapp favicon lookup fails

### DIFF
--- a/bin/omarchy-webapp-install
+++ b/bin/omarchy-webapp-install
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # omarchy:summary=Create a desktop launcher for a web app
-# omarchy:args=[name url icon-url-or-name [custom-exec] [mime-types]]
+# omarchy:args=[name url [icon-url-or-name] [custom-exec] [mime-types]]
 
 set -e
 
@@ -136,7 +136,7 @@ desktop_exec_arg() {
   printf '"%s"' "$escaped"
 }
 
-if (( $# < 3 )); then
+if (( $# < 2 )); then
   echo -e "\e[32mLet's create a new web app you can start with the app launcher.\n\e[0m"
   APP_NAME=$(gum input --prompt "Name> " --placeholder "My favorite web app")
   require_plain_name "$APP_NAME"
@@ -144,15 +144,7 @@ if (( $# < 3 )); then
   APP_URL=$(normalize_webapp_url "$APP_URL")
   require_http_url "$APP_URL"
 
-  # Try to fetch the site's icon automatically first.
-  mkdir -p "$ICON_DIR"
-  ICON_VALUE=$(safe_icon_name "$APP_NAME")
-  if fetch_site_icon "$APP_URL" "$ICON_DIR/$ICON_VALUE.png"; then
-    gtk-update-icon-cache "$HOME/.local/share/icons/hicolor" &>/dev/null || true
-    ICON_REF="$ICON_VALUE"
-  else
-    ICON_REF=$(gum input --prompt "Icon URL/name> " --placeholder "Could not fetch favicon automatically. Enter PNG icon URL or icon name")
-  fi
+  ICON_REF=""
 
   CUSTOM_EXEC=""
   MIME_TYPES=""
@@ -161,7 +153,7 @@ else
   APP_NAME="$1"
   APP_URL=$(normalize_webapp_url "$2")
   require_http_url "$APP_URL"
-  ICON_REF="$3"
+  ICON_REF="${3:-}"
   CUSTOM_EXEC="$4" # Optional custom exec command
   MIME_TYPES="$5"  # Optional mime types
   INTERACTIVE_MODE=false
@@ -178,19 +170,21 @@ require_plain_name "$APP_NAME"
 if [[ -z $ICON_REF ]]; then
   ICON_VALUE=$(safe_icon_name "$APP_NAME")
   mkdir -p "$ICON_DIR"
-  if ! fetch_site_icon "$APP_URL" "$ICON_DIR/$ICON_VALUE.png"; then
-    echo "Error: Failed to download icon."
-    exit 1
+  if fetch_site_icon "$APP_URL" "$ICON_DIR/$ICON_VALUE.png"; then
+    gtk-update-icon-cache "$HOME/.local/share/icons/hicolor" &>/dev/null || true
+  else
+    ICON_VALUE="web-browser"
+    echo "Could not fetch the site icon; using a generic browser icon." >&2
   fi
-  gtk-update-icon-cache "$HOME/.local/share/icons/hicolor" &>/dev/null || true
 elif [[ $ICON_REF =~ ^https?:// ]]; then
   ICON_VALUE=$(safe_icon_name "$APP_NAME")
   mkdir -p "$ICON_DIR"
-  if ! download_icon "$ICON_REF" "$ICON_DIR/$ICON_VALUE.png"; then
-    echo "Error: Failed to download icon."
-    exit 1
+  if download_icon "$ICON_REF" "$ICON_DIR/$ICON_VALUE.png"; then
+    gtk-update-icon-cache "$HOME/.local/share/icons/hicolor" &>/dev/null || true
+  else
+    ICON_VALUE="web-browser"
+    echo "Could not download the requested icon; using a generic browser icon." >&2
   fi
-  gtk-update-icon-cache "$HOME/.local/share/icons/hicolor" &>/dev/null || true
 elif [[ -f $ICON_REF ]]; then
   ICON_VALUE=$(install_user_icon "$ICON_REF" "$(safe_icon_name "$APP_NAME")")
 else

--- a/test/shell.d/webapp-install-test.sh
+++ b/test/shell.d/webapp-install-test.sh
@@ -122,3 +122,22 @@ grep -Fq 'must be http or https' "$tmpdir/err" ||
   fail "interactive webapp install refuses before fetching the URL" "$(cat "$tmpdir/curl-log")"
 [[ ! -e $(desktop_for Evil) ]] || fail "interactive webapp install writes no desktop file"
 pass "interactive webapp install refuses a bad URL before fetching it"
+
+# A missing favicon is not a reason to refuse an otherwise valid launcher.
+for icon in "" "https://example.com/missing.png"; do
+  CURL_LOG="$tmpdir/curl-log" PATH="$stubs:$PATH" install_webapp "Fallback" "https://example.com" "$icon"
+  grep -Fxq 'Icon=web-browser' "$(desktop_for Fallback)" || fail "failed icon download uses a generic icon"
+done
+pass "automatic and explicit icon download failures still install"
+
+CURL_LOG="$tmpdir/curl-log" PATH="$stubs:$PATH" install_webapp "Optional" "https://example.com"
+grep -Fxq 'Icon=web-browser' "$(desktop_for Optional)" || fail "two-argument install accepts an omitted icon"
+pass "webapp icon argument is optional"
+
+printf 'Interactive\nhttps://example.com\n' >"$tmpdir/answers"
+printf '0\n' >"$tmpdir/gum-count"
+GUM_ANSWERS="$tmpdir/answers" GUM_COUNT="$tmpdir/gum-count" CURL_LOG="$tmpdir/curl-log" \
+  PATH="$stubs:$PATH" HOME="$home" "$ROOT/bin/omarchy-webapp-install"
+grep -Fxq 'Icon=web-browser' "$(desktop_for Interactive)" || fail "interactive install uses a generic icon"
+[[ $(cat "$tmpdir/gum-count") == "2" ]] || fail "interactive install must not request a replacement icon"
+pass "interactive favicon failure installs without another prompt"


### PR DESCRIPTION
When favicon discovery fails, installing a web app currently asks for another icon, and submitting an empty icon (or using a failing explicit icon URL) aborts installation. Use the theme's generic `web-browser` icon instead so a valid app name and URL are sufficient.

The interactive flow now asks only for name and URL. The CLI also accepts two arguments, while successful automatic downloads, explicit icon names/files, custom Exec commands, and MIME types retain their existing behavior.

Validation: the webapp install, escaping, and name suites pass, including new offline/failing-download cases for interactive installs, omitted icons, and explicit icon URLs. Bash syntax and `git diff --check` pass.

Full `./test/all`: CLI suite passed; 228 of 236 shell test files passed. Failures: bar-icon-geometry, config, launch-about, locate, runtime-smoke, snapper, unowned-system-paths, and update-lock. Bar geometry and About failures were reproduced on clean upstream 31bd80d. Several checks require a sibling omarchy-pkgs checkout absent here. The other failures are reported without attributing a cause; the two branch suites were run concurrently in a live desktop environment. None of the webapp suites failed.
