### PR TITLE
Accept bar style tokens from shell config

### DIFF
--- a/shell/Commons/Style.qml
+++ b/shell/Commons/Style.qml
@@ -405,7 +405,7 @@ QtObject {
       } else if (section === "bar") {
         if (key === "scale-with-font") {
           nextBarScaleWithFont = boolToken(raw, nextBarScaleWithFont)
-        } else if (key === "size-horizontal" || key === "size-vertical") {
+        } else if (["size-horizontal", "size-vertical", "icon-slot", "icon-canvas", "icon-font", "status-slot"].indexOf(key) >= 0) {
           var b = parseInt(raw, 10)
           if (isFinite(b)) barOut[key] = b
         }

--- a/test/shell.d/bar-style-config-test.sh
+++ b/test/shell.d/bar-style-config-test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const styleSource = fs.readFileSync(root + '/shell/Commons/Style.qml', 'utf8')
+const barConfigBranch = styleSource.match(
+  /else if \(section === .bar.\) \{([\s\S]*?)else if \(section === .spacing.\)/
+)[1]
+
+for (const token of ['size-horizontal', 'size-vertical', 'icon-slot', 'icon-canvas', 'icon-font', 'status-slot']) {
+  assert(
+    barConfigBranch.includes(token),
+    `[bar] ${token} is accepted from shell.toml`
+  )
+}
+JS


### PR DESCRIPTION
## What

- Accept icon-slot, icon-canvas, icon-font, and status-slot from the bar section of shell.toml.
- Add a focused shell test covering all six supported bar metric tokens.

## Why

Style.qml already exposes and consumes these four tokens through barToken(), but applyShellValues() silently discarded them. This makes the documented configuration surface unreachable while size-horizontal and size-vertical work.

## Testing

- bash -n test/shell.d/bar-style-config-test.sh
- bash test/shell.d/bar-style-config-test.sh
- git diff --check upstream/quattro...HEAD

Fixes #11359