### PR TITLE
Reduce OSD and notification layer surface area

### DIFF
--- a/default/hypr/apps/omarchy-shell.lua
+++ b/default/hypr/apps/omarchy-shell.lua
@@ -4,6 +4,9 @@
 -- Keep the bar instant: no layer-shell fade/slide animation.
 hl.layer_rule({ match = { namespace = "omarchy-bar" }, no_anim = true, animation = "none" })
 
+-- Notification strips should appear without animating the transparent surface.
+hl.layer_rule({ match = { namespace = "omarchy-notifications" }, no_anim = true, animation = "none" })
+
 -- Launcher, image selector, emojis, clipboard overlays, and keyboard-driven
 -- panels should pop without compositor layer fades. Panels keep their own
 -- QML opacity transition for normal open/close, and skip it for panel handoff.

--- a/default/hypr/apps/omarchy-shell.lua
+++ b/default/hypr/apps/omarchy-shell.lua
@@ -4,6 +4,9 @@
 -- Keep the bar instant: no layer-shell fade/slide animation.
 hl.layer_rule({ match = { namespace = "omarchy-bar" }, no_anim = true, animation = "none" })
 
+-- The OSD animates its progress value itself; keep the small surface instant.
+hl.layer_rule({ match = { namespace = "omarchy-osd" }, no_anim = true, animation = "none" })
+
 -- Notification strips should appear without animating the transparent surface.
 hl.layer_rule({ match = { namespace = "omarchy-notifications" }, no_anim = true, animation = "none" })
 

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -14,6 +14,8 @@ The end-user view (hotkey notices for time, battery, weather) is in
 
 ## Toast lifecycle
 
+Each output uses a fixed-width, full-height transparent strip sized to the card width plus its right clearance, rather than a full-screen surface. Keeping the dimensions independent of the popup count avoids stale-buffer stretching when cards are added or removed. Only the card column accepts input, and the Hyprland layer rule disables compositor animation for the strip.
+
 A toast lives on screen for at least 5s (low), 8s (normal), or forever
 (critical), stretched up to 30s if the sender asked for a longer
 `expire_timeout`. Hovering pauses the countdown, and a content update restarts

--- a/shell/plugins/notifications/Service.qml
+++ b/shell/plugins/notifications/Service.qml
@@ -967,14 +967,14 @@ Item {
       readonly property var popupPlacement: NotificationLogic.popupPlacement(
         service.barPosition, service.barClearance, Style.gapsOut)
 
-      // Full-screen, fixed-size surface (like the OSD overlay). Adding or
-      // removing a toast changes only the content inside; the Wayland surface
-      // never resizes, so the compositor can't briefly scale a stale buffer --
-      // which is what stretched/squished the cards during count changes.
-      anchors { top: true; bottom: true; left: true; right: true }
+      // Keep a fixed-width strip instead of allocating a full-screen
+      // transparent surface on every output. Full height keeps adding and
+      // removing cards from resizing the surface and stretching stale buffers.
+      anchors { top: true; bottom: true; right: true }
+      implicitWidth: Math.ceil(Style.space(380) + popupPlacement.margins.right)
 
       // Keep the surface click-through except over the toast column, so the
-      // rest of the (invisible) full-screen overlay never eats input.
+      // rest of the invisible notification strip never eats input.
       mask: Region { item: popupColumn }
 
       ColumnLayout {

--- a/shell/plugins/osd/Osd.qml
+++ b/shell/plugins/osd/Osd.qml
@@ -126,7 +126,11 @@ Item {
   PanelWindow {
     id: panel
     visible: root.opened
-    anchors { top: true; bottom: true; left: true; right: true }
+    // Only allocate a surface for the card, not the entire output.
+    anchors { bottom: true }
+    margins { bottom: Style.space(67) }
+    implicitWidth: card.width
+    implicitHeight: card.height
     color: "transparent"
     WlrLayershell.namespace: "omarchy-osd"
     WlrLayershell.layer: WlrLayer.Overlay
@@ -140,9 +144,7 @@ Item {
       id: card
       width: card.borderLeft + root.pad + root.contentWidth + root.pad + card.borderRight
       height: card.borderTop + root.pad + Style.font.displayLarge + root.pad + card.borderBottom
-      anchors.horizontalCenter: parent.horizontalCenter
-      anchors.bottom: parent.bottom
-      anchors.bottomMargin: Style.space(67)
+      anchors.centerIn: parent
       color: Util.alpha(Color.background, 0.97)
       borderSpec: Border.surfaceSpec("popups", "border", Color.popups.border, Math.max(1, Style.space(2)))
       radius: Style.cornerRadius

--- a/test/shell.d/notifications-test.sh
+++ b/test/shell.d/notifications-test.sh
@@ -571,6 +571,28 @@ assert(!('exec' in legacyRestored), 'a restored legacy popup drops the old exec 
 assertEqual(notifications.parseExecArgv(legacyRestored.execArgv || ''), null, 'a restored legacy popup has no runnable click action')
 
 const serviceQml = fs.readFileSync(path.join(root, 'shell/plugins/notifications/Service.qml'), 'utf8')
+const popupWindowQml = serviceQml.slice(serviceQml.indexOf('id: popupWindow'))
+assert(
+  /anchors \{ top: true; bottom: true; right: true \}/.test(popupWindowQml),
+  'notification surfaces keep full height without spanning the output width'
+)
+assert(
+  /implicitWidth: Math\.ceil\(Style\.space\(380\) \+ popupPlacement\.margins\.right\)/.test(popupWindowQml),
+  'notification surface width includes the fixed card width and right clearance'
+)
+assert(
+  /implicitWidth: Style\.space\(380\)/.test(cardQml),
+  'notification surface and card widths remain in sync'
+)
+assert(
+  /mask: Region \{ item: popupColumn \}/.test(popupWindowQml),
+  'notification strips remain click-through outside the popup column'
+)
+const shellLayerRules = fs.readFileSync(path.join(root, 'default/hypr/apps/omarchy-shell.lua'), 'utf8')
+assert(
+  /hl\.layer_rule\(\{ match = \{ namespace = "omarchy-notifications" \}, no_anim = true, animation = "none" \}\)/.test(shellLayerRules),
+  'notification surfaces do not animate at compositor level'
+)
 assert(
   /readonly property int historyLimit: 10/.test(serviceQml),
   'notifications service keeps the last ten notifications in history'

--- a/test/shell.d/osd-test.sh
+++ b/test/shell.d/osd-test.sh
@@ -6,6 +6,11 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
 run_node_test <<'JS'
 const osd = requireFromRoot('shell/plugins/osd/OsdModel.js')
+const fs = require('fs')
+const qml = fs.readFileSync(path.join(root, 'shell/plugins/osd/Osd.qml'), 'utf8')
+assert(qml.includes('implicitWidth: card.width') && qml.includes('implicitHeight: card.height'), 'osd surface follows the card size')
+assert(qml.includes('anchors { bottom: true }') && qml.includes('margins { bottom: Style.space(67) }'), 'osd preserves the bottom offset without stretching across the output')
+assert(qml.includes('mask: Region {}'), 'osd remains click-through')
 
 assertEqual(osd.iconFor('', 0), osd.iconFor('muted', 50), 'osd falls back to muted icon at zero percent')
 assertEqual(osd.iconFor('volume-high', 1), osd.iconFor('', 100), 'osd maps high volume aliases')


### PR DESCRIPTION
Volume/status OSDs and notifications currently allocate transparent layer surfaces across the output even though their visible content occupies a small area. On a 4K desktop this substantially increases the surface area presented to the compositor during overlay activity.

This change sizes the OSD surface to its measured card, keeps it centered with the same bottom margin, and retains its empty input region. Notification surfaces become narrow right-hand strips while preserving full height, popup positioning, and the column input mask. Compositor animations are disabled for these surfaces; the OSD's progress animation remains intact.

Validation: focused OSD and notification suites pass, including surface-sizing and click-through assertions. The equivalent local compact OSD was inspected in the running desktop and through `hyprctl layers`: a volume card occupied 256×60 logical pixels on a 2400×1350 logical output. This establishes the surface reduction, not a quantified GPU or audio improvement. Private desktop captures are not attached.

Full `./test/all`: CLI suite passed; 228 of 236 shell test files passed. Failures: bar-icon-geometry, config, launch-about, locate, runtime-smoke, snapper, unowned-system-paths, and update-lock. Bar geometry and About failures were reproduced on clean upstream 31bd80d; several checks require a sibling omarchy-pkgs checkout absent here. The other failures are reported without attributing a cause; the two branch suites were run concurrently in a live desktop environment. The same eight failures occurred on the favicon-only branch, which does not modify overlay code. OSD and notification tests passed.

Draft pending clean before/after visual captures and broader layout verification (notification stacking, alternate bar positions, and scale factors). This does not change audio buffering or NVIDIA driver settings and does not claim to resolve all audio underruns.
