### PR TITLE
Dismiss stale low battery warnings

### DIFF
--- a/shell/plugins/services/battery/BatteryModel.js
+++ b/shell/plugins/services/battery/BatteryModel.js
@@ -9,12 +9,13 @@ function isDischarging(device, onBattery, dischargingState) {
 
 function shouldWarnLowBattery(device, onBattery, dischargingState, threshold, alreadyNotified) {
   var level = batteryPercentage(device)
-  if (level < 0) return { level: level, notify: false, notifiedLowBattery: false }
+  if (level < 0) return { level: level, notify: false, dismiss: false, notifiedLowBattery: false }
 
   var low = isDischarging(device, onBattery, dischargingState) && level <= threshold
   return {
     level: level,
     notify: low && !alreadyNotified,
+    dismiss: !low && alreadyNotified,
     notifiedLowBattery: low
   }
 }

--- a/shell/plugins/services/battery/Service.qml
+++ b/shell/plugins/services/battery/Service.qml
@@ -33,6 +33,7 @@ Item {
     var state = BatteryModel.shouldWarnLowBattery(UPower.displayDevice, UPower.onBattery, UPowerDeviceState.Discharging, batteryThreshold, persisted.notifiedLowBattery)
     persisted.notifiedLowBattery = state.notifiedLowBattery
     if (state.notify) sendLowBatteryWarning(state.level)
+    if (state.dismiss) dismissLowBatteryWarning()
   }
 
   function sendLowBatteryWarning(level) {
@@ -42,6 +43,10 @@ Item {
       String(level)
     ]
     warningProcess.running = true
+  }
+
+  function dismissLowBatteryWarning() {
+    if (!dismissWarningProcess.running) dismissWarningProcess.running = true
   }
 
   function applyPowerProfile() {
@@ -60,6 +65,11 @@ Item {
   }
 
   Process { id: warningProcess }
+
+  Process {
+    id: dismissWarningProcess
+    command: ["omarchy-notification-dismiss", "Time to recharge!"]
+  }
 
   Process {
     id: powerProfileProcess

--- a/test/shell.d/battery-test.sh
+++ b/test/shell.d/battery-test.sh
@@ -15,17 +15,22 @@ assert(!battery.isDischarging({ isPresent: true, state: discharging }, false, di
 
 assertDeepEqual(
   battery.shouldWarnLowBattery({ isPresent: true, percentage: 0.08, state: discharging }, true, discharging, 10, false),
-  { level: 8, notify: true, notifiedLowBattery: true },
+  { level: 8, notify: true, dismiss: false, notifiedLowBattery: true },
   'battery warns once under threshold'
 )
 assertDeepEqual(
   battery.shouldWarnLowBattery({ isPresent: true, percentage: 0.08, state: discharging }, true, discharging, 10, true),
-  { level: 8, notify: false, notifiedLowBattery: true },
+  { level: 8, notify: false, dismiss: false, notifiedLowBattery: true },
   'battery keeps low-battery notified state'
 )
 assertDeepEqual(
   battery.shouldWarnLowBattery({ isPresent: true, percentage: 0.4, state: discharging }, true, discharging, 10, true),
-  { level: 40, notify: false, notifiedLowBattery: false },
+  { level: 40, notify: false, dismiss: true, notifiedLowBattery: false },
   'battery clears notified state after recovery'
+)
+assertDeepEqual(
+  battery.shouldWarnLowBattery({ isPresent: true, percentage: 1, state: discharging }, true, discharging, 10, true),
+  { level: 100, notify: false, dismiss: true, notifiedLowBattery: false },
+  'battery dismisses a stale low-battery warning after a full recharge'
 )
 JS


### PR DESCRIPTION
## Summary
- dismiss the persistent low-battery notification once the battery recovers or stops discharging
- preserve one-shot warning behavior while the battery remains low
- add regression coverage for recovery to a full charge

## Root cause
Low-battery notifications use critical urgency, which intentionally gives them an infinite lifetime. The battery service reset its notification bookkeeping after recovery but never dismissed the visible critical toast.

## Testing
- `bash ./test/shell.d/battery-test.sh`
- `bash ./test/shell.d/notifications-test.sh`
- visually verified the warning is removed through the shell notification dismissal path