### PR TITLE
Detect Microarray MAFP fingerprint readers

### DIFF
--- a/bin/omarchy-hw-fingerprint
+++ b/bin/omarchy-hw-fingerprint
@@ -8,7 +8,10 @@
 # ship fingerprint readers; multi-purpose vendors (e.g. Elan/STMicro, which
 # also make USB touchscreens) are left out to avoid nagging laptops with no
 # reader — those still match on the product string below when present.
-fingerprint_vendors=" 27c6 138a 06cb 08ff 1c7a 147e "
+# 3274 is Microarray Technology, whose MAFP match-on-chip readers libfprint
+# drives (mafpmoc); they enumerate as "MAFP General Device" with no
+# "fingerprint" in the string, so the vendor guess is what catches them.
+fingerprint_vendors=" 27c6 138a 06cb 08ff 1c7a 147e 3274 "
 usb_devices_path="${OMARCHY_USB_DEVICES_PATH:-/sys/bus/usb/devices}"
 
 # libfprint drives every reader it supports from userspace over libusb, so a
@@ -42,8 +45,9 @@ for dev in "$usb_devices_path"/*; do
     # the manufacturer rather than the function. Both vendors are left out of
     # the list above on purpose (Elan also makes touchscreens), so without these
     # they match nothing. FPC leads the string on every reader on record, and
-    # three letters are little to match on, so require the prefix.
-    [[ $product == *fingerprint* || $product == *biometric* || $product == *elan:arm-m4* || $product == "fpc "* ]] && exit 0
+    # three letters are little to match on, so require the prefix. Microarray
+    # readers say "MAFP General Device" — MAFP is MicroArray FingerPrint.
+    [[ $product == *fingerprint* || $product == *biometric* || $product == *elan:arm-m4* || $product == "fpc "* || $product == *mafp* ]] && exit 0
   fi
 
   if [[ -r $dev/idVendor ]]; then

--- a/test/shell.d/hw-fingerprint-test.sh
+++ b/test/shell.d/hw-fingerprint-test.sh
@@ -74,6 +74,15 @@ assert_detects "a reader is detected by an existing product-name match"
 write_usb_devices '27c6:1234'
 assert_detects "a reader is detected by an existing vendor match"
 
+# Microarray's MAFP readers enumerate as "MAFP General Device" — no
+# "fingerprint" in the string — so both the vendor guess and an MAFP token
+# have to catch them. Each is exercised on its own.
+write_usb_devices '3274:8012'
+assert_detects "a Microarray reader is detected by its vendor"
+
+write_usb_devices '1234:5678:MAFP General Device'
+assert_detects "a reader is detected by the MAFP product token"
+
 bind_driver() {
   local dev="$1" driver="$2"
 


### PR DESCRIPTION
Microarray's MAFP match-on-chip readers (USB vendor `3274`, driven by libfprint's `mafpmoc`) enumerate as "MAFP General Device": no "fingerprint" in the product string, and a vendor missing from `fingerprint_vendors`. `omarchy-hw-fingerprint` therefore returned false and `omarchy-setup-security-fingerprint` refused to run on a reader fprintd handles fine (enroll + verify confirmed on a `3274:8012`).

This adds the vendor to the guess list and an `mafp` token to the product-string match, each with its own case in `test/shell.d/hw-fingerprint-test.sh`. Both new cases fail on `quattro` without the change; the file passes 13/13 with it.

Tested on ASUS ProArt P16 / Omarchy 4.0.2-1 with the reader attached: detection passes, and the wizard's PAM stacks for sudo, polkit and the lock screen work end to end.

Fixes #11426

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJZgHbukBfk6NyncUQFYt1
