### PR TITLE
Fix keyboard layout persistence after first-boot setup

### DIFF
--- a/bin/omarchy-provision-owner
+++ b/bin/omarchy-provision-owner
@@ -613,18 +613,25 @@ confirm_reboot() {
 # vconsole.conf, leaving every other line (KEYMAP, FONT, comments) alone.
 omarchy_write_xkb_layout() {
   local file="$1" layout="$2" variant="$3"
+  local payload="XKBLAYOUT=$layout"
+
+  if [[ -n $variant ]]; then
+    payload+=$'\nXKBVARIANT='"$variant"
+  fi
 
   if grep -q '^XKBLAYOUT=' "$file"; then
     sed -i "s/^XKBLAYOUT=.*/XKBLAYOUT=$layout/" "$file"
+    if [[ -n $variant ]]; then
+      if grep -q '^XKBVARIANT=' "$file"; then
+        sed -i "s/^XKBVARIANT=.*/XKBVARIANT=$variant/" "$file"
+      else
+        printf 'XKBVARIANT=%s\n' "$variant" >>"$file"
+      fi
+    fi
   else
-    printf 'XKBLAYOUT=%s\n' "$layout" >>"$file"
-  fi
-
-  [[ -n $variant ]] || return 0
-  if grep -q '^XKBVARIANT=' "$file"; then
-    sed -i "s/^XKBVARIANT=.*/XKBVARIANT=$variant/" "$file"
-  else
-    printf 'XKBVARIANT=%s\n' "$variant" >>"$file"
+    # Both values land with a single write, so a failure leaves nothing half
+    # set for a later run to treat as already exposed.
+    printf '%s\n' "$payload" >>"$file"
   fi
 }
 
@@ -664,7 +671,10 @@ apply_keyboard() {
   if localectl --no-pager list-keymaps 2>/dev/null | grep -qix "$keymap"; then
     if systemd-firstboot --keymap="$keymap" --force >>"$LOG_FILE" 2>&1 ||
       localectl set-keymap "$keymap" >>"$LOG_FILE" 2>&1; then
-      omarchy_expose_xkb_layout /etc/vconsole.conf "$keymap"
+      # Best-effort like the persistence above: a failed exposure must not
+      # abort setup, it only leaves the layout unpersisted.
+      omarchy_expose_xkb_layout /etc/vconsole.conf "$keymap" ||
+        log_step "could not expose the XKB layout for $keymap"
     else
       log_step "could not persist keymap $keymap"
     fi

--- a/bin/omarchy-provision-owner
+++ b/bin/omarchy-provision-owner
@@ -609,19 +609,65 @@ confirm_reboot() {
   gum confirm --affirmative "Yes, reboot" --negative "No, keep setting up" "Reboot this machine?"
 }
 
+# Set (or replace) the XKB layout — and variant, when there is one — in a
+# vconsole.conf, leaving every other line (KEYMAP, FONT, comments) alone.
+omarchy_write_xkb_layout() {
+  local file="$1" layout="$2" variant="$3"
+
+  if grep -q '^XKBLAYOUT=' "$file"; then
+    sed -i "s/^XKBLAYOUT=.*/XKBLAYOUT=$layout/" "$file"
+  else
+    printf 'XKBLAYOUT=%s\n' "$layout" >>"$file"
+  fi
+
+  [[ -n $variant ]] || return 0
+  if grep -q '^XKBVARIANT=' "$file"; then
+    sed -i "s/^XKBVARIANT=.*/XKBVARIANT=$variant/" "$file"
+  else
+    printf 'XKBVARIANT=%s\n' "$variant" >>"$file"
+  fi
+}
+
+# When persistence left the XKB variables out of a vconsole.conf — systemd's
+# kbd-model-map has no conversion row for the keymap — fill them from the
+# form's gap table. The user session and the SDDM greeter both resolve the
+# layout from XKBLAYOUT/XKBVARIANT, so without them login falls back to "us"
+# and a password typed under the chosen layout becomes untypeable. Only runs
+# after persistence actually landed (nothing to pair a layout with otherwise),
+# so a persisted KEYMAP and XKB layout can never disagree.
+omarchy_expose_xkb_layout() {
+  local vconsole="$1" keymap="$2" xkb xkb_layout xkb_variant
+
+  if grep -q '^XKBLAYOUT=' "$vconsole" 2>/dev/null; then
+    return 0
+  fi
+
+  xkb=$(omarchy_keyboard_xkb "$keymap")
+  [[ -n $xkb ]] || return 0
+
+  read -r xkb_layout xkb_variant <<<"$xkb"
+  omarchy_write_xkb_layout "$vconsole" "$xkb_layout" "$xkb_variant"
+  log_step "keymap $keymap has no XKB conversion; exposed layout $xkb_layout${xkb_variant:+ ($xkb_variant)}"
+}
+
 # Load the layout on the live VT and persist it for the installed system.
 # systemd-firstboot writes both the console KEYMAP and the XKB layout Hyprland
-# reads, matching what the ISO's configure_keyboard does at install time. A
-# keymap localectl doesn't know keeps the default rather than failing (defensive;
-# the picker no longer offers any such layout).
+# reads, matching what the ISO's configure_keyboard does at install time —
+# except for the keymaps systemd's kbd-model-map has no conversion row for
+# (omarchy_expose_xkb_layout covers those). A keymap localectl doesn't know
+# keeps the default rather than failing (defensive; the picker no longer
+# offers any such layout).
 apply_keyboard() {
   local keymap="$1"
   [[ $(tty 2>/dev/null) == /dev/tty* ]] && loadkeys "$keymap" 2>/dev/null || true
 
   if localectl --no-pager list-keymaps 2>/dev/null | grep -qix "$keymap"; then
-    systemd-firstboot --keymap="$keymap" --force >>"$LOG_FILE" 2>&1 || \
-      localectl set-keymap "$keymap" >>"$LOG_FILE" 2>&1 || \
+    if systemd-firstboot --keymap="$keymap" --force >>"$LOG_FILE" 2>&1 ||
+      localectl set-keymap "$keymap" >>"$LOG_FILE" 2>&1; then
+      omarchy_expose_xkb_layout /etc/vconsole.conf "$keymap"
+    else
       log_step "could not persist keymap $keymap"
+    fi
   else
     log_step "keymap $keymap unknown to localectl; keeping the default"
   fi

--- a/default/hypr/input.lua
+++ b/default/hypr/input.lua
@@ -1,58 +1,13 @@
 -- https://wiki.hypr.land/Configuring/Basics/Variables/#input
 
-local function read_vconsole()
-  local values = {}
-  local file = io.open("/etc/vconsole.conf", "r")
-  if not file then
-    return values
-  end
-
-  for line in file:lines() do
-    local key, value = line:match("^%s*([%w_]+)%s*=%s*(.-)%s*$")
-    if key and value then
-      value = value:gsub("%s+#.*$", "")
-      value = value:gsub('^"(.*)"$', "%1")
-      value = value:gsub("^'(.*)'$", "%1")
-      values[key] = value
-    end
-  end
-
-  file:close()
-  return values
-end
-
--- Layouts that can't type Latin letters. Keep in sync with the list in
--- etc/mkinitcpio.conf.d/omarchy_hooks.conf.
-local non_latin_layouts =
-  " af am ara bd bg by et ge gr il in iq ir kg kh kz la lk mk mm mn mv np rs ru sy th tj ua "
-
-local vconsole = read_vconsole()
-
-local kb_layout = vconsole.XKBLAYOUT or "us"
-local kb_variant = vconsole.XKBVARIANT or ""
--- CapsLock is the compose key, so Caps Lock itself has to live somewhere else.
--- Both Shifts together is the usual home for it, but it's easy to hit by
--- accident while typing. The _cancel variant sets Caps Lock the same way and
--- releases it on the next lone Shift, so a misfire clears itself.
-local kb_options = "compose:caps,shift:both_capslock_cancel"
-
--- Hyprland resolves keybindings against the first entry in kb_layout, not the
--- layout that's currently active, so Omarchy's Latin-keysym bindings (SUPER + W
--- and friends) only fire when a Latin layout leads. Installing with a non-Latin
--- one would otherwise leave the desktop unusable.
-if non_latin_layouts:find(" " .. kb_layout:match("^[^,]*") .. " ", 1, true) then
-  kb_layout = "us," .. kb_layout
-  kb_variant = "," .. kb_variant
-  -- Reach the original layout with Left Alt + Right Alt.
-  kb_options = kb_options .. ",grp:alts_toggle"
-end
+local keyboard = require("default.hypr.keyboard")
 
 hl.config({
   input = {
-    kb_layout = kb_layout,
-    kb_variant = kb_variant,
+    kb_layout = keyboard.layout,
+    kb_variant = keyboard.variant,
     kb_model = "",
-    kb_options = kb_options,
+    kb_options = keyboard.options,
     kb_rules = "",
     follow_mouse = 1,
     sensitivity = 0,

--- a/default/hypr/keyboard.lua
+++ b/default/hypr/keyboard.lua
@@ -1,0 +1,60 @@
+-- Keyboard layout resolved from the system's /etc/vconsole.conf.
+-- Shared by the user session (default/hypr/input.lua) and by the SDDM greeter
+-- (default/sddm/hyprland.lua). They are separate Hyprland instances, but a
+-- password is typed at one and set from the other, so both have to agree on
+-- the layout.
+
+local function read_vconsole()
+  local values = {}
+  local file = io.open("/etc/vconsole.conf", "r")
+  if not file then
+    return values
+  end
+
+  for line in file:lines() do
+    local key, value = line:match("^%s*([%w_]+)%s*=%s*(.-)%s*$")
+    if key and value then
+      value = value:gsub("%s+#.*$", "")
+      value = value:gsub('^"(.*)"$', "%1")
+      value = value:gsub("^'(.*)'$", "%1")
+      values[key] = value
+    end
+  end
+
+  file:close()
+  return values
+end
+
+-- Layouts that can't type Latin letters. Keep in sync with the list in
+-- etc/mkinitcpio.conf.d/omarchy_hooks.conf.
+local non_latin_layouts =
+  " af am ara bd bg by et ge gr il in iq ir kg kh kz la lk mk mm mn mv np rs ru sy th tj ua "
+
+local vconsole = read_vconsole()
+
+local kb_layout = vconsole.XKBLAYOUT or "us"
+local kb_variant = vconsole.XKBVARIANT or ""
+-- CapsLock is the compose key, so Caps Lock itself has to live somewhere else.
+-- Both Shifts together is the usual home for it, but it's easy to hit by
+-- accident while typing. The _cancel variant sets Caps Lock the same way and
+-- releases it on the next lone Shift, so a misfire clears itself.
+local kb_options = "compose:caps,shift:both_capslock_cancel"
+
+-- Hyprland resolves keybindings against the first entry in kb_layout, not the
+-- layout that's currently active, so Omarchy's Latin-keysym bindings (SUPER + W
+-- and friends) only fire when a Latin layout leads. Installing with a non-Latin
+-- one would otherwise leave the desktop unusable. The greeter needs the same
+-- fallback for a different reason: passwords are Latin, so a non-Latin-only
+-- layout would leave the correct one untypeable at the login prompt.
+if non_latin_layouts:find(" " .. kb_layout:match("^[^,]*") .. " ", 1, true) then
+  kb_layout = "us," .. kb_layout
+  kb_variant = "," .. kb_variant
+  -- Reach the original layout with Left Alt + Right Alt.
+  kb_options = kb_options .. ",grp:alts_toggle"
+end
+
+return {
+  layout = kb_layout,
+  variant = kb_variant,
+  options = kb_options,
+}

--- a/default/sddm/hyprland.lua
+++ b/default/sddm/hyprland.lua
@@ -1,6 +1,22 @@
 -- Minimal Hyprland config for the SDDM Wayland greeter.
 -- SDDM starts the greeter itself after the compositor is ready.
+
+-- The greeter is its own Hyprland instance, started by sddm-helper instead of
+-- the user session, so it never runs default/hypr/bootstrap.lua. Set up just
+-- enough of the module path to share the session's layout resolution: with no
+-- input block Hyprland falls back to its built-in "us" default, and a password
+-- set under any other layout cannot be typed at the login prompt.
+package.path = (os.getenv("OMARCHY_PATH") or "/usr/share/omarchy") .. "/?.lua;" .. package.path
+
+local keyboard = require("default.hypr.keyboard")
+
 hl.config({
+  input = {
+    kb_layout = keyboard.layout,
+    kb_variant = keyboard.variant,
+    kb_options = keyboard.options,
+  },
+
   misc = {
     disable_hyprland_logo = true,
     disable_splash_rendering = true,

--- a/docs/file-layout.md
+++ b/docs/file-layout.md
@@ -220,6 +220,13 @@ the root-side work. `omarchy-provision-owner` makes the same call (with
 `OMARCHY_SETUP_CONTEXT=provision-owner`) when it creates the user during
 deferred first-boot provisioning.
 
+Keyboard layout: the ISO's `configure_keyboard` and `omarchy-provision-owner`'s
+`apply_keyboard` persist the picked layout as both a console `KEYMAP` and the
+XKB variables in `/etc/vconsole.conf` — Hyprland's package-owned default input
+and the SDDM greeter resolve their layout from `XKBLAYOUT` / `XKBVARIANT` there
+(via `default/hypr/keyboard.lua`), so a password typed under the chosen layout
+at install time stays typeable at the login prompt.
+
 ## Migrations (`omarchy-migrate`)
 
 See [`migrations.md`](../agents/skills/migrations.md) for the full migration model, authoring

--- a/install/provisioning/setup-form.sh
+++ b/install/provisioning/setup-form.sh
@@ -88,10 +88,15 @@ Ukrainian|ua'
 # systemd does convert need no entry here; omarchy_keyboard_xkb only answers
 # for the gaps.
 #
-# azerty is the French AZERTY console keymap (offered as Azerbaijani for
-# historical reasons), so it maps to the XKB layout that reproduces the bytes
-# typed at install time, not to the country the label names.
-OMARCHY_KEYBOARD_XKB_GAPS=$'azerty|fr|\nbg-cp1251|bg|\ncolemak|us|colemak\ncz|cz|\nde_CH-latin1|ch|\nkyrgyz|kg|\nno-latin1|no|\npl|pl|\nua|ua|'
+# The variants matter: a blank variant selects XKB's default, which is not
+# always what the console keymap types. bg-cp1251 is the phonetic Bulgarian
+# map (XKB's default is BDS) and cz is QWERTY (XKB's default is QWERTZ), so
+# blank variants would silently move the very keys a setup-typed password
+# depends on. azerty is the French AZERTY console keymap (offered as
+# Azerbaijani for historical reasons), so it maps to the XKB layout that
+# reproduces the bytes typed at install time, not to the country the label
+# names.
+OMARCHY_KEYBOARD_XKB_GAPS=$'azerty|fr|\nbg-cp1251|bg|phonetic\ncolemak|us|colemak\ncz|cz|qwerty\nde_CH-latin1|ch|\nkyrgyz|kg|\nno-latin1|no|\npl|pl|\nua|ua|'
 
 # The XKB layout and variant a console keymap must be paired with when systemd
 # itself cannot derive them. Prints "layout variant" (variant possibly empty),

--- a/install/provisioning/setup-form.sh
+++ b/install/provisioning/setup-form.sh
@@ -78,6 +78,38 @@ Tajik|tj_alt-UTF8
 Turkish|trq
 Ukrainian|ua'
 
+# Console keymaps systemd's kbd-model-map has no conversion row for. For these,
+# systemd-firstboot --keymap and localectl set-keymap persist KEYMAP alone, and
+# the XKB variables the user session (default/hypr/input.lua) and the SDDM
+# greeter (default/sddm/hyprland.lua) read — XKBLAYOUT and XKBVARIANT — would
+# never land in /etc/vconsole.conf, leaving both on Hyprland's built-in "us"
+# default with a password the layout it was typed under can no longer produce.
+# keymap|xkb-layout|xkb-variant (the variant field may be empty). The layouts
+# systemd does convert need no entry here; omarchy_keyboard_xkb only answers
+# for the gaps.
+#
+# azerty is the French AZERTY console keymap (offered as Azerbaijani for
+# historical reasons), so it maps to the XKB layout that reproduces the bytes
+# typed at install time, not to the country the label names.
+OMARCHY_KEYBOARD_XKB_GAPS=$'azerty|fr|\nbg-cp1251|bg|\ncolemak|us|colemak\ncz|cz|\nde_CH-latin1|ch|\nkyrgyz|kg|\nno-latin1|no|\npl|pl|\nua|ua|'
+
+# The XKB layout and variant a console keymap must be paired with when systemd
+# itself cannot derive them. Prints "layout variant" (variant possibly empty),
+# or nothing when the keymap is not one of the gaps.
+omarchy_keyboard_xkb() {
+  local row
+  while IFS= read -r row; do
+    [[ -n $row ]] || continue
+    [[ ${row%%|*} == "$1" ]] || continue
+    row=${row#*|}
+    printf '%s %s\n' "${row%%|*}" "${row#*|}"
+    return 0
+  done < <(printf '%s\n' "$OMARCHY_KEYBOARD_XKB_GAPS")
+  # A miss must not read as a failure: callers run under `set -e`, where the
+  # loop's terminating `read` status would otherwise abort the assignment.
+  return 0
+}
+
 OMARCHY_USERNAME_PATTERN='^[a-z_][a-z0-9_-]*[$]?$'
 OMARCHY_RESERVED_USERNAMES='^(root|bin|daemon|mail|ftp|http|nobody|dbus|systemd-coredump|systemd-network|systemd-oom|systemd-journal-remote|systemd-resolve|systemd-timesync|tss|uuidd|alpm|git|avahi|cups|cups-browsed|lp|_talkd|polkitd|rtkit|qemu|brltty|gluster|rpc|libvirt-qemu|pcscd|nvidia-persistenced|sddm)$'
 OMARCHY_HOSTNAME_PATTERN='^[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?$'

--- a/migrations/1789183087.sh
+++ b/migrations/1789183087.sh
@@ -12,6 +12,7 @@ echo "Expose the XKB keyboard layout in /etc/vconsole.conf when the console keym
 
 vconsole="${OMARCHY_VCONSOLE_CONF:-/etc/vconsole.conf}"
 kbd_map="${OMARCHY_KBD_MODEL_MAP:-/usr/share/systemd/kbd-model-map}"
+hooks_conf="${OMARCHY_HOOKS_CONF:-/etc/mkinitcpio.conf.d/omarchy_hooks.conf}"
 
 [[ -f $vconsole ]] || exit 0
 
@@ -40,12 +41,14 @@ layout=""
 variant=""
 
 # systemd's own conversion table, where it knows the keymap. Its columns are
-# tab-separated with deliberate empty padding: the layout sits in field 4 and
-# the variant in field 7 (`-` when there is none). Keep the first entry of
+# separated by runs of tabs used for alignment, so split on tab runs and read
+# the logical columns: layout in field 2, variant in field 4 (`-` when there
+# is none). Fixed positions would hand back alignment padding or the model —
+# is-latin1's row would surface as pc105. Keep the first entry of
 # comma-separated lists: the session and greeter prepend "us" to non-Latin
 # layouts themselves.
 if [[ -f $kbd_map ]]; then
-  map_row=$(awk -F'\t' -v key="$keymap" '$1 == key { print $4 "\t" $7; exit }' "$kbd_map") || map_row=""
+  map_row=$(awk -F'\t+' -v key="$keymap" '$1 == key { print $2 "\t" $4; exit }' "$kbd_map") || map_row=""
   if [[ -n $map_row ]]; then
     layout=${map_row%%$'\t'*}
     variant=${map_row#*$'\t'}
@@ -69,7 +72,36 @@ fi
 
 [[ -n $layout ]] || exit 0
 
-printf 'XKBLAYOUT=%s\n' "$layout" | sudo tee -a "$vconsole" >/dev/null
-if [[ -n $variant ]]; then
-  printf 'XKBVARIANT=%s\n' "$variant" | sudo tee -a "$vconsole" >/dev/null
+# A non-Latin layout must not reach the initramfs: bundling vconsole.conf
+# makes Plymouth apply the layout at the LUKS prompt, and a passphrase is
+# Latin. migrations/1784476564.sh removed exactly this bundling, but it no-ops
+# when vconsole.conf carries no XKBLAYOUT — the shape every install this
+# migration repairs is in — so its repair may still be pending here. Remove
+# the bundling and rebuild before the layout below lands, or the next UKI
+# rebuild would reintroduce the lockout that migration exists to prevent.
+# Ordered before the write, so a cancelled sudo leaves the migration pending
+# with nothing applied rather than marked complete mid-repair.
+if [[ $layout =~ ^(af|am|ara|bd|bg|by|et|ge|gr|il|in|iq|ir|kg|kh|kz|la|lk|mk|mm|mn|mv|np|rs|ru|sy|th|tj|ua)$ ]] &&
+  [[ -f $hooks_conf ]] && grep -Eq '^#?FILES\+=\(/etc/vconsole.conf\)$' "$hooks_conf"; then
+  # Disable the line first, because mkinitcpio sources this file during the
+  # rebuild itself. Only a successful rebuild drops it: limine-mkinitcpio
+  # failing leaves the line disabled, so the migration exits non-zero and the
+  # retry's guard still matches and rebuilds, instead of finding the line gone
+  # and completing while the old UKI still bundles the unsafe vconsole.conf.
+  sudo sed -i 's|^FILES+=(/etc/vconsole.conf)$|#FILES+=(/etc/vconsole.conf)|' "$hooks_conf"
+  if omarchy-cmd-present limine-mkinitcpio; then
+    if sudo limine-mkinitcpio; then
+      sudo sed -i '\|^#FILES+=(/etc/vconsole.conf)$|d' "$hooks_conf"
+    else
+      exit 1
+    fi
+  fi
 fi
+
+# One write, so a failure (a cancelled sudo prompt, say) leaves nothing
+# half-applied for a retry's XKBLAYOUT guard to treat as complete.
+payload="XKBLAYOUT=$layout"
+if [[ -n $variant ]]; then
+  payload+=$'\nXKBVARIANT='"$variant"
+fi
+printf '%s\n' "$payload" | sudo tee -a "$vconsole" >/dev/null

--- a/migrations/1789183087.sh
+++ b/migrations/1789183087.sh
@@ -1,0 +1,75 @@
+echo "Expose the XKB keyboard layout in /etc/vconsole.conf when the console keymap left it out"
+
+# The installer persists the chosen console keymap with systemd-firstboot or
+# localectl, and systemd derives XKBLAYOUT/XKBVARIANT from its kbd-model-map.
+# Keymaps with no conversion row there (Polish, Czech, Ukrainian, Colemak, ...)
+# got KEYMAP only. Both the user session (default/hypr/input.lua) and the SDDM
+# greeter (default/sddm/hyprland.lua) resolve their layout from the XKB
+# variables, so those installs fell back to "us" and a password typed under the
+# chosen layout during setup could not be reproduced at login (#9442). Fill the
+# gap from systemd's own table, then from the installer's gap table
+# (install/provisioning/setup-form.sh) for the keymaps the table has no row for.
+
+vconsole="${OMARCHY_VCONSOLE_CONF:-/etc/vconsole.conf}"
+kbd_map="${OMARCHY_KBD_MODEL_MAP:-/usr/share/systemd/kbd-model-map}"
+
+[[ -f $vconsole ]] || exit 0
+
+vconsole_value() {
+  awk -F= -v key="$1" '
+    $1 == key {
+      value = $2
+      sub(/^[[:space:]]*/, "", value)
+      sub(/[[:space:]]*$/, "", value)
+      gsub(/^"/, "", value)
+      gsub(/"$/, "", value)
+      print value
+      exit
+    }
+  ' "$vconsole"
+}
+
+# Idempotency: a vconsole.conf that already carries the layout (or no keymap to
+# derive one from) needs nothing — including reruns and other users on this
+# machine, who each run this migration.
+[[ -z $(vconsole_value XKBLAYOUT) ]] || exit 0
+keymap=$(vconsole_value KEYMAP)
+[[ -n $keymap ]] || exit 0
+
+layout=""
+variant=""
+
+# systemd's own conversion table, where it knows the keymap. Its columns are
+# tab-separated with deliberate empty padding: the layout sits in field 4 and
+# the variant in field 7 (`-` when there is none). Keep the first entry of
+# comma-separated lists: the session and greeter prepend "us" to non-Latin
+# layouts themselves.
+if [[ -f $kbd_map ]]; then
+  map_row=$(awk -F'\t' -v key="$keymap" '$1 == key { print $4 "\t" $7; exit }' "$kbd_map") || map_row=""
+  if [[ -n $map_row ]]; then
+    layout=${map_row%%$'\t'*}
+    variant=${map_row#*$'\t'}
+    layout=${layout%%,*}
+    variant=${variant%%,*}
+    if [[ $variant == "-" ]]; then
+      variant=""
+    fi
+  fi
+fi
+
+# The keymaps kbd-model-map has no row for, from the installer's gap table.
+if [[ -z $layout && -f $OMARCHY_PATH/install/provisioning/setup-form.sh ]]; then
+  source "$OMARCHY_PATH/install/provisioning/setup-form.sh"
+  gap=$(omarchy_keyboard_xkb "$keymap")
+  if [[ -n $gap ]]; then
+    layout=${gap%% *}
+    variant=${gap#* }
+  fi
+fi
+
+[[ -n $layout ]] || exit 0
+
+printf 'XKBLAYOUT=%s\n' "$layout" | sudo tee -a "$vconsole" >/dev/null
+if [[ -n $variant ]]; then
+  printf 'XKBVARIANT=%s\n' "$variant" | sudo tee -a "$vconsole" >/dev/null
+fi

--- a/test/shell.d/hyprland-keyboard-layout-test.sh
+++ b/test/shell.d/hyprland-keyboard-layout-test.sh
@@ -4,10 +4,10 @@ source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
 
 require_command lua
 
-resolved_input() {
-  OMARCHY_PATH="$ROOT" OMARCHY_VCONSOLE="${1-}" lua <<'LUA'
-package.path = os.getenv("OMARCHY_PATH") .. "/?.lua;" .. package.path
-
+# The session and the greeter are separate Hyprland instances that must resolve
+# the same layout, so both are driven through the same stubbed vconsole.conf.
+lua_stub() {
+  cat <<'LUA'
 local vconsole = os.getenv("OMARCHY_VCONSOLE")
 local real_open = io.open
 
@@ -34,25 +34,44 @@ hl = {
 }
 
 o = { window = function() end }
-
-require("default.hypr.input")
 LUA
 }
 
-assert_input() {
-  local description="$1"
-  local expected="$2"
+resolved_input() {
+  OMARCHY_PATH="$ROOT" OMARCHY_VCONSOLE="${1-}" lua -e "$(lua_stub)" \
+    -e 'package.path = os.getenv("OMARCHY_PATH") .. "/?.lua;" .. package.path' \
+    -e 'require("default.hypr.input")'
+}
+
+# Loaded the way SDDM loads it: by path, with no module path set up for it.
+resolved_greeter() {
+  OMARCHY_PATH="$ROOT" OMARCHY_VCONSOLE="${1-}" lua -e "$(lua_stub)" \
+    -e 'dofile(os.getenv("OMARCHY_PATH") .. "/default/sddm/hyprland.lua")'
+}
+
+assert_resolved() {
+  local resolver="$1"
+  local description="$2"
+  local expected="$3"
   local actual
 
-  if (( $# > 2 )); then
-    actual=$(resolved_input "$3")
+  if (( $# > 3 )); then
+    actual=$("$resolver" "$4")
   else
-    actual=$(resolved_input)
+    actual=$("$resolver")
   fi
 
   [[ $actual == "$expected" ]] ||
     fail "$description" "expected: $expected"$'\n'"actual:   $actual"
   pass "$description"
+}
+
+assert_input() {
+  assert_resolved resolved_input "$@"
+}
+
+assert_greeter() {
+  assert_resolved resolved_greeter "$@"
 }
 
 base_options="compose:caps,shift:both_capslock_cancel"
@@ -73,11 +92,22 @@ XKBVARIANT=phonetic
 assert_input "non-latin layout in front gains us even when us trails" "[us,il,us] [,] [$toggle_options]" 'XKBLAYOUT=il,us
 '
 
+# A greeter left on Hyprland's built-in "us" default makes a password set under
+# any other layout untypeable at the login prompt.
+assert_greeter "greeter falls back to us without vconsole.conf" "[us] [] [$base_options]"
+assert_greeter "greeter follows the system layout" "[be] [] [$base_options]" 'XKBLAYOUT=be
+'
+assert_greeter "greeter keeps the variant" "[de] [nodeadkeys] [$base_options]" 'XKBLAYOUT=de
+XKBVARIANT=nodeadkeys
+'
+assert_greeter "greeter keeps a latin layout reachable for passwords" "[us,ru] [,] [$toggle_options]" 'XKBLAYOUT=ru
+'
+
 hooks_conf="$ROOT/etc/mkinitcpio.conf.d/omarchy_hooks.conf"
-input_lua="$ROOT/default/hypr/input.lua"
+keyboard_lua="$ROOT/default/hypr/keyboard.lua"
 
 hooks_layouts=$(awk -F')' '/\) ;;$/ { gsub(/[[:space:]|]+/, "\n", $1); print $1 }' "$hooks_conf" | grep '^[a-z]\+$' | sort)
-lua_layouts=$(sed -n '/^local non_latin_layouts =/,+1p' "$input_lua" | grep -o '"[^"]*"' | tr -d '"' | tr ' ' '\n' | grep '^[a-z]\+$' | sort)
+lua_layouts=$(sed -n '/^local non_latin_layouts =/,+1p' "$keyboard_lua" | grep -o '"[^"]*"' | tr -d '"' | tr ' ' '\n' | grep '^[a-z]\+$' | sort)
 
 [[ -n $hooks_layouts ]] || fail "non-latin layout list is readable from omarchy_hooks.conf"
 [[ $hooks_layouts == "$lua_layouts" ]] ||

--- a/test/shell.d/keyboard-xkb-migration-test.sh
+++ b/test/shell.d/keyboard-xkb-migration-test.sh
@@ -21,15 +21,26 @@ stub_bin="$TMPDIR/bin"
 mkdir -p "$stub_bin"
 cat >"$stub_bin/sudo" <<'STUB'
 #!/bin/bash
+[[ ${SUDO_FAIL:-0} == 1 ]] && exit 1
 exec "$@"
 STUB
-chmod +x "$stub_bin/sudo"
+cat >"$stub_bin/limine-mkinitcpio" <<'STUB'
+#!/bin/bash
+[[ ${LIMINE_FAIL:-0} == 1 ]] && exit 1
+touch "$LIMINE_REBUILD_MARKER"
+STUB
+chmod +x "$stub_bin/sudo" "$stub_bin/limine-mkinitcpio"
+LIMINE_REBUILD_MARKER="$TMPDIR/rebuild-called"
+export LIMINE_REBUILD_MARKER
 
 # omarchy-migrate runs each migration with `bash -euo pipefail` and stops the
-# whole chain on a non-zero exit, so match that invocation exactly.
+# whole chain on a non-zero exit, so match that invocation exactly. The hooks
+# conf defaults to an absent fixture: cases that don't exercise the initramfs
+# repair must not depend on the machine's real one.
 run_migration() {
-  local vconsole="$1"
+  local vconsole="$1" hooks="${2:-$TMPDIR/absent-hooks.conf}"
   PATH="$stub_bin:$PATH" OMARCHY_PATH="$ROOT" OMARCHY_VCONSOLE_CONF="$vconsole" \
+    OMARCHY_HOOKS_CONF="$hooks" \
     bash -euo pipefail "$migration" >/dev/null ||
     fail "migration exits clean for $(basename "$vconsole")"
 }
@@ -65,6 +76,17 @@ if [[ -f /usr/share/systemd/kbd-model-map ]]; then
     fail "migration derives the layout from kbd-model-map" "$(cat "$vconsole")"
   pass "migration derives the layout from kbd-model-map"
 
+  # kbd-model-map pads its columns with a variable number of tabs; is-latin1's
+  # row carries one tab fewer, which would hand the model (pc105) back as the
+  # layout under a fixed-position read.
+  vconsole="$TMPDIR/icelandic.conf"
+  printf 'KEYMAP=is-latin1\n' >"$vconsole"
+  run_migration "$vconsole"
+  [[ $(value XKBLAYOUT "$vconsole") == "is" ]] ||
+    fail "migration parses padded rows by logical column" "$(cat "$vconsole")"
+  grep -q '^XKBVARIANT=' "$vconsole" && fail "migration writes no variant for is-latin1"
+  pass "migration writes no variant for is-latin1"
+
   # A comma-separated conversion keeps only its first entry: the session and
   # greeter prepend "us" to non-Latin layouts themselves.
   vconsole="$TMPDIR/russian.conf"
@@ -76,6 +98,87 @@ if [[ -f /usr/share/systemd/kbd-model-map ]]; then
 else
   pass "no kbd-model-map on this machine; skipping the conversion-table cases"
 fi
+
+# Gap-table variants: a blank variant would select XKB's default (BDS for
+# Bulgarian, QWERTZ for Czech) and silently move the keys a setup-typed
+# password depends on.
+vconsole="$TMPDIR/bulgarian.conf"
+printf 'KEYMAP=bg-cp1251\n' >"$vconsole"
+run_migration "$vconsole"
+[[ $(value XKBLAYOUT "$vconsole") == "bg" && $(value XKBVARIANT "$vconsole") == "phonetic" ]] ||
+  fail "migration exposes the phonetic Bulgarian variant" "$(cat "$vconsole")"
+pass "migration exposes the phonetic Bulgarian variant"
+
+vconsole="$TMPDIR/czech.conf"
+printf 'KEYMAP=cz\n' >"$vconsole"
+run_migration "$vconsole"
+[[ $(value XKBLAYOUT "$vconsole") == "cz" && $(value XKBVARIANT "$vconsole") == "qwerty" ]] ||
+  fail "migration exposes the qwerty Czech variant" "$(cat "$vconsole")"
+pass "migration exposes the qwerty Czech variant"
+
+# The non-Latin initramfs repair: 1784476564.sh no-oped for installs whose
+# vconsole.conf carried no XKBLAYOUT, so its bundling may still be pending.
+# Exposing bg here must remove it and rebuild, or the next UKI rebuild locks
+# the LUKS passphrase behind a Cyrillic console map.
+hooks="$TMPDIR/omarchy_hooks.conf"
+vconsole="$TMPDIR/bulgarian-stale-hooks.conf"
+printf 'KEYMAP=bg-cp1251\n' >"$vconsole"
+printf 'HOOKS=(base udev plymouth keyboard)\nFILES+=(/etc/vconsole.conf)\n' >"$hooks"
+rm -f "$LIMINE_REBUILD_MARKER"
+PATH="$stub_bin:$PATH" SUDO_FAIL=1 OMARCHY_PATH="$ROOT" OMARCHY_VCONSOLE_CONF="$vconsole" \
+  OMARCHY_HOOKS_CONF="$hooks" bash -euo pipefail "$migration" >/dev/null 2>&1 &&
+  fail "migration fails when the privileged write fails"
+grep -q 'FILES+=(/etc/vconsole.conf)' "$hooks" || fail "a failed write leaves the hooks file untouched"
+grep -q '^XKBLAYOUT=' "$vconsole" && fail "a failed write leaves the vconsole untouched"
+pass "a failed write leaves the migration pending with nothing applied"
+
+run_migration "$vconsole" "$hooks"
+grep -q 'FILES+=(/etc/vconsole.conf)' "$hooks" && fail "migration removes the stale initramfs bundling" "$(cat "$hooks")"
+pass "migration removes the stale initramfs bundling"
+[[ -e $LIMINE_REBUILD_MARKER ]] || fail "migration rebuilds the initramfs after removing the bundling"
+pass "migration rebuilds the initramfs after removing the bundling"
+[[ $(value XKBLAYOUT "$vconsole") == "bg" && $(value XKBVARIANT "$vconsole") == "phonetic" ]] ||
+  fail "migration still exposes the layout after the repair" "$(cat "$vconsole")"
+pass "migration still exposes the layout after the repair"
+grep -q '^HOOKS=(base udev plymouth keyboard)' "$hooks" || fail "migration keeps the rest of the hooks file" "$(cat "$hooks")"
+pass "migration keeps the rest of the hooks file"
+
+# A failed initramfs rebuild must keep the repair pending: the bundling is
+# disabled in place, so the retry still matches the guard and rebuilds
+# instead of completing while the old UKI bundles the unsafe vconsole.conf.
+hooks="$TMPDIR/omarchy_hooks-retry.conf"
+vconsole="$TMPDIR/bulgarian-retry.conf"
+printf 'KEYMAP=bg-cp1251\n' >"$vconsole"
+printf 'HOOKS=(base udev plymouth keyboard)\nFILES+=(/etc/vconsole.conf)\n' >"$hooks"
+rm -f "$LIMINE_REBUILD_MARKER"
+PATH="$stub_bin:$PATH" LIMINE_FAIL=1 OMARCHY_PATH="$ROOT" OMARCHY_VCONSOLE_CONF="$vconsole" \
+  OMARCHY_HOOKS_CONF="$hooks" bash -euo pipefail "$migration" >/dev/null 2>&1 &&
+  fail "migration fails when the initramfs rebuild fails"
+grep -q '^#FILES+=(/etc/vconsole.conf)$' "$hooks" || fail "a failed rebuild leaves the bundling disabled" "$(cat "$hooks")"
+grep -qx 'FILES+=(/etc/vconsole.conf)' "$hooks" && fail "a failed rebuild leaves no active bundling" "$(cat "$hooks")"
+grep -q '^XKBLAYOUT=' "$vconsole" && fail "a failed rebuild leaves the vconsole untouched"
+pass "a failed rebuild disables the bundling and stays pending"
+
+run_migration "$vconsole" "$hooks"
+[[ -e $LIMINE_REBUILD_MARKER ]] || fail "the retry rebuilds the initramfs after a failed rebuild"
+pass "the retry rebuilds the initramfs after a failed rebuild"
+grep -q 'FILES+=(/etc/vconsole.conf)' "$hooks" && fail "the retry drops the disabled bundling" "$(cat "$hooks")"
+pass "the retry drops the disabled bundling"
+[[ $(value XKBLAYOUT "$vconsole") == "bg" && $(value XKBVARIANT "$vconsole") == "phonetic" ]] ||
+  fail "the retry exposes the layout" "$(cat "$vconsole")"
+pass "the retry exposes the layout"
+
+# An already-repaired (or never-stale) hooks file is left alone.
+hooks="$TMPDIR/omarchy_hooks-conditional.conf"
+vconsole="$TMPDIR/ukrainian-conditional.conf"
+printf 'KEYMAP=ua\n' >"$vconsole"
+printf 'HOOKS=(base)\n    *) FILES+=(/etc/vconsole.conf) ;;\n' >"$hooks"
+rm -f "$LIMINE_REBUILD_MARKER"
+run_migration "$vconsole" "$hooks"
+[[ $(value XKBLAYOUT "$vconsole") == "ua" ]] || fail "migration exposes the ukrainian layout" "$(cat "$vconsole")"
+grep -q 'FILES+=(/etc/vconsole.conf)' "$hooks" || fail "migration leaves a conditional hooks file alone"
+[[ -e $LIMINE_REBUILD_MARKER ]] && fail "migration rebuilds nothing when the hooks file is fine"
+pass "migration leaves a conditional hooks file alone"
 
 # A layout already present (ISO-written, or another user's earlier run) must
 # leave the file byte-identical, and rerunning a fixed file stays clean.

--- a/test/shell.d/keyboard-xkb-migration-test.sh
+++ b/test/shell.d/keyboard-xkb-migration-test.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+#
+# The XKB-exposure migration repairs installs whose /etc/vconsole.conf carries
+# only KEYMAP — the shape systemd-firstboot leaves behind for console keymaps
+# its kbd-model-map has no conversion row for. Without XKBLAYOUT/XKBVARIANT
+# the session and the SDDM greeter resolve "us" and a password typed under the
+# chosen layout during setup no longer works.
+
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+migration=$(grep -rl 'Expose the XKB keyboard layout' "$ROOT/migrations" | head -n 1 || true)
+[[ -n $migration ]] || fail "XKB exposure migration exists"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# The migration edits /etc/vconsole.conf through sudo. Stub sudo so the write
+# lands on the fixture, and point $OMARCHY_PATH at the checkout so the gap
+# table resolves.
+stub_bin="$TMPDIR/bin"
+mkdir -p "$stub_bin"
+cat >"$stub_bin/sudo" <<'STUB'
+#!/bin/bash
+exec "$@"
+STUB
+chmod +x "$stub_bin/sudo"
+
+# omarchy-migrate runs each migration with `bash -euo pipefail` and stops the
+# whole chain on a non-zero exit, so match that invocation exactly.
+run_migration() {
+  local vconsole="$1"
+  PATH="$stub_bin:$PATH" OMARCHY_PATH="$ROOT" OMARCHY_VCONSOLE_CONF="$vconsole" \
+    bash -euo pipefail "$migration" >/dev/null ||
+    fail "migration exits clean for $(basename "$vconsole")"
+}
+
+value() {
+  awk -F= -v key="$1" '$1 == key { sub(/^[[:space:]]*/,"",$2); sub(/[[:space:]]*$/,"",$2); print $2; exit }' "$2"
+}
+
+# A gap-table keymap: systemd-firstboot wrote KEYMAP only.
+vconsole="$TMPDIR/polish.conf"
+printf 'KEYMAP=pl\nFONT=default8x16\n' >"$vconsole"
+run_migration "$vconsole"
+[[ $(value XKBLAYOUT "$vconsole") == "pl" ]] || fail "migration exposes the polish layout" "$(cat "$vconsole")"
+grep -q '^XKBVARIANT=' "$vconsole" && fail "migration writes no variant for a variantless keymap"
+pass "migration writes no variant for a variantless keymap"
+[[ $(value KEYMAP "$vconsole") == "pl" ]] || fail "migration keeps the keymap"
+pass "migration keeps the keymap"
+
+# A gap-table keymap with a variant.
+vconsole="$TMPDIR/colemak.conf"
+printf 'KEYMAP=colemak\n' >"$vconsole"
+run_migration "$vconsole"
+[[ $(value XKBLAYOUT "$vconsole") == "us" && $(value XKBVARIANT "$vconsole") == "colemak" ]] ||
+  fail "migration exposes the colemak layout and variant" "$(cat "$vconsole")"
+pass "migration exposes the colemak layout and variant"
+
+# A keymap systemd's own table converts: layout and variant come from there.
+if [[ -f /usr/share/systemd/kbd-model-map ]]; then
+  vconsole="$TMPDIR/dvorak.conf"
+  printf 'KEYMAP=dvorak\n' >"$vconsole"
+  run_migration "$vconsole"
+  [[ $(value XKBLAYOUT "$vconsole") == "us" && $(value XKBVARIANT "$vconsole") == "dvorak" ]] ||
+    fail "migration derives the layout from kbd-model-map" "$(cat "$vconsole")"
+  pass "migration derives the layout from kbd-model-map"
+
+  # A comma-separated conversion keeps only its first entry: the session and
+  # greeter prepend "us" to non-Latin layouts themselves.
+  vconsole="$TMPDIR/russian.conf"
+  printf 'KEYMAP=ru\n' >"$vconsole"
+  run_migration "$vconsole"
+  [[ $(value XKBLAYOUT "$vconsole") == "ru" ]] ||
+    fail "migration keeps the first entry of a converted list" "$(cat "$vconsole")"
+  pass "migration keeps the first entry of a converted list"
+else
+  pass "no kbd-model-map on this machine; skipping the conversion-table cases"
+fi
+
+# A layout already present (ISO-written, or another user's earlier run) must
+# leave the file byte-identical, and rerunning a fixed file stays clean.
+vconsole="$TMPDIR/already.conf"
+printf 'KEYMAP=de\nXKBLAYOUT=de\nFONT=default8x16\n' >"$vconsole"
+cp "$vconsole" "$TMPDIR/already.orig"
+run_migration "$vconsole"
+run_migration "$vconsole"
+cmp -s "$vconsole" "$TMPDIR/already.orig" || fail "migration leaves an exposed layout alone" "$(cat "$vconsole")"
+pass "migration leaves an exposed layout alone"
+
+# No keymap to derive a layout from: leave the file alone.
+vconsole="$TMPDIR/nokeymap.conf"
+printf 'FONT=default8x16\n' >"$vconsole"
+run_migration "$vconsole"
+grep -q '^XKBLAYOUT=' "$vconsole" && fail "migration skips a keymap-less vconsole.conf"
+pass "migration skips a keymap-less vconsole.conf"
+
+# Missing file entirely: clean exit, nothing created.
+vconsole="$TMPDIR/absent.conf"
+run_migration "$vconsole"
+[[ -e $vconsole ]] && fail "migration no-ops without vconsole.conf"
+pass "migration no-ops without vconsole.conf"

--- a/test/shell.d/provision-owner-keyboard-test.sh
+++ b/test/shell.d/provision-owner-keyboard-test.sh
@@ -1,0 +1,174 @@
+#!/bin/bash
+#
+# First-boot keyboard step: whatever layout the owner picked to type their
+# password with must still be the layout the login screen resolves. The
+# session and the SDDM greeter both read XKBLAYOUT/XKBVARIANT out of
+# /etc/vconsole.conf, so the step has to guarantee those variables even for
+# the console keymaps systemd's kbd-model-map has no conversion row for.
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# The gap table and its lookup live in the shared setup form, so the installer
+# and this test read the same mapping.
+source "$ROOT/install/provisioning/setup-form.sh"
+
+# The keyboard step's functions, extracted the way the provisioning tests run
+# single pieces of omarchy-provision-owner.
+eval "$(sed -n '/^omarchy_write_xkb_layout() {/,/^}/p' "$ROOT/bin/omarchy-provision-owner")"
+eval "$(sed -n '/^omarchy_expose_xkb_layout() {/,/^}/p' "$ROOT/bin/omarchy-provision-owner")"
+eval "$(sed -n '/^apply_keyboard() {/,/^}/p' "$ROOT/bin/omarchy-provision-owner")"
+
+LOG_FILE="$TMPDIR/log"
+log_step() { printf '%s\n' "$1" >>"$LOG_FILE"; }
+
+assert_equal() {
+  local actual="$1" expected="$2" description="$3"
+
+  [[ $actual == "$expected" ]] ||
+    fail "$description" "expected: $expected"$'\n'"actual:   $actual"
+  pass "$description"
+}
+
+vconsole_value() {
+  awk -F= -v key="$1" '
+    $1 == key {
+      value = $2
+      sub(/^[[:space:]]*/, "", value)
+      sub(/[[:space:]]*$/, "", value)
+      print value
+      exit
+    }
+  ' "$2"
+}
+
+# ── omarchy_keyboard_xkb ─────────────────────────────────────────────────────
+
+assert_equal "$(omarchy_keyboard_xkb azerty)" "fr " "the azerty gap maps to the layout typed at install time"
+assert_equal "$(omarchy_keyboard_xkb colemak)" "us colemak" "the colemak gap keeps the ISO's layout and variant"
+assert_equal "$(omarchy_keyboard_xkb pl)" "pl " "the polish gap maps to the polish layout"
+assert_equal "$(omarchy_keyboard_xkb ua)" "ua " "the ukrainian gap maps to the ukrainian layout"
+assert_equal "$(omarchy_keyboard_xkb fr)" "" "a keymap systemd converts is not a gap"
+assert_equal "$(omarchy_keyboard_xkb nosuchkeymap)" "" "an unknown keymap is not a gap"
+
+# Every layout the form offers must resolve somewhere: either systemd's own
+# conversion table knows the keymap, or the gap table does. A new row in the
+# picker with neither would silently log the machine into a "us" login screen.
+if [[ -f /usr/share/systemd/kbd-model-map ]]; then
+  while IFS='|' read -r _ keymap; do
+    [[ -n $keymap ]] || continue
+    if cut -f1 /usr/share/systemd/kbd-model-map | grep -qix "$keymap"; then
+      continue
+    fi
+    [[ -n $(omarchy_keyboard_xkb "$keymap") ]] ||
+      fail "offered keymap $keymap resolves to an XKB layout" "neither kbd-model-map nor OMARCHY_KEYBOARD_XKB_GAPS knows $keymap"
+  done < <(printf '%s\n' "$OMARCHY_KEYBOARD_LAYOUTS")
+  pass "every offered keymap resolves to an XKB layout"
+else
+  pass "no kbd-model-map on this machine; skipping the conversion-table cross-check"
+fi
+
+# ── omarchy_write_xkb_layout ─────────────────────────────────────────────────
+
+file="$TMPDIR/vconsole-upsert"
+printf '# Written by systemd-localed(8)\nKEYMAP=pl\nFONT=default8x16\n' >"$file"
+omarchy_write_xkb_layout "$file" "pl" ""
+assert_equal "$(vconsole_value XKBLAYOUT "$file")" "pl" "an absent XKB layout is appended"
+[[ $(grep -c '^XKBVARIANT=' "$file") == 0 ]] || fail "an empty variant writes no XKBVARIANT"
+assert_equal "$(vconsole_value KEYMAP "$file")" "pl" "the upsert leaves the keymap alone"
+assert_equal "$(vconsole_value FONT "$file")" "default8x16" "the upsert leaves the font alone"
+head -1 "$file" | grep -q '^# Written' || fail "the upsert leaves comments alone"
+pass "the upsert preserves the rest of vconsole.conf"
+
+omarchy_write_xkb_layout "$file" "be" ""
+assert_equal "$(vconsole_value XKBLAYOUT "$file")" "be" "a present XKB layout is replaced in place"
+
+printf 'XKBVARIANT=old\n' >>"$file"
+omarchy_write_xkb_layout "$file" "us" "colemak"
+assert_equal "$(vconsole_value XKBVARIANT "$file")" "colemak" "a present variant is replaced in place"
+assert_equal "$(vconsole_value XKBLAYOUT "$file")" "us" "the layout rides along with a variant write"
+
+# ── omarchy_expose_xkb_layout ────────────────────────────────────────────────
+
+file="$TMPDIR/vconsole-gap"
+printf 'KEYMAP=pl\nFONT=default8x16\n' >"$file"
+omarchy_expose_xkb_layout "$file" "pl"
+assert_equal "$(vconsole_value XKBLAYOUT "$file")" "pl" "a keymap-only vconsole.conf gains its layout"
+grep -q '^XKBVARIANT=' "$file" && fail "a variantless keymap gains no variant line"
+pass "a variantless keymap gains no variant line"
+
+file="$TMPDIR/vconsole-variant-gap"
+printf 'KEYMAP=colemak\n' >"$file"
+omarchy_expose_xkb_layout "$file" "colemak"
+assert_equal "$(vconsole_value XKBLAYOUT "$file")" "us" "the colemak gap exposes its layout"
+assert_equal "$(vconsole_value XKBVARIANT "$file")" "colemak" "the colemak gap exposes its variant"
+
+file="$TMPDIR/vconsole-already"
+printf 'KEYMAP=de\nXKBLAYOUT=de\n' >"$file"
+omarchy_expose_xkb_layout "$file" "pl"
+assert_equal "$(vconsole_value XKBLAYOUT "$file")" "de" "a vconsole.conf that already carries a layout is untouched"
+
+file="$TMPDIR/vconsole-nongap"
+printf 'KEYMAP=fr\n' >"$file"
+omarchy_expose_xkb_layout "$file" "fr"
+grep -q '^XKBLAYOUT=' "$file" && fail "a converted keymap is left to systemd"
+pass "a converted keymap is left to systemd"
+
+grep -q 'no XKB conversion' "$LOG_FILE" || fail "the gap fill is logged"
+pass "the gap fill is logged"
+
+# ── apply_keyboard wiring ────────────────────────────────────────────────────
+#
+# The real functions are replaced with a recorder, so the collaborators can be
+# driven without root and without touching this machine's /etc/vconsole.conf.
+
+STUB_BIN="$TMPDIR/bin"
+mkdir -p "$STUB_BIN"
+cat >"$STUB_BIN/systemd-firstboot" <<'STUB'
+#!/bin/bash
+[[ ${STUB_FIRSTBOOT:-ok} == ok ]]
+STUB
+cat >"$STUB_BIN/localectl" <<'STUB'
+#!/bin/bash
+if [[ $1 == "--no-pager" ]]; then
+  printf '%s\n' ${STUB_KEYMAPS:-}
+  exit 0
+fi
+[[ ${STUB_LOCALECTL:-} == ok ]]
+STUB
+cat >"$STUB_BIN/loadkeys" <<'STUB'
+#!/bin/bash
+touch "$STUB_LOADKEYS_MARKER"
+STUB
+chmod +x "$STUB_BIN/systemd-firstboot" "$STUB_BIN/localectl" "$STUB_BIN/loadkeys"
+export PATH="$STUB_BIN:$PATH"
+export STUB_LOADKEYS_MARKER="$TMPDIR/loadkeys-called"
+
+exposed_args=""
+omarchy_expose_xkb_layout() { exposed_args="$*"; }
+
+run_apply() {
+  exposed_args=""
+  rm -f "$STUB_LOADKEYS_MARKER"
+  apply_keyboard "$1"
+}
+
+STUB_KEYMAPS=pl run_apply pl
+assert_equal "$exposed_args" "/etc/vconsole.conf pl" "a persisted keymap has its XKB layout exposed"
+
+STUB_KEYMAPS=pl run_apply pl
+[[ -e $STUB_LOADKEYS_MARKER ]] && fail "loadkeys is skipped off the console"
+pass "loadkeys is skipped off the console"
+
+STUB_KEYMAPS=pl STUB_FIRSTBOOT=fail STUB_LOCALECTL=ok run_apply pl
+assert_equal "$exposed_args" "/etc/vconsole.conf pl" "the localectl fallback exposes the layout too"
+
+STUB_KEYMAPS=pl STUB_FIRSTBOOT=fail STUB_LOCALECTL=fail run_apply pl
+assert_equal "$exposed_args" "" "a keymap nothing persisted exposes nothing"
+
+STUB_KEYMAPS=de STUB_FIRSTBOOT=fail STUB_LOCALECTL=fail run_apply pl
+assert_equal "$exposed_args" "" "a keymap localectl does not know exposes nothing"

--- a/test/shell.d/provision-owner-keyboard-test.sh
+++ b/test/shell.d/provision-owner-keyboard-test.sh
@@ -172,3 +172,8 @@ assert_equal "$exposed_args" "" "a keymap nothing persisted exposes nothing"
 
 STUB_KEYMAPS=de STUB_FIRSTBOOT=fail STUB_LOCALECTL=fail run_apply pl
 assert_equal "$exposed_args" "" "a keymap localectl does not know exposes nothing"
+
+omarchy_expose_xkb_layout() { return 1; }
+STUB_KEYMAPS=pl run_apply pl
+grep -q 'could not expose the XKB layout' "$LOG_FILE" || fail "a failed exposure is logged, not fatal"
+pass "a failed exposure is logged, not fatal"


### PR DESCRIPTION
Depends on #9762. Closes #9442

This follows up the SDDM greeter keyboard-layout change for installs whose `vconsole.conf` contains only `KEYMAP`.

- expose missing XKB layout and variant values after initial keyboard setup
- migrate existing KEYMAP-only configurations
- keep migration writes recoverable if privilege escalation is cancelled