### PR TITLE
Reload shell when local plugin QML changes

### DIFF
--- a/shell/services/PluginRegistry.qml
+++ b/shell/services/PluginRegistry.qml
@@ -29,7 +29,7 @@ QtObject {
   signal pluginsChanged()
   signal scanFinished()
   signal pluginLoadFailed(string id, string error)
-  signal localPluginChanged(string id)
+  signal localPluginChanged(string id, bool qmlSourceChanged)
 
   // ---------------------------------------------------------------- helpers
 
@@ -675,7 +675,7 @@ QtObject {
     stdout: SplitParser {
       onRead: function(path) {
         var pluginId = registry.localPluginIdForPath(path)
-        if (pluginId) registry.localPluginChanged(pluginId)
+        if (pluginId) registry.localPluginChanged(pluginId, registry.localPluginQmlChangedForPath(path))
       }
     }
     onExited: localPluginWatcherRestart.restart()
@@ -737,6 +737,10 @@ QtObject {
 
     var slash = relative.indexOf("/")
     return slash === -1 ? relative : relative.slice(0, slash)
+  }
+
+  function localPluginQmlChangedForPath(filePath) {
+    return /\.qml$/i.test(String(filePath || "").trim())
   }
 
   Component.onCompleted: ensureUserDir()

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -57,11 +57,19 @@ ShellRoot {
   property var shellConfig: builtinShellConfig
   property bool pluginReloading: false
   property bool pluginReloadPending: false
+  property bool localPluginQmlReloadPending: false
 
   Timer {
     id: localPluginReloadTimer
     interval: 150
-    onTriggered: shell.reloadPlugins()
+    onTriggered: {
+      if (shell.localPluginQmlReloadPending) {
+        shell.localPluginQmlReloadPending = false
+        Quickshell.reload(false)
+      } else {
+        shell.reloadPlugins()
+      }
+    }
   }
 
   onShellConfigChanged: {
@@ -1456,14 +1464,14 @@ ShellRoot {
       shell.pluginReloadPending = true
       return
     }
-    if (typeof Qt.clearComponentCache === "function") Qt.clearComponentCache()
     shell.pluginRegistry.rescan()
   }
 
   Connections {
     target: shell.pluginRegistry
-    function onLocalPluginChanged(pluginId) {
+    function onLocalPluginChanged(pluginId, qmlSourceChanged) {
       console.log("Local plugin changed, reloading:", pluginId)
+      if (qmlSourceChanged) shell.localPluginQmlReloadPending = true
       localPluginReloadTimer.restart()
     }
     function onScanFinished() {

--- a/test/shell.d/plugin-hot-reload-test.sh
+++ b/test/shell.d/plugin-hot-reload-test.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const registrySource = fs.readFileSync(root + '/shell/services/PluginRegistry.qml', 'utf8')
+const shellSource = fs.readFileSync(root + '/shell/shell.qml', 'utf8')
+
+assert(
+  /function localPluginQmlChangedForPath\(filePath\) \{[\s\S]*?\/\\\.qml\$\/i\.test/.test(registrySource),
+  'the plugin watcher identifies QML changes case-insensitively'
+)
+assert(
+  /localPluginChanged\(pluginId, registry\.localPluginQmlChangedForPath\(path\)\)/.test(registrySource),
+  'the plugin watcher reports whether changed content is QML'
+)
+assert(
+  /if \(qmlSourceChanged\) shell\.localPluginQmlReloadPending = true/.test(shellSource),
+  'QML changes request an engine reload'
+)
+assert(
+  /if \(shell\.localPluginQmlReloadPending\) \{[\s\S]*?Quickshell\.reload\(false\)[\s\S]*?\} else \{[\s\S]*?shell\.reloadPlugins\(\)/.test(shellSource),
+  'only QML changes soft-reload the shell engine'
+)
+assert(
+  !shellSource.includes('Qt.clearComponentCache'),
+  'plugin reload does not call the unavailable QML cache API'
+)
+JS


### PR DESCRIPTION
## What

- Mark local plugin watcher events when the changed path is QML.
- Debounce QML edits into Quickshell.reload(false), while retaining the existing registry-only reload for non-QML changes.
- Remove the unreachable Qt.clearComponentCache guard.
- Add focused regression coverage for the watcher-to-reload path.

## Why

Qt.clearComponentCache is a QQmlEngine C++ method and is not available on the QML Qt global, so the existing guard never runs. Rescanning then reuses the already compiled component for the same file URL.

Using the supported soft reload refreshes QML while allowing Quickshell to reuse existing windows. Restricting it to QML paths prevents runtime files such as Python __pycache__ entries from repeatedly reloading the whole shell.

## Testing

- bash -n test/shell.d/plugin-hot-reload-test.sh
- bash test/shell.d/plugin-hot-reload-test.sh
- bash test/shell.d/plugin-registry-contract-test.sh
  - Skipped cleanly because Quickshell is not installed in this environment.
- git diff --check upstream/quattro...HEAD

Live visual verification was not performed because this Windows/WSL environment does not provide an Omarchy Quickshell session.

Fixes #11397