### PR TITLE
Fix monitor scaling widget coupling multiple monitors' scale

### DIFF
--- a/bin/omarchy-hyprland-monitor-scaling
+++ b/bin/omarchy-hyprland-monitor-scaling
@@ -71,6 +71,31 @@ normalize_scale() {
   awk 'NR == 1 { printf "%g\n", $0 }'
 }
 
+# A monitor can have its own hl.monitor({ output = "..." }) block that still
+# references the shared omarchy_monitor_scale variable (Omarchy's own
+# commented example in monitors.lua encourages exactly this for a second
+# monitor). If we always rewrote that shared variable below, scaling one
+# monitor would silently rescale every other monitor referencing it too.
+# Update the monitor's own line in place instead, when it has one, so the
+# change stays scoped to the monitor the user is actually looking at.
+persist_named_monitor_scale() {
+  local monitor="$1"
+  local new_scale="$2"
+  local monitor_lua="$3"
+
+  [[ -f $monitor_lua ]] || return 1
+  grep -Fq "output = \"$monitor\"" "$monitor_lua" || return 1
+
+  local tmp
+  tmp=$(mktemp)
+  MONITOR="$monitor" NEW_SCALE="$new_scale" awk '
+    BEGIN { needle = "output = \"" ENVIRON["MONITOR"] "\""; scale = ENVIRON["NEW_SCALE"] }
+    index($0, needle) > 0 { sub(/scale = [^, }]+/, "scale = " scale) }
+    { print }
+  ' "$monitor_lua" >"$tmp"
+  mv "$tmp" "$monitor_lua"
+}
+
 set_scale() {
   local requested_scale="$1"
   local requested="${2:-$requested_scale}"
@@ -97,9 +122,13 @@ set_scale() {
   hyprctl eval "hl.monitor({ output = \"$active_monitor\", mode = \"${width}x${height}@${refresh_rate}\", position = \"auto\", scale = $new_scale })" >/dev/null
   audit_scale_change "$requested" "$active_monitor" "$current_scale" "$new_scale"
 
-  # Persist to monitors.lua if the user still has Omarchy's generic catch-all
-  # defaults, so the scale survives reboots.
-  if [[ -f $monitor_lua ]] && grep -q '^local omarchy_monitor_scale = ' "$monitor_lua"; then
+  # Persist to monitors.lua so the scale survives reboots. A monitor with its
+  # own hl.monitor({ output = "..." }) block is handled first, above; only
+  # fall back to the shared catch-all defaults when there's no dedicated line
+  # for this monitor to update instead.
+  if persist_named_monitor_scale "$active_monitor" "$new_scale" "$monitor_lua"; then
+    :
+  elif [[ -f $monitor_lua ]] && grep -q '^local omarchy_monitor_scale = ' "$monitor_lua"; then
     sed -i -E \
       -e "s|^local omarchy_monitor_scale = .*|local omarchy_monitor_scale = ${new_scale}|" \
       -e "s|^local omarchy_gdk_scale = .*|local omarchy_gdk_scale = ${new_gdk_scale}|" \

--- a/test/shell.d/monitor-scaling-test.sh
+++ b/test/shell.d/monitor-scaling-test.sh
@@ -129,3 +129,28 @@ grep -F 'scale = 2' "$eval_out" >/dev/null || fail "monitor scaling down skips d
 grep -Fx 'local omarchy_monitor_scale = 2' "$monitor_lua" >/dev/null ||
   fail "monitor scaling down persists 2x after skipping duplicate approximation"
 pass "monitor scaling down skips duplicate approximation"
+
+# Two real monitors can each have their own hl.monitor() block while still
+# referencing the shared omarchy_monitor_scale variable, as Omarchy's own
+# commented example in monitors.lua encourages. Scaling the focused one must
+# not silently rescale the other.
+write_two_monitor_config() {
+  cat >"$monitor_lua" <<'LUA'
+local omarchy_gdk_scale = 2
+local omarchy_monitor_scale = 2
+
+hl.monitor({ output = "eDP-1", mode = "2880x1800@120", position = "0x0", scale = omarchy_monitor_scale })
+hl.monitor({ output = "DP-2", mode = "2560x1440@144", position = "2880x0", scale = omarchy_monitor_scale })
+LUA
+}
+
+write_two_monitor_config
+OMARCHY_TEST_MONITOR_SCALE=2 run_scaling 3
+grep -F 'scale = 3' "$eval_out" >/dev/null || fail "monitor scaling on a named monitor still applies live"
+grep -Fx 'hl.monitor({ output = "eDP-1", mode = "2880x1800@120", position = "0x0", scale = 3 })' "$monitor_lua" >/dev/null ||
+  fail "monitor scaling persists to the focused monitor's own hl.monitor line"
+grep -Fx 'hl.monitor({ output = "DP-2", mode = "2560x1440@144", position = "2880x0", scale = omarchy_monitor_scale })' "$monitor_lua" >/dev/null ||
+  fail "monitor scaling leaves a different monitor sharing the variable untouched"
+grep -Fx 'local omarchy_monitor_scale = 2' "$monitor_lua" >/dev/null ||
+  fail "monitor scaling leaves the shared variable itself untouched when a named block absorbs the change"
+pass "monitor scaling on a named monitor updates only that monitor's own line"


### PR DESCRIPTION
## Summary
- `omarchy-hyprland-monitor-scaling` (used by the shell's monitor-scale panel) persists a scale change by rewriting the shared `omarchy_monitor_scale` variable in `monitors.lua` whenever it's declared, regardless of how many `hl.monitor()` blocks reference it.
- On a multi-monitor setup where each real monitor has its own named block still pointing at that variable — the pattern Omarchy's own commented example in `monitors.lua` encourages — changing one monitor's scale from the panel silently rescales every other monitor sharing the variable too.
- This updates the focused monitor's own `hl.monitor()` line in place when it has one, before falling back to the shared variable/catch-all defaults, so a scale change stays scoped to the monitor the user is actually looking at.

Repro'd and fixed on a real dual-monitor Hyprland setup (a primary display plus a rotated secondary), and added a regression test covering two named monitors sharing the variable.

## Test plan
- [x] `./test/shell.d/monitor-scaling-test.sh` — all pass, including the new regression test
- [x] `./test/cli` — all pass
- [x] Verified the 6 unrelated `./test/shell` failures on this machine (missing `omarchy-pkgs` fixture, an unrelated locale bug, two Quickshell/IPC flakiness tests) are pre-existing and reproduce identically on a clean checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017N8JuTskGq1PDbbrwEjxCX