### PR TITLE
Install OpenCode V2 through mise's npm backend

### DIFF
--- a/bin/omarchy-default-agent
+++ b/bin/omarchy-default-agent
@@ -26,7 +26,7 @@ fi
 case "$1" in
 pi) agent="pi"; name="Pi" ;;
 omp | oh-my-pi) agent="omp"; name="Oh My Pi"; agent_package="github:can1357/oh-my-pi" ;;
-opencode | open-code) agent="opencode"; name="OpenCode" ;;
+opencode | open-code) agent="opencode"; name="OpenCode"; agent_package="npm:@opencode/cli[allow_builds=@opencode/cli]" ;;
 ori | openrouter) agent="ori"; name="Ori"; agent_package="github:OpenRouterLabs/ori-releases" ;;
 claude | claude-code) agent="claude"; name="Claude Code" ;;
 codex) agent="codex"; name="Codex" ;;

--- a/install/user/mise.sh
+++ b/install/user/mise.sh
@@ -8,7 +8,8 @@ omarchy-mise-install crush
 omarchy-mise-install antigravity-cli agy
 omarchy-mise-install gh
 omarchy-mise-install copilot
-omarchy-mise-install opencode
+# V2's npm package selects the native binary in its postinstall script.
+omarchy-mise-install "npm:@opencode/cli[allow_builds=@opencode/cli]" opencode
 omarchy-mise-install npm:playwright playwright
 omarchy-mise-install pi
 omarchy-mise-install github:can1357/oh-my-pi omp

--- a/manual/17-ai.md
+++ b/manual/17-ai.md
@@ -22,6 +22,8 @@ Omarchy treats AI coding agents as first-class citizens, but it doesn't pick a f
 
 To wrap an additional CLI the same way, run `omarchy-mise-install <package> [command-name]`. The stubs are kept current along with everything else mise manages when you run `omarchy update` (or the `mup` alias).
 
+OpenCode V2 comes from the official `@opencode/cli` npm package through mise, with its binary-selection postinstall script enabled. It still runs as `opencode` and updates through `omarchy update`. See the [OpenCode V2 migration guide](https://opencode.ai/v2/docs/migrate-v1/) for changes to plugins, API integrations, and terminal configuration.
+
 ### The default agent
 
 Pick your default agent with `omarchy default agent <name>` or under _Setup > Defaults > Agent_ in the Omarchy Menu (`Super + Space`). If the agent isn't installed yet, picking it installs it first. A fresh Omarchy will invite you to make this choice with a one-time notification.

--- a/migrations/1789156273.sh
+++ b/migrations/1789156273.sh
@@ -1,0 +1,51 @@
+echo "Move the default OpenCode CLI installation to the V2 npm distribution"
+
+[[ ! -f $HOME/.local/state/omarchy/preinstalls-removed ]] || exit 0
+
+wrapper="$HOME/.local/bin/opencode"
+# Earlier wrapper migrations normalize older stock launchers to this form.
+# Compare the whole file so symlinks and hand-edited launchers remain intact.
+if [[ -e $wrapper || -L $wrapper ]]; then
+  [[ -f $wrapper && ! -L $wrapper ]] || exit 0
+  (($(stat -c%s "$wrapper") <= 1024)) || exit 0
+  stock=$(printf '#!/bin/bash\nexport MISE_MINIMUM_RELEASE_AGE=0\nmise use -g --quiet "opencode" || exit 1\nexec mise x "opencode" -- "opencode" "$@"')
+  [[ $(<"$wrapper") == "$stock" ]] || exit 0
+fi
+
+config="${MISE_GLOBAL_CONFIG_FILE:-${MISE_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/mise}/config.toml}"
+action=$(python - "$config" <<'PY'
+import pathlib
+import sys
+import tomllib
+
+path = pathlib.Path(sys.argv[1])
+data = tomllib.loads(path.read_text()) if path.exists() else {}
+tools = data.get("tools", {})
+old = tools.get("opencode")
+new = tools.get("npm:@opencode/cli")
+# Explicit pins, alternate backends, aliases and beta setups belong to the user.
+custom = (
+    old not in (None, "latest")
+    or "opencode" in data.get("alias", {})
+    or any("opencode" in key and key not in ("opencode", "npm:@opencode/cli") for key in tools)
+    or new not in (None, "latest", {"version": "latest", "allow_builds": "@opencode/cli"})
+)
+print("skip" if custom else "migrate" if old == "latest" else "lazy")
+PY
+)
+
+if [[ $action == "skip" ]]; then
+  echo "Keeping the customized OpenCode mise configuration"
+  exit 0
+fi
+
+if [[ $action == "migrate" ]]; then
+  # Install successfully before removing the old request. Leave its executable
+  # on disk for running sessions and rollback; never use OpenCode's uninstaller.
+  MISE_MINIMUM_RELEASE_AGE=0 mise use --path "$config" --fuzzy "npm:@opencode/cli[allow_builds=@opencode/cli]@latest"
+  mise unuse --path "$config" --no-prune opencode
+fi
+
+# Unused preinstalls stay lazy. On failure above the old wrapper stays usable,
+# and the migration runner leaves this migration pending for a retry.
+omarchy-mise-install "npm:@opencode/cli[allow_builds=@opencode/cli]" opencode

--- a/test/shell.d/default-agent-test.sh
+++ b/test/shell.d/default-agent-test.sh
@@ -114,6 +114,7 @@ export OMARCHY_PATH="$ROOT"
 grok_package="npm:@xai-official/grok"
 omp_package="github:can1357/oh-my-pi"
 crush_package="crush"
+opencode_package="npm:@opencode/cli[allow_builds=@opencode/cli]"
 agy_package="antigravity-cli"
 ori_package="github:OpenRouterLabs/ori-releases"
 cursor_agent_package="cursor-agent"
@@ -135,6 +136,7 @@ assert_lazy_stub() {
 assert_lazy_stub "$grok_package" grok
 assert_lazy_stub "$omp_package" omp
 assert_lazy_stub "$crush_package" crush
+assert_lazy_stub "$opencode_package" opencode
 assert_lazy_stub "$ori_package" ori
 assert_lazy_stub "$cursor_agent_package" cursor-agent
 assert_lazy_stub "$muse_package" muse
@@ -146,6 +148,7 @@ grep -Fx "$grok_package grok" "$stub_log" >/dev/null || fail "user setup creates
 grep -Fx "$cursor_agent_package" "$stub_log" >/dev/null || fail "user setup creates the Cursor CLI lazy stub"
 grep -Fx "$omp_package omp" "$stub_log" >/dev/null || fail "user setup creates the Oh My Pi lazy stub"
 grep -Fx "$crush_package" "$stub_log" >/dev/null || fail "user setup creates the Crush lazy stub"
+grep -Fx "$opencode_package opencode" "$stub_log" >/dev/null || fail "user setup creates the OpenCode V2 lazy stub"
 grep -Fx "$ori_package ori" "$stub_log" >/dev/null || fail "user setup creates the Ori lazy stub"
 OMARCHY_TEST_MISSING_COMMAND=muse source "$ROOT/install/user/mise.sh"
 grep -Fx "$muse_package muse" "$stub_log" >/dev/null || fail "user setup creates the Muse lazy stub"
@@ -391,7 +394,7 @@ declare -A expected_agents=(
 declare -A expected_packages=(
   [pi]="pi"
   [omp]="$omp_package"
-  [opencode]="opencode"
+  [opencode]="$opencode_package"
   [ori]="$ori_package"
   [claude]="claude"
   [codex]="codex"

--- a/test/shell.d/opencode-migration-test.sh
+++ b/test/shell.d/opencode-migration-test.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+mkdir -p "$test_tmp/bin"
+export HOME="$test_tmp/home"
+export XDG_CONFIG_HOME="$HOME/.config"
+export MISE_CONFIG_DIR="$XDG_CONFIG_HOME/mise"
+export MISE_GLOBAL_CONFIG_FILE="$MISE_CONFIG_DIR/config.toml"
+export OMARCHY_PATH="$ROOT"
+export OMARCHY_TEST_MISE_LOG="$test_tmp/mise.log"
+export PATH="$test_tmp/bin:$ROOT/bin:$PATH"
+wrapper="$HOME/.local/bin/opencode"
+migration="$ROOT/migrations/1789156273.sh"
+package="npm:@opencode/cli[allow_builds=@opencode/cli]"
+
+cat >"$test_tmp/bin/mise" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$OMARCHY_TEST_MISE_LOG"
+[[ $1 != "${OMARCHY_TEST_FAIL_COMMAND:-}" ]]
+SH
+chmod +x "$test_tmp/bin/mise"
+
+reset_home() {
+  rm -rf "$HOME"
+  mkdir -p "$MISE_CONFIG_DIR"
+  : >"$OMARCHY_TEST_MISE_LOG"
+  "$ROOT/bin/omarchy-mise-install" opencode
+}
+
+run_migration() {
+  bash -euo pipefail "$migration" >"$test_tmp/output" 2>&1
+}
+
+reset_home
+run_migration
+[[ ! -s $OMARCHY_TEST_MISE_LOG ]] || fail "unused OpenCode stays lazy"
+"$wrapper" --auto --prompt "Review this project"
+mapfile -t calls <"$OMARCHY_TEST_MISE_LOG"
+[[ ${calls[0]} == "use -g --quiet $package" &&
+  ${calls[1]} == "x $package -- opencode --auto --prompt Review this project" ]] ||
+  fail "the migrated lazy wrapper installs V2 with its binary-selection script"
+pass "unused OpenCode stays lazy and launches through the V2 package"
+
+reset_home
+printf '[tools]\nopencode = "latest"\nnode = "24"\n' >"$MISE_GLOBAL_CONFIG_FILE"
+run_migration
+mapfile -t calls <"$OMARCHY_TEST_MISE_LOG"
+[[ ${#calls[@]} == 2 &&
+  ${calls[0]} == "use --path $MISE_GLOBAL_CONFIG_FILE --fuzzy $package@latest" &&
+  ${calls[1]} == "unuse --path $MISE_GLOBAL_CONFIG_FILE --no-prune opencode" ]] ||
+  fail "migration installs V2 before removing only the V1 request, without pruning"
+cp "$wrapper" "$test_tmp/migrated-wrapper"
+: >"$OMARCHY_TEST_MISE_LOG"
+run_migration
+[[ ! -s $OMARCHY_TEST_MISE_LOG ]] || fail "migration is idempotent"
+cmp -s "$wrapper" "$test_tmp/migrated-wrapper" || fail "a migrated wrapper stays intact"
+pass "active defaults migrate in order and repeated migration is a no-op"
+
+for command in use unuse; do
+  reset_home
+  printf '[tools]\nopencode = "latest"\n' >"$MISE_GLOBAL_CONFIG_FILE"
+  cp "$wrapper" "$test_tmp/old-wrapper"
+  if OMARCHY_TEST_FAIL_COMMAND="$command" run_migration; then
+    fail "$command failure must leave the migration pending"
+  fi
+  cmp -s "$wrapper" "$test_tmp/old-wrapper" || fail "$command failure preserves the old launcher"
+  if [[ $command == "use" ]]; then
+    ! grep -q '^unuse ' "$OMARCHY_TEST_MISE_LOG" || fail "a failed install never removes V1"
+  fi
+  run_migration
+  grep -Fq "$package" "$wrapper" || fail "migration can retry after $command failure"
+done
+pass "installation and config-removal failures preserve the launcher and can retry"
+
+for config in \
+  'opencode = "1.18.30"' \
+  'opencode = ["latest", "1.18.30"]' \
+  'opencode = { version = "latest", install_env = { CUSTOM = "yes" } }' \
+  '"github:anomalyco/opencode" = "latest"' \
+  '"npm:@opencode-ai/cli" = "beta"' \
+  '"npm:@opencode/cli" = "2.0.1"' \
+  $'opencode = "latest"\n[alias.opencode]\nbackend = "github:anomalyco/opencode"'; do
+  reset_home
+  printf '[tools]\n%s\n' "$config" >"$MISE_GLOBAL_CONFIG_FILE"
+  cp "$wrapper" "$test_tmp/old-wrapper"
+  cp "$MISE_GLOBAL_CONFIG_FILE" "$test_tmp/old-config"
+  run_migration
+  cmp -s "$wrapper" "$test_tmp/old-wrapper" || fail "migration preserves a customized mise setup"
+  cmp -s "$MISE_GLOBAL_CONFIG_FILE" "$test_tmp/old-config" || fail "migration preserves custom config contents"
+  [[ ! -s $OMARCHY_TEST_MISE_LOG ]] || fail "custom mise setups trigger no installations"
+done
+pass "migration leaves explicit pins, options, backends, aliases and beta setups alone"
+
+reset_home
+printf '[tools]\nopencode = "latest"\n"npm:@opencode/cli" = { version = "latest", allow_builds = "@opencode/cli" }\n' >"$MISE_GLOBAL_CONFIG_FILE"
+run_migration
+grep -Fq "unuse --path $MISE_GLOBAL_CONFIG_FILE --no-prune opencode" "$OMARCHY_TEST_MISE_LOG" ||
+  fail "retry handles the new package already being configured"
+pass "migration handles a retry after V2 was configured but V1 was not yet removed"
+
+for kind in edited symlink; do
+  reset_home
+  printf '[tools]\nopencode = "latest"\n' >"$MISE_GLOBAL_CONFIG_FILE"
+  if [[ $kind == "edited" ]]; then
+    printf '\n# My custom launcher\n' >>"$wrapper"
+  else
+    mv "$wrapper" "$test_tmp/user-wrapper"
+    ln -s "$test_tmp/user-wrapper" "$wrapper"
+  fi
+  cp "$wrapper" "$test_tmp/old-wrapper"
+  run_migration
+  cmp -s "$wrapper" "$test_tmp/old-wrapper" || fail "migration preserves $kind launchers"
+  [[ ! -s $OMARCHY_TEST_MISE_LOG ]] || fail "$kind launchers trigger no installations"
+  if [[ $kind == "symlink" ]]; then
+    [[ -L $wrapper ]] || fail "migration preserves launcher symlinks"
+  fi
+done
+pass "custom launchers and symlinks are preserved"
+
+reset_home
+mkdir -p "$HOME/.local/state/omarchy"
+touch "$HOME/.local/state/omarchy/preinstalls-removed"
+rm "$wrapper"
+run_migration
+[[ ! -e $wrapper && ! -s $OMARCHY_TEST_MISE_LOG ]] || fail "migration respects the preinstall opt-out"
+pass "migration respects the preinstall opt-out"
+
+reset_home
+printf 'invalid toml = [' >"$MISE_GLOBAL_CONFIG_FILE"
+cp "$wrapper" "$test_tmp/old-wrapper"
+if run_migration; then
+  fail "invalid TOML leaves the migration pending"
+fi
+[[ ! -s $OMARCHY_TEST_MISE_LOG ]] || fail "invalid TOML triggers no installations"
+cmp -s "$wrapper" "$test_tmp/old-wrapper" || fail "invalid TOML preserves the launcher"
+pass "invalid config fails without changing the launcher"


### PR DESCRIPTION
## Summary

Install the stable OpenCode V2 CLI through mise's npm backend, using the official `@opencode/cli` package.

OpenCode's [V2 installation documentation](https://opencode.ai/v2/docs/) now points to `@opencode/cli` or its npm-backed curl installer. On September 12, npm's stable release is `2.0.1`, while the GitHub release feed used by `aqua:anomalyco/opencode` still resolves to `1.18.30`. Consequently, both `omarchy update` and `omarchy update mise` keep the default CLI on V1.

## Changes

- Point fresh-install stubs and default-agent selection at `npm:@opencode/cli`.
- Approve only `@opencode/cli`'s postinstall script with mise's `allow_builds` option. This script selects the platform/CPU-specific native executable; installing the package with lifecycle scripts disabled is insufficient.
- Migrate the ordinary `opencode = "latest"` global mise entry: install V2 first, then remove the old request with `--no-prune`, then regenerate the launcher. The installed V1 executable remains available for running processes and rollback.
- Keep unused preinstalls lazy. The migration respects the preinstall opt-out and leaves customized launchers, symlinks, explicit version pins, alternate backends, and beta configurations for their owners to migrate.
- Add regression coverage for installation order, failure/retry behavior, idempotence, customization preservation, fresh stubs, and default-agent package selection.

The migration edits mise configuration through mise itself. OpenCode configuration/session data are not part of this installation-source migration; the manual links to OpenCode's [V1-to-V2 migration guide](https://opencode.ai/v2/docs/migrate-v1/) for plugin/API/terminal changes.

## Related work

Related to #7143, which proposes an npm-backed V2 beta migration using the earlier `@opencode-ai/cli` package and changes to shared wrapper pin handling. This proposal targets the stable package and uses the existing shared wrapper behavior. Happy to coordinate or consolidate with that work.

Also accounts for the backend-key concern raised in #6886: the migration explicitly removes the old active request after the replacement installs, rather than leaving two competing mise entries.

## Validation

- `bash test/shell.d/default-agent-test.sh` — passes.
- `bash test/shell.d/opencode-migration-test.sh` — passes.
- `bash -n` on the changed shell files and `git diff --check` — pass.
- Real isolated installation using mise `2026.9.4` on Linux x86_64: installed the official npm package with its scoped postinstall approval; `opencode --version` reports `opencode v2.0.1`.
- Real isolated migration from a V1-only global configuration: V2 becomes active, the V1 binary stays installed but inactive, unrelated mise configuration and OpenCode data/config sentinels survive, a second migration is a no-op, and `mise up` stays on V2.
- The installed V2 binary accepts the launcher's existing `--auto` and `--prompt` arguments (checked with `--help`); existing launcher argument tests pass.

Mise's embedded installer currently asks for confirmation because the `@opencode/cli` package name was registered less than 30 days ago. I confirmed the official package in the isolated interactive installation. An unattended refusal fails the migration before removing the V1 request; the package manager's checks are retained.

`./test/all` completed: the CLI suite passed; **230/237 shell test files passed**. The remaining results are recorded rather than presented as a green full suite:

- `bar-icon-geometry-test.sh`: monitor icon painted bounds off-center by 0.59375 pixels; reproduced on unchanged upstream `31bd80d`.
- `config-test.sh`, `snapper-test.sh`, `unowned-system-paths-test.sh`: require a separate `omarchy-pkgs` checkout; reproduced on unchanged upstream.
- `locate-test.sh`: reads generated `bin/__pycache__/*.pyc` as UTF-8 after the agent scanner tests. Reproduced on unchanged upstream by running the Claude scanner test before the locate test; locate passes on a clean baseline before that cache is generated.
- `update-package-conflict-test.sh`: terminal-resolution assertion fails; reproduced on unchanged upstream.
- `runtime-smoke-test.sh`: all assertions pass, but its EXIT cleanup fails with `rm: ... Directory not empty`, also on a focused retry of this branch. The unchanged baseline passed this test. The test's runtime/cleanup code is unchanged by this PR; the cleanup failure is not resolved here.

AI-assisted implementation and testing using OpenCode.
