### PR TITLE
Fix stale city suggestions in weather location search

### DIFF
--- a/shell/plugins/panels/weather/Panel.qml
+++ b/shell/plugins/panels/weather/Panel.qml
@@ -208,6 +208,7 @@ Panel {
     savingLocation = false
     savingLocationQueryStarted = false
     locationSuggestions = []
+    geocodePendingQuery = ""
     geocodeDebounce.stop()
     Qt.callLater(function() { if (keyCatcher) keyCatcher.forceActiveFocus() })
   }
@@ -264,15 +265,17 @@ Panel {
   // while a fetch was in flight, the latest query is fetched right after.
   function requestGeocode() {
     var query = locationField.text.trim()
+    geocodePendingQuery = query
     if (query.length < 2) {
       locationSuggestions = []
       return
     }
-    geocodePendingQuery = query
     if (!geocodeProc.running) startGeocode()
   }
 
   function startGeocode() {
+    if (!editingLocation || savingLocation || geocodeProc.running || geocodePendingQuery.length < 2) return
+    geocodeDebounce.stop()
     geocodeActiveQuery = geocodePendingQuery
     geocodeProc.command = ["curl", "-fsS", "--max-time", "5",
       "https://geocoding-api.open-meteo.com/v1/search?name=" + encodeURIComponent(geocodeActiveQuery) + "&count=5&language=en&format=json"]
@@ -421,8 +424,12 @@ Panel {
     stdout: StdioCollector {
       waitForEnd: true
       onStreamFinished: {
-        root.locationSuggestions = root.editingLocation ? Model.parseGeocodingResults(text) : []
-        root.suggestionIndex = 0
+        // The field can change while this request is in flight, including
+        // before the next debounce fires. Only publish matching suggestions.
+        if (root.editingLocation && !root.savingLocation && root.geocodeActiveQuery === locationField.text.trim()) {
+          root.locationSuggestions = Model.parseGeocodingResults(text)
+          root.suggestionIndex = 0
+        }
         if (root.geocodePendingQuery !== root.geocodeActiveQuery) Qt.callLater(root.startGeocode)
       }
     }
@@ -620,7 +627,15 @@ Panel {
               foreground: root.bar.foreground
               font.family: root.bar.fontFamily
 
-              onTextChanged: if (root.editingLocation && !root.savingLocation) geocodeDebounce.restart()
+              onTextChanged: {
+                if (root.editingLocation && !root.savingLocation) {
+                  // Enter during the debounce must not commit the old city.
+                  root.locationSuggestions = []
+                  root.suggestionIndex = 0
+                  root.geocodePendingQuery = locationField.text.trim()
+                  geocodeDebounce.restart()
+                }
+              }
 
               Keys.onPressed: function(event) {
                 if (event.key === Qt.Key_Escape) {

--- a/test/shell.d/weather-test.sh
+++ b/test/shell.d/weather-test.sh
@@ -6,6 +6,7 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
 run_node_test <<'JS'
 const fs = require('fs')
+const vm = require('vm')
 const weather = requireFromRoot('shell/plugins/panels/weather/Model.js')
 const panelSource = fs.readFileSync(root + '/shell/plugins/panels/weather/Panel.qml', 'utf8')
 const widgetSource = fs.readFileSync(root + '/shell/plugins/panels/weather/BarWidget.qml', 'utf8')
@@ -49,6 +50,140 @@ assertDeepEqual(
 )
 assertDeepEqual(weather.parseGeocodingResults('{}'), [], 'weather handles empty geocoding responses')
 assertDeepEqual(weather.parseGeocodingResults('{'), [], 'weather handles invalid geocoding JSON')
+
+// Execute the editor's actual QML functions and signal handlers. A queued
+// response or debounce can arrive between any two user actions.
+function qmlBody(marker, closingIndent, offset = 0) {
+  const markerStart = panelSource.indexOf(marker, offset)
+  if (markerStart < 0) fail('weather editor handler is missing: ' + marker)
+  const start = panelSource.indexOf('{', markerStart)
+  const end = panelSource.indexOf('\n' + closingIndent + '}', start)
+  if (end <= start) fail('weather editor handler does not close: ' + marker)
+  return panelSource.slice(start + 1, end)
+}
+
+const textChangedLine = panelSource.split('onTextChanged:')[1].split('\n')[0].trim()
+const textChangedBody = textChangedLine === '{' ? qmlBody('onTextChanged:', '              ') : textChangedLine
+const responseBody = qmlBody('      onStreamFinished:', '      ', panelSource.indexOf('    id: geocodeProc'))
+
+function weatherEditor() {
+  const queued = []
+  const requests = []
+  const editor = {
+    Model: weather,
+    editingLocation: true,
+    savingLocation: false,
+    savingLocationQueryStarted: false,
+    locationSuggestions: [],
+    suggestionIndex: 0,
+    geocodePendingQuery: '',
+    geocodeActiveQuery: '',
+    locationField: { text: '' },
+    keyCatcher: null,
+    Qt: { callLater: fn => queued.push(fn) },
+    geocodeDebounce: {
+      running: false,
+      restart() { this.running = true },
+      stop() { this.running = false }
+    },
+    persistLocation(name, latitude, longitude) { editor.saved = { name, latitude, longitude } },
+    clearLocation() { editor.saved = { name: '', latitude: null, longitude: null } }
+  }
+  let running = false
+  editor.geocodeProc = {
+    command: [],
+    get running() { return running },
+    set running(value) {
+      running = value
+      if (value) requests.push(this.command.slice())
+    }
+  }
+  editor.root = editor
+  vm.createContext(editor)
+  for (const name of ['requestGeocode', 'startGeocode', 'commitLocation', 'cancelEditingLocation']) {
+    vm.runInContext('function ' + name + '() {' + qmlBody('  function ' + name + '(', '  ') + '\n}', editor)
+  }
+  editor.type = text => {
+    editor.locationField.text = text
+    vm.runInContext(textChangedBody, editor)
+  }
+  editor.respond = results => {
+    editor.geocodeProc.running = false
+    editor.text = JSON.stringify({ results })
+    vm.runInContext(responseBody, editor)
+  }
+  editor.flush = () => {
+    while (queued.length) queued.shift()()
+  }
+  editor.requests = requests
+  return editor
+}
+
+const london = { name: 'London', latitude: 51.50853, longitude: -0.12574 }
+const paris = { name: 'Paris', latitude: 48.85341, longitude: 2.3488 }
+const edited = weatherEditor()
+edited.type('London')
+edited.requestGeocode()
+edited.respond([london])
+edited.suggestionIndex = 2
+edited.type('Paris')
+assertDeepEqual(edited.locationSuggestions, [], 'weather clears old suggestions as soon as the query changes')
+assertEqual(edited.suggestionIndex, 0, 'weather resets the selected suggestion when typing')
+edited.commitLocation()
+assertDeepEqual(edited.saved, { name: 'Paris', latitude: null, longitude: null }, 'weather Enter before debounce saves the typed city instead of the previous suggestion')
+edited.requestGeocode()
+assertEqual(edited.requests.length, 1, 'weather pending debounce cannot start a request while saving')
+
+const delayed = weatherEditor()
+delayed.type('London')
+delayed.requestGeocode()
+delayed.type('Pa')
+delayed.requestGeocode()
+assertEqual(delayed.requests.length, 1, 'weather keeps only one geocoding request in flight')
+delayed.type('Paris')
+delayed.respond([london])
+assertDeepEqual(delayed.locationSuggestions, [], 'weather ignores an obsolete response while the next query is pending')
+delayed.flush()
+assertEqual(delayed.requests.length, 2, 'weather fetches the latest queued query after the old request completes')
+assert(delayed.requests[1].at(-1).includes('name=Paris&'), 'weather coalesces intermediate queries into the latest city')
+assertEqual(delayed.geocodeDebounce.running, false, 'weather stops the debounce when a queued request starts')
+delayed.respond([paris])
+delayed.commitLocation()
+assertEqual(delayed.saved.name, 'Paris', 'weather accepts the current query suggestion')
+assertEqual(delayed.saved.latitude, paris.latitude, 'weather preserves coordinates from the current suggestion')
+
+for (const query of ['', 'P']) {
+  const shortened = weatherEditor()
+  shortened.type('London')
+  shortened.requestGeocode()
+  shortened.type(query)
+  shortened.respond([london])
+  shortened.flush()
+  shortened.requestGeocode()
+  assertDeepEqual(shortened.locationSuggestions, [], 'weather keeps obsolete results hidden after shortening to ' + JSON.stringify(query))
+  assertEqual(shortened.requests.length, 1, 'weather does not fetch a blank or one-character queued query')
+}
+
+const cancelled = weatherEditor()
+cancelled.type('London')
+cancelled.requestGeocode()
+cancelled.type('Paris')
+cancelled.respond([london])
+cancelled.cancelEditingLocation()
+cancelled.flush()
+assertEqual(cancelled.requests.length, 1, 'weather cancellation prevents a deferred geocoding request from starting')
+assertEqual(cancelled.geocodePendingQuery, '', 'weather cancellation clears the queued query')
+
+const reopened = weatherEditor()
+reopened.type('London')
+reopened.requestGeocode()
+reopened.cancelEditingLocation()
+reopened.editingLocation = true
+reopened.type('Paris')
+reopened.respond([london])
+assertDeepEqual(reopened.locationSuggestions, [], 'weather reopening cannot publish the cancelled editor query')
+reopened.flush()
+assertEqual(reopened.requests.length, 2, 'weather reopening fetches the new editor query after an old request finishes')
 
 assertEqual(weather.roundedTemp('21.6'), '22', 'weather rounds temperatures')
 assertEqual(weather.roundedTemp('nope'), '', 'weather ignores invalid temperatures')


### PR DESCRIPTION
Changing the weather city search can save the previous city. After London suggestions load, replacing the text with Paris and pressing Enter before the next search finishes still commits the highlighted London suggestion. A delayed response can also restore old suggestions after the field changes or is cleared.

Clear suggestions immediately when the text changes and only accept results for the current query while editing. Keep one request in flight, fetch the latest queued query, and prevent queued work from starting after cancellation or while saving.

## Reproduction

1. Open the weather panel and edit its location.
2. Search for London and wait for its suggestion.
3. Replace the field with Paris and press Enter before Paris suggestions arrive.
4. Observe that London is saved, even though the field contained Paris.

With this change, Paris is saved without stale London coordinates. Waiting for Paris suggestions still allows selecting the matching coordinates. The bug was reproduced on upstream `quattro` at `31bd80da`.

## Before and after

**Before:** Paris in the field, London still highlighted.

![Paris search with stale London suggestion](https://raw.githubusercontent.com/richardslatter/omarchy/6e98b1cb1b10a53eb645120ae194bcbc25d76ee6/before.png)

**After:** the old suggestion disappears immediately when the query changes.

![Paris search with stale suggestions cleared](https://raw.githubusercontent.com/richardslatter/omarchy/6e98b1cb1b10a53eb645120ae194bcbc25d76ee6/after.png)

[Before recording](https://github.com/richardslatter/omarchy/blob/6e98b1cb1b10a53eb645120ae194bcbc25d76ee6/before.mp4) · [After recording](https://github.com/richardslatter/omarchy/blob/6e98b1cb1b10a53eb645120ae194bcbc25d76ee6/after.mp4)

## Validation

- `bash test/shell.d/weather-test.sh` — 76 assertions pass, including regressions that execute the actual QML functions and handlers. The new regression fails against the original panel.
- `bash test/shell.d/panel-command-path-test.sh`, `bash -n test/shell.d/weather-test.sh`, and `git diff --check` pass.
- Verified before and after in the full Omarchy shell on an isolated Hyprland compositor with a temporary home and deterministic HTTP response fixtures. Checked typing before suggestions arrive, a delayed obsolete response, selecting the current result with coordinates, and clearing the field during a request. Screenshots and recordings capture the running UI; the weather values are fixtures.
