### PR TITLE
Sync Omarchy theme to Opencode

### DIFF
--- a/bin/omarchy-restart-opencode
+++ b/bin/omarchy-restart-opencode
@@ -2,6 +2,13 @@
 
 # omarchy:summary=Reload opencode configuration (used by the Omarchy theme switching).
 
-if pgrep -x opencode >/dev/null; then
-  killall -SIGUSR2 opencode
-fi
+# Signal only interactive TUI processes: the background service
+# (`opencode serve --service`) does not handle SIGUSR2, so signaling it
+# would kill the service instead of refreshing the configuration.
+for pid in $(pgrep -x opencode 2>/dev/null); do
+  cmdline=$(tr '\0' ' ' <"/proc/$pid/cmdline" 2>/dev/null) || continue
+  if [[ $cmdline == *" serve"* ]]; then
+    continue
+  fi
+  kill -SIGUSR2 "$pid" 2>/dev/null || true
+done

--- a/bin/omarchy-theme-set
+++ b/bin/omarchy-theme-set
@@ -371,6 +371,7 @@ post_theme_commands=(
   omarchy-theme-set-gnome
   omarchy-theme-set-pi
   omarchy-theme-set-claude
+  omarchy-theme-set-opencode
   omarchy-theme-set-hermes
   omarchy-theme-set-t3code
   omarchy-theme-set-browser

--- a/bin/omarchy-theme-set-opencode
+++ b/bin/omarchy-theme-set-opencode
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+# omarchy:summary=Sync the generated Omarchy theme to Opencode
+# omarchy:args=[--activate]
+# omarchy:hidden=true
+
+set -euo pipefail
+
+CURRENT_THEME_PATH="$HOME/.local/state/omarchy/current/theme"
+OPENCODE_SOURCE_PATH="$CURRENT_THEME_PATH/opencode.json"
+OPENCODE_CONFIG_DIR="$HOME/.config/opencode"
+OPENCODE_THEME_DIR="$OPENCODE_CONFIG_DIR/themes"
+OPENCODE_THEME_PATH="$OPENCODE_THEME_DIR/omarchy.json"
+OPENCODE_SETTINGS_PATH="$OPENCODE_CONFIG_DIR/cli.json"
+OPENCODE_ACTIVATE=0
+
+usage() {
+  echo "Usage: omarchy-theme-set-opencode [--activate]"
+}
+
+for arg in "$@"; do
+  case "$arg" in
+    --activate)
+      OPENCODE_ACTIVATE=1
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    --*)
+      usage >&2
+      exit 1
+      ;;
+    *)
+      # Ignore positional args. When run as a theme-set hook the theme
+      # slug arrives in $1; the active theme is read from state instead.
+      ;;
+  esac
+done
+
+if [[ ! -f $OPENCODE_SOURCE_PATH ]]; then
+  if (( OPENCODE_ACTIVATE == 1 )); then
+    echo "Opencode theme source missing: $OPENCODE_SOURCE_PATH" >&2
+    echo "Run omarchy-theme-refresh after selecting an Omarchy theme." >&2
+    exit 1
+  fi
+
+  exit 0
+fi
+
+if (( OPENCODE_ACTIVATE == 0 )) && [[ ! -d $OPENCODE_CONFIG_DIR ]]; then
+  exit 0
+fi
+
+write_setting_theme() {
+  local tmp
+
+  mkdir -p "$OPENCODE_CONFIG_DIR"
+
+  if [[ -f $OPENCODE_SETTINGS_PATH ]]; then
+    tmp=$(mktemp "$OPENCODE_SETTINGS_PATH.XXXXXX")
+    if jq '.theme |= (if type == "object" then .name = "omarchy" else {"name": "omarchy"} end)' "$OPENCODE_SETTINGS_PATH" >"$tmp"; then
+      mv "$tmp" "$OPENCODE_SETTINGS_PATH"
+    else
+      rm -f "$tmp"
+      return 1
+    fi
+  else
+    cat >"$OPENCODE_SETTINGS_PATH" <<EOF
+{
+  "\$schema": "https://opencode.ai/v2/cli.json",
+  "theme": {
+    "name": "omarchy"
+  }
+}
+EOF
+  fi
+}
+
+# Opencode reloads its theme list on SIGUSR2, so running sessions retint
+# without a restart. Copy first, then signal: omarchy-theme-set dispatches
+# its retint commands in parallel, so signaling here (after the copy)
+# guarantees the refresh sees the new file even if
+# omarchy-restart-opencode fires first with the stale one.
+#
+# Signal only interactive TUI processes: the background service
+# (`opencode serve --service`) does not handle SIGUSR2, so signaling it
+# would kill the service instead of refreshing the theme.
+mkdir -p "$OPENCODE_THEME_DIR"
+tmp=$(mktemp "$OPENCODE_THEME_PATH.XXXXXX")
+cp "$OPENCODE_SOURCE_PATH" "$tmp"
+mv "$tmp" "$OPENCODE_THEME_PATH"
+
+if (( OPENCODE_ACTIVATE == 1 )); then
+  write_setting_theme
+fi
+
+refresh_running_tui() {
+  local pid cmdline
+
+  for pid in $(pgrep -x opencode 2>/dev/null); do
+    cmdline=$(tr '\0' ' ' <"/proc/$pid/cmdline" 2>/dev/null) || continue
+    if [[ $cmdline == *" serve"* ]]; then
+      continue
+    fi
+    kill -SIGUSR2 "$pid" 2>/dev/null || true
+  done
+}
+
+refresh_running_tui

--- a/default/themed/opencode.json.tpl
+++ b/default/themed/opencode.json.tpl
@@ -1,0 +1,226 @@
+{
+  "$schema": "https://opencode.ai/theme.json",
+  "defs": {
+    "background": "{{ background }}",
+    "backgroundPanel": "{{ dark_background }}",
+    "backgroundElement": "{{ lighter_background }}",
+    "foreground": "{{ foreground }}",
+    "foregroundMuted": "{{ dark_foreground }}",
+    "foregroundBright": "{{ bright_foreground }}",
+    "accent": "{{ accent }}",
+    "red": "{{ red }}",
+    "redBright": "{{ bright_red }}",
+    "green": "{{ green }}",
+    "greenBright": "{{ bright_green }}",
+    "yellow": "{{ yellow }}",
+    "blue": "{{ blue }}",
+    "magenta": "{{ magenta }}",
+    "cyan": "{{ cyan }}",
+    "orange": "{{ orange }}",
+    "muted": "{{ muted }}",
+    "diffAddedBg": "{{ mix background green 15% }}",
+    "diffRemovedBg": "{{ mix background red 15% }}"
+  },
+  "theme": {
+    "primary": {
+      "dark": "accent",
+      "light": "accent"
+    },
+    "secondary": {
+      "dark": "magenta",
+      "light": "magenta"
+    },
+    "accent": {
+      "dark": "accent",
+      "light": "accent"
+    },
+    "error": {
+      "dark": "red",
+      "light": "red"
+    },
+    "warning": {
+      "dark": "yellow",
+      "light": "yellow"
+    },
+    "success": {
+      "dark": "green",
+      "light": "green"
+    },
+    "info": {
+      "dark": "cyan",
+      "light": "cyan"
+    },
+    "text": {
+      "dark": "foreground",
+      "light": "foreground"
+    },
+    "textMuted": {
+      "dark": "foregroundMuted",
+      "light": "foregroundMuted"
+    },
+    "background": {
+      "dark": "background",
+      "light": "background"
+    },
+    "backgroundPanel": {
+      "dark": "backgroundPanel",
+      "light": "backgroundPanel"
+    },
+    "backgroundElement": {
+      "dark": "backgroundElement",
+      "light": "backgroundElement"
+    },
+    "border": {
+      "dark": "muted",
+      "light": "muted"
+    },
+    "borderActive": {
+      "dark": "accent",
+      "light": "accent"
+    },
+    "borderSubtle": {
+      "dark": "backgroundPanel",
+      "light": "backgroundPanel"
+    },
+    "diffAdded": {
+      "dark": "green",
+      "light": "green"
+    },
+    "diffRemoved": {
+      "dark": "red",
+      "light": "red"
+    },
+    "diffContext": {
+      "dark": "foregroundMuted",
+      "light": "foregroundMuted"
+    },
+    "diffHunkHeader": {
+      "dark": "cyan",
+      "light": "cyan"
+    },
+    "diffHighlightAdded": {
+      "dark": "greenBright",
+      "light": "greenBright"
+    },
+    "diffHighlightRemoved": {
+      "dark": "redBright",
+      "light": "redBright"
+    },
+    "diffAddedBg": {
+      "dark": "diffAddedBg",
+      "light": "diffAddedBg"
+    },
+    "diffRemovedBg": {
+      "dark": "diffRemovedBg",
+      "light": "diffRemovedBg"
+    },
+    "diffContextBg": {
+      "dark": "backgroundPanel",
+      "light": "backgroundPanel"
+    },
+    "diffLineNumber": {
+      "dark": "foregroundMuted",
+      "light": "foregroundMuted"
+    },
+    "diffAddedLineNumberBg": {
+      "dark": "diffAddedBg",
+      "light": "diffAddedBg"
+    },
+    "diffRemovedLineNumberBg": {
+      "dark": "diffRemovedBg",
+      "light": "diffRemovedBg"
+    },
+    "markdownText": {
+      "dark": "foreground",
+      "light": "foreground"
+    },
+    "markdownHeading": {
+      "dark": "accent",
+      "light": "accent"
+    },
+    "markdownLink": {
+      "dark": "blue",
+      "light": "blue"
+    },
+    "markdownLinkText": {
+      "dark": "cyan",
+      "light": "cyan"
+    },
+    "markdownCode": {
+      "dark": "green",
+      "light": "green"
+    },
+    "markdownBlockQuote": {
+      "dark": "foregroundMuted",
+      "light": "foregroundMuted"
+    },
+    "markdownEmph": {
+      "dark": "yellow",
+      "light": "yellow"
+    },
+    "markdownStrong": {
+      "dark": "foregroundBright",
+      "light": "foregroundBright"
+    },
+    "markdownHorizontalRule": {
+      "dark": "muted",
+      "light": "muted"
+    },
+    "markdownListItem": {
+      "dark": "blue",
+      "light": "blue"
+    },
+    "markdownListEnumeration": {
+      "dark": "cyan",
+      "light": "cyan"
+    },
+    "markdownImage": {
+      "dark": "blue",
+      "light": "blue"
+    },
+    "markdownImageText": {
+      "dark": "cyan",
+      "light": "cyan"
+    },
+    "markdownCodeBlock": {
+      "dark": "foreground",
+      "light": "foreground"
+    },
+    "syntaxComment": {
+      "dark": "foregroundMuted",
+      "light": "foregroundMuted"
+    },
+    "syntaxKeyword": {
+      "dark": "magenta",
+      "light": "magenta"
+    },
+    "syntaxFunction": {
+      "dark": "blue",
+      "light": "blue"
+    },
+    "syntaxVariable": {
+      "dark": "foreground",
+      "light": "foreground"
+    },
+    "syntaxString": {
+      "dark": "green",
+      "light": "green"
+    },
+    "syntaxNumber": {
+      "dark": "yellow",
+      "light": "yellow"
+    },
+    "syntaxType": {
+      "dark": "cyan",
+      "light": "cyan"
+    },
+    "syntaxOperator": {
+      "dark": "orange",
+      "light": "orange"
+    },
+    "syntaxPunctuation": {
+      "dark": "foreground",
+      "light": "foreground"
+    }
+  }
+}

--- a/test/cli
+++ b/test/cli
@@ -510,6 +510,48 @@ HOME="$PI_TMPDIR" CLAUDE_CONFIG_DIR="$CLAUDE_TEST_CONFIG" "$ROOT/bin/omarchy-the
 jq -e '.theme == "custom:omarchy" and .model == "keep-me"' "$CLAUDE_TEST_CONFIG/settings.json" >/dev/null
 pass "claude theme activation preserves configured settings"
 
+jq -e '.defs.background == "#000000" and .defs.foreground == "#ffffff" and .theme.background.dark == "background" and .theme.syntaxOperator.dark == "orange"' "$NEXT_THEME/opencode.json" >/dev/null
+pass "opencode theme template is generated from standard themed templates"
+jq -e '.defs.orange | test("^#[0-9a-fA-F]{6}$")' "$NEXT_THEME/opencode.json" >/dev/null
+pass "opencode theme template derives missing palette keys"
+if rg -q '\{\{[^}]+\}\}' "$NEXT_THEME/opencode.json"; then
+  fail "opencode theme template leaves no placeholders"
+fi
+pass "opencode theme template leaves no placeholders"
+cp "$NEXT_THEME/opencode.json" "$CURRENT_THEME/opencode.json"
+
+make_tmpdir OPENCODE_STUB_BIN
+cat >"$OPENCODE_STUB_BIN/pgrep" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+chmod +x "$OPENCODE_STUB_BIN/pgrep"
+
+PATH="$OPENCODE_STUB_BIN:$ROOT/bin:$PATH" HOME="$PI_TMPDIR" "$ROOT/bin/omarchy-theme-set-opencode"
+[[ ! -d $PI_TMPDIR/.config/opencode ]] || fail "opencode theme sync skips missing opencode config when not activating"
+pass "opencode theme sync skips missing opencode config when not activating"
+
+PATH="$OPENCODE_STUB_BIN:$ROOT/bin:$PATH" HOME="$PI_TMPDIR" "$ROOT/bin/omarchy-theme-set-opencode" --activate
+[[ -f $PI_TMPDIR/.config/opencode/themes/omarchy.json ]] || fail "opencode theme file is synced"
+pass "opencode theme file is synced"
+jq -e '.defs.background == "#000000"' "$PI_TMPDIR/.config/opencode/themes/omarchy.json" >/dev/null
+pass "opencode synced theme JSON is valid"
+jq -e '.theme.name == "omarchy"' "$PI_TMPDIR/.config/opencode/cli.json" >/dev/null
+pass "opencode generated theme is activated"
+
+jq '.mode = "keep-me"' "$PI_TMPDIR/.config/opencode/cli.json" >"$PI_TMPDIR/cli.json.tmp"
+mv "$PI_TMPDIR/cli.json.tmp" "$PI_TMPDIR/.config/opencode/cli.json"
+PATH="$OPENCODE_STUB_BIN:$ROOT/bin:$PATH" HOME="$PI_TMPDIR" "$ROOT/bin/omarchy-theme-set-opencode" --activate
+jq -e '.theme.name == "omarchy" and .mode == "keep-me"' "$PI_TMPDIR/.config/opencode/cli.json" >/dev/null
+pass "opencode theme activation preserves existing settings"
+
+PATH="$OPENCODE_STUB_BIN:$ROOT/bin:$PATH" HOME="$PI_TMPDIR" "$ROOT/bin/omarchy-theme-set-opencode" "tokyo-night"
+pass "opencode theme sync tolerates the hook theme slug"
+if PATH="$OPENCODE_STUB_BIN:$ROOT/bin:$PATH" HOME="$PI_TMPDIR" "$ROOT/bin/omarchy-theme-set-opencode" --bogus 2>/dev/null; then
+  fail "opencode theme sync rejects unknown flags"
+fi
+pass "opencode theme sync rejects unknown flags"
+
 make_tmpdir THEME_TMPDIR
 OMARCHY_PATH="$ROOT" HOME="$THEME_TMPDIR" OMARCHY_THEME_HEADLESS=1 "$ROOT/bin/omarchy-theme-set" "Tokyo Night"
 background_path=$(readlink -f "$THEME_TMPDIR/.local/state/omarchy/current/background" 2>/dev/null || true)

--- a/test/shell.d/opencode-refresh-test.sh
+++ b/test/shell.d/opencode-refresh-test.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+source "$(dirname "$0")/base-test.sh"
+
+require_command tail
+
+TEST_HOME=$(mktemp -d)
+FAKE_BIN="$TEST_HOME/bin"
+CURRENT_THEME="$TEST_HOME/.local/state/omarchy/current/theme"
+mkdir -p "$FAKE_BIN" "$CURRENT_THEME" "$TEST_HOME/.config/opencode"
+
+SERVE_PID=""
+TUI_PID=""
+
+# shellcheck disable=SC2329
+cleanup() {
+  kill "$SERVE_PID" "$TUI_PID" 2>/dev/null || true
+  rm -rf "$TEST_HOME"
+}
+trap cleanup EXIT
+
+# pgrep shim: report only PIDs this test controls, never real processes.
+cat >"$FAKE_BIN/pgrep" <<'EOF'
+#!/bin/bash
+cat "$PGREP_PID_FILE" 2>/dev/null || true
+EOF
+chmod +x "$FAKE_BIN/pgrep"
+PGREP_PID_FILE="$TEST_HOME/pgrep-pids"
+: >"$PGREP_PID_FILE"
+export PGREP_PID_FILE
+
+# Fake opencode processes: same process name, but only one carries the
+# background service command line.
+start_fake_processes() {
+  kill "$SERVE_PID" "$TUI_PID" 2>/dev/null || true
+  ln -sf "$(command -v tail)" "$FAKE_BIN/opencode"
+  "$FAKE_BIN/opencode" -f /dev/null -- serve --service 2>/dev/null &
+  SERVE_PID=$!
+  "$FAKE_BIN/opencode" -f /dev/null 2>/dev/null &
+  TUI_PID=$!
+  printf '%s\n%s\n' "$SERVE_PID" "$TUI_PID" >"$PGREP_PID_FILE"
+}
+
+printf '{"background": "#15191d"}\n' >"$CURRENT_THEME/opencode.json"
+
+start_fake_processes
+TRACE="$TEST_HOME/trace.log"
+PATH="$FAKE_BIN:$ROOT/bin:$PATH" HOME="$TEST_HOME" bash -x "$ROOT/bin/omarchy-theme-set-opencode" "some-theme" 2>"$TRACE" || fail "opencode theme sync exits zero with processes running"
+grep -Fq "kill -SIGUSR2 $TUI_PID" "$TRACE" || fail "opencode theme sync refreshes the running TUI"
+grep -Fq "kill -SIGUSR2 $SERVE_PID" "$TRACE" && fail "opencode theme sync never signals the background service"
+
+start_fake_processes
+: >"$TRACE"
+PATH="$FAKE_BIN:$ROOT/bin:$PATH" HOME="$TEST_HOME" bash -x "$ROOT/bin/omarchy-restart-opencode" 2>"$TRACE" || fail "opencode restart exits zero with processes running"
+grep -Fq "kill -SIGUSR2 $TUI_PID" "$TRACE" || fail "opencode restart refreshes the running TUI"
+grep -Fq "kill -SIGUSR2 $SERVE_PID" "$TRACE" && fail "opencode restart never signals the background service"
+
+pass "opencode refresh signals only the TUI"


### PR DESCRIPTION
Generates an Opencode file theme from `colors.toml` on every theme switch and syncs it to `~/.config/opencode/themes/omarchy.json`, so Opencode follows the Omarchy theme. Open sessions retint live via SIGUSR2 without a restart. Opt in once with `omarchy-theme-set-opencode --activate` (mirrors the `claude`/`pi` sync scripts).

Reloads target interactive TUIs only: the background service (`opencode serve --service`) does not handle SIGUSR2, so the previous `killall -SIGUSR2 opencode` killed the service on every theme switch instead of refreshing. Both the new sync script and `omarchy-restart-opencode` now skip service processes.

Notes:
- The template uses the file theme format (same shape as the built-in themes and `.opencode/themes/mytheme.json` upstream). The newer version-2 documented format with partial keys did not apply on 0.0.0-beta-19500 in testing (theme silently falls back to built-in), so this ships the complete key set that was verified to load and live-refresh.
- Verified end to end on beta-19500: template renders with zero placeholders left (including palettes missing derived keys like `orange`), sync + activation preserve unrelated `cli.json` settings, and a running TUI switched Mandalorian -> Tokyo Night -> Mandalorian purely via file sync + SIGUSR2 (confirmed by reading the TUI's emitted truecolor sequences).
- Tests: new theme template/sync/activation coverage in `./test/cli` (10 assertions) plus `test/shell.d/opencode-refresh-test.sh` for the TUI-only signaling of both scripts. Full `./test/cli` passes (126 ok); `./test/shell` shows only the pre-existing environmental failures (missing omarchy-pkgs checkout, non-executable snapper test).

Screenshots of the running TUI under each theme to follow (attached via web UI).
<img width="2376" height="1404" alt="shot-tokyonight" src="https://github.com/user-attachments/assets/fa9dcbff-6aaf-41b0-ae79-962a40e5d97b" />
<img width="2376" height="1404" alt="shot-mandalorian" src="https://github.com/user-attachments/assets/a3e7ad6d-f473-418b-9d68-99e1c8c0ad6a" />
