### PR TITLE
add flight mode bar widget next 2 bluetooth icon

### DIFF
--- a/bin/omarchy-toggle-flight-mode
+++ b/bin/omarchy-toggle-flight-mode
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# omarchy:summary=Toggle flight mode
+# omarchy:args=[--status]
+# omarchy:examples=omarchy toggle flight-mode
+
+blocked() {
+  local list
+
+  list=$(rfkill list 2>/dev/null) || return 1
+  [[ -n $list ]] || return 1
+  ! grep -q "Soft blocked: no" <<<"$list"
+}
+
+status_json() {
+  local enabled
+
+  if blocked; then
+    enabled=true
+  else
+    enabled=false
+  fi
+
+  jq -cn --argjson enabled "$enabled" '{enabled:$enabled}'
+}
+
+if [[ ${1:-} == "--status" ]]; then
+  status_json
+  exit 0
+fi
+
+if blocked; then
+  rfkill unblock all
+else
+  rfkill block all
+fi
+
+omarchy-shell -q omarchy.flight-mode refresh

--- a/config/omarchy/shell.json
+++ b/config/omarchy/shell.json
@@ -45,6 +45,9 @@
           "id": "omarchy.agents"
         },
         {
+          "id": "omarchy.flight-mode"
+        },
+        {
           "id": "omarchy.bluetooth"
         },
         {

--- a/migrations/1788961483.sh
+++ b/migrations/1788961483.sh
@@ -1,0 +1,5 @@
+echo "Add the flight mode widget to the bar"
+
+# flymode icon sitting just right of the agents widget and left of bluetooth
+
+omarchy-bar put omarchy.flight-mode --after omarchy.agents

--- a/shell/plugins/bar/README.md
+++ b/shell/plugins/bar/README.md
@@ -70,6 +70,7 @@ Example `shell.json` (bar subtree only shown):
 | `omarchy.agents` | AI coding agent limits with pace, today, last week, and all-time model breakdown | left = panel · right = launch agent · middle = next subscription |
 | `omarchy.power` | Battery/AC icon + popup with battery stats, power profiles, and system info | left = popup · right = toggle percentage |
 | `omarchy.bluetooth` | Bluetooth icon + popup with device list, connect/disconnect, battery | left = popup · right = toggle radio |
+| `omarchy.flight-mode` | Flight mode icon — blocks/unblocks all wireless radios via rfkill | left = toggle |
 | `omarchy.monitor` | Brightness and laptop display controls | left = popup |
 
 The `omarchy.indicators` widget loads individual bar indicators from `indicators/`. Omit `items` (or set it to an empty array) to show all indicators in the default order, or set `items` to a subset such as `["Dnd", "Reminder", "NightLight"]`. Set `alwaysShow` to `true` to keep inactive indicators visible instead of revealing them only on hover. Multiple `omarchy.indicators` instances are allowed, so different sections can show different subsets.

--- a/shell/plugins/bar/widgets/FlightMode.manifest.json
+++ b/shell/plugins/bar/widgets/FlightMode.manifest.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": 1,
+  "id": "omarchy.flight-mode",
+  "name": "Flight Mode",
+  "version": "1.0.0",
+  "author": "Omarchy",
+  "description": "Block or unblock all wireless radios",
+  "kinds": [
+    "bar-widget"
+  ],
+  "entryPoints": {
+    "barWidget": "FlightMode.qml"
+  },
+  "barWidget": {
+    "displayName": "Flight Mode",
+    "description": "Block or unblock all wireless radios",
+    "category": "Network",
+    "allowMultiple": false
+  }
+}

--- a/shell/plugins/bar/widgets/FlightMode.qml
+++ b/shell/plugins/bar/widgets/FlightMode.qml
@@ -1,0 +1,72 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs.Ui
+
+BarWidget {
+  id: root
+  moduleName: "omarchy.flight-mode"
+
+  property bool enabled: false
+
+  implicitWidth: button.implicitWidth
+  implicitHeight: button.implicitHeight
+
+  function refresh() {
+    if (!statusProc.running) statusProc.running = true
+  }
+
+  function toggle() {
+    root.bar.run("omarchy-toggle-flight-mode")
+    toggleDebounce.restart()
+  }
+
+  IpcHandler {
+    target: "omarchy.flight-mode"
+
+    function refresh(): void {
+      root.broadcast("refresh")
+    }
+  }
+
+  Process {
+    id: statusProc
+    command: ["omarchy-toggle-flight-mode", "--status"]
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: {
+        try {
+          root.enabled = JSON.parse(text).enabled === true
+        } catch (error) {
+          root.enabled = false
+        }
+      }
+    }
+  }
+
+  Timer {
+    id: toggleDebounce
+    interval: 250
+    onTriggered: root.refresh()
+  }
+
+  Timer {
+    interval: 15000
+    running: true
+    repeat: true
+    triggeredOnStart: true
+    onTriggered: root.refresh()
+  }
+
+  Component.onCompleted: root.refresh()
+
+  BarIconButton {
+    id: button
+    anchors.fill: parent
+    bar: root.bar
+    text: "󰀝"
+    active: root.enabled
+    tooltipText: root.enabled ? "Flight Mode On" : "Flight Mode Off"
+    onPressed: root.toggle()
+  }
+}

--- a/test/shell.d/flight-mode-test.sh
+++ b/test/shell.d/flight-mode-test.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+mkdir -p "$TMPDIR/bin"
+STATE="$TMPDIR/rfkill-blocked"
+SHELL_LOG="$TMPDIR/omarchy-shell-log"
+
+cat >"$TMPDIR/bin/rfkill" <<'SH'
+#!/bin/bash
+
+case "${1:-}" in
+  list)
+    if [[ $(<"$RFKILL_STATE") == "blocked" ]]; then
+      echo "0: wifi: Wireless LAN"
+      echo "	Soft blocked: yes"
+      echo "	Hard blocked: no"
+      echo "1: bluetooth: Bluetooth"
+      echo "	Soft blocked: yes"
+      echo "	Hard blocked: no"
+    else
+      echo "0: wifi: Wireless LAN"
+      echo "	Soft blocked: no"
+      echo "	Hard blocked: no"
+      echo "1: bluetooth: Bluetooth"
+      echo "	Soft blocked: no"
+      echo "	Hard blocked: no"
+    fi
+    ;;
+  block)
+    printf 'blocked' >"$RFKILL_STATE"
+    ;;
+  unblock)
+    printf 'unblocked' >"$RFKILL_STATE"
+    ;;
+esac
+SH
+
+cat >"$TMPDIR/bin/omarchy-shell" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$OMARCHY_SHELL_LOG"
+SH
+
+chmod +x "$TMPDIR/bin/rfkill" "$TMPDIR/bin/omarchy-shell"
+
+flight_mode_cli() {
+  PATH="$TMPDIR/bin:$PATH" \
+  RFKILL_STATE="$STATE" \
+  OMARCHY_SHELL_LOG="$SHELL_LOG" \
+    "$ROOT/bin/omarchy-toggle-flight-mode" "$@"
+}
+
+flight_mode_status() {
+  printf '%s\n' "$1" >"$STATE"
+  flight_mode_cli --status
+}
+
+[[ $(flight_mode_status unblocked | jq -r .enabled) == "false" ]] || fail "flight mode status reports unblocked radios as disabled"
+pass "flight mode status reports unblocked radios as disabled"
+
+[[ $(flight_mode_status blocked | jq -r .enabled) == "true" ]] || fail "flight mode status reports blocked radios as enabled"
+pass "flight mode status reports blocked radios as enabled"
+
+printf 'unblocked' >"$STATE"
+: >"$SHELL_LOG"
+flight_mode_cli >/dev/null
+[[ $(<"$STATE") == "blocked" ]] || fail "flight mode toggle blocks all radios from off"
+pass "flight mode toggle blocks all radios from off"
+
+grep -Fqx -- '-q omarchy.flight-mode refresh' "$SHELL_LOG" || fail "flight mode toggle nudges the bar widget"
+pass "flight mode toggle nudges the bar widget"
+
+flight_mode_cli >/dev/null
+[[ $(<"$STATE") == "unblocked" ]] || fail "flight mode toggle unblocks all radios from on"
+pass "flight mode toggle unblocks all radios from on"


### PR DESCRIPTION
summary -> implemented rfkill based flymode option

smoke tested on quattro by omarchy bar put omarchy.flight-mode --after omarchy.tray & omarchy-toggle-flight-mode & 
./test/cli & flight-mode-test.sh
./test/shell.d/flight-mode-test.sh
./test/shell
I made it cause I needed it badly for my vacations and It works perfectly :)

--------------------------

smoke tetsing photos included (on/off)
<img width="373" height="139" alt="off" src="https://github.com/user-attachments/assets/9eff9bf6-880d-4d00-8be5-525f571dcd0e" />
<img width="384" height="154" alt="on" src="https://github.com/user-attachments/assets/ed254c61-a5d3-4720-b1f2-fad2540aee6a" />