### PR TITLE
fix: hybrid GPU VA-API video decode and Chromium browser flags

### DIFF
--- a/config/chromium-flags.conf
+++ b/config/chromium-flags.conf
@@ -2,4 +2,6 @@
 --ozone-platform-hint=wayland
 --password-store=gnome-libsecret
 --enable-features=TouchpadOverscrollHistoryNavigation
+--enable-features=VaapiVideoDecoder,VaapiIgnoreDriverChecks
+--disable-features=UseChromeOSDirectVideoDecoder
 --load-extension=/usr/share/omarchy/default/chromium/extensions/copy-url,/usr/share/omarchy/default/chromium/extensions/yt-dlp,/usr/share/omarchy/default/chromium/extensions/whatsapp-slim

--- a/default/hypr/nvidia.lua
+++ b/default/hypr/nvidia.lua
@@ -3,6 +3,7 @@ local paths = require("default.hypr.paths")
 local nvidia = paths.omarchy_path .. "/bin/omarchy-hw-nvidia"
 local nvidia_gsp = paths.omarchy_path .. "/bin/omarchy-hw-nvidia-gsp"
 local nvidia_without_gsp = paths.omarchy_path .. "/bin/omarchy-hw-nvidia-without-gsp"
+local hybrid_gpu = paths.omarchy_path .. "/bin/omarchy-hw-hybrid-gpu"
 
 -- These detectors read cached sysfs IDs rather than shelling out to lspci.
 -- lspci reads PCI config space, which resumes a runtime-suspended GPU, and on a
@@ -10,10 +11,26 @@ local nvidia_without_gsp = paths.omarchy_path .. "/bin/omarchy-hw-nvidia-without
 if o.shell_succeeds(o.shell_quote(nvidia)) then
   if o.shell_succeeds(o.shell_quote(nvidia_gsp)) then
     hl.env("NVD_BACKEND", "direct")
-    hl.env("LIBVA_DRIVER_NAME", "nvidia")
     hl.env("__GLX_VENDOR_LIBRARY_NAME", "nvidia")
+    -- On hybrid laptops, the panel scans out through the Intel iGPU. Using
+    -- the nvidia VA-API driver for video decode produces broken playback in
+    -- Chromium-based browsers (black screen, spinner, audio-only) because the
+    -- decoded frames cannot be handed back to the Intel compositor over
+    -- Wayland. Point VA-API at the Intel iHD driver so the iGPU's hardware
+    -- decoder handles VP9/AV1, which scans out locally. The nvidia GPU
+    -- remains available for GL rendering and CUDA.
+    if o.shell_succeeds(o.shell_quote(hybrid_gpu)) then
+      hl.env("LIBVA_DRIVER_NAME", "iHD")
+    else
+      hl.env("LIBVA_DRIVER_NAME", "nvidia")
+    end
   elseif o.shell_succeeds(o.shell_quote(nvidia_without_gsp)) then
     hl.env("NVD_BACKEND", "egl")
     hl.env("__GLX_VENDOR_LIBRARY_NAME", "nvidia")
+    if o.shell_succeeds(o.shell_quote(hybrid_gpu)) then
+      hl.env("LIBVA_DRIVER_NAME", "iHD")
+    else
+      hl.env("LIBVA_DRIVER_NAME", "nvidia")
+    end
   end
 end

--- a/test/shell.d/default-apps-test.sh
+++ b/test/shell.d/default-apps-test.sh
@@ -208,6 +208,14 @@ OMARCHY_TEST_REAL_BROWSER_INSTALL=true omarchy-default-browser --install chromiu
 [[ $(omarchy-default-browser) == "chromium" ]] || fail "Chromium becomes the default after its full installer succeeds"
 cmp -s "$ROOT/config/chromium-flags.conf" "$test_home/.config/chromium-flags.conf" ||
   fail "Chromium browser installer copies the default flags"
+
+# Verify VA-API flags are present in the default Chromium flags config
+grep -Fxq -- '--enable-features=VaapiVideoDecoder,VaapiIgnoreDriverChecks' "$ROOT/config/chromium-flags.conf" ||
+  fail "Chromium flags config enables VA-API video decoder"
+grep -Fxq -- '--disable-features=UseChromeOSDirectVideoDecoder' "$ROOT/config/chromium-flags.conf" ||
+  fail "Chromium flags config disables ChromeOS direct video decoder"
+pass "Chromium flags config includes VA-API video decode flags"
+
 grep -Fxq 'sudo:install -d -m 0755 -o root -g root /etc/chromium' "$setup_log" ||
   fail "Chromium browser installer creates a root-owned Chromium policy parent"
 grep -Fxq 'sudo:install -d -m 0755 -o root -g root /etc/chromium/policies' "$setup_log" ||

--- a/test/shell.d/fixtures/hybrid-gpu-vaapi-intel.lua
+++ b/test/shell.d/fixtures/hybrid-gpu-vaapi-intel.lua
@@ -1,0 +1,61 @@
+local captured = {}
+local seen_order = {}
+
+hl = {
+  env = function(name, value)
+    table.insert(seen_order, name)
+    if name == "PATH" then return end
+    captured[name] = value
+  end,
+  config = function() end,
+  monitor = function() end,
+  bind = function() end,
+  window_rule = function() end,
+  workspace_rule = function() end,
+  layer_rule = function() end,
+  gesture = function() end,
+  animation = function() end,
+  curve = function() end,
+  exec_cmd = function() end,
+  dispatch = function() end,
+  on = function() end,
+  timer = function() end,
+}
+
+o = {
+  shell_succeeds = function(command)
+    -- Lua 5.3+ os.execute returns true for exit 0, nil otherwise
+    local success = os.execute(command .. ' >/dev/null 2>&1')
+    return success == true
+  end,
+  shell_quote = function(path)
+    return "'" .. path:gsub("'", "'\\''") .. "'"
+  end,
+}
+
+package.path = os.getenv("OMARCHY_PATH") .. "/?.lua;" .. package.path
+dofile(os.getenv("OMARCHY_PATH") .. "/default/hypr/nvidia.lua")
+
+local json_encode
+json_encode = function(value)
+  if type(value) == 'table' then
+    local parts = {}
+    local is_array = #value > 0
+    if is_array then
+      for _, v in ipairs(value) do
+        table.insert(parts, json_encode(v))
+      end
+      return '[' .. table.concat(parts, ',') .. ']'
+    end
+    for k, v in pairs(value) do
+      table.insert(parts, json_encode(k) .. ':' .. json_encode(v))
+    end
+    return '{' .. table.concat(parts, ',') .. '}'
+  end
+  if type(value) == 'string' then
+    return '"' .. value:gsub('\\', '\\\\'):gsub('"', '\\"') .. '"'
+  end
+  return tostring(value)
+end
+
+print(json_encode({ env = captured, order = seen_order }))

--- a/test/shell.d/hybrid-gpu-vaapi-intel-test.sh
+++ b/test/shell.d/hybrid-gpu-vaapi-intel-test.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command lua
+
+MOCK_OMARCHY_DIR=""
+
+cleanup() {
+  if [[ -n $MOCK_OMARCHY_DIR && -d $MOCK_OMARCHY_DIR ]]; then
+    rm -rf "$MOCK_OMARCHY_DIR"
+  fi
+}
+trap cleanup EXIT
+
+# Mock hardware detection commands. nvidia.lua constructs the path as
+# paths.omarchy_path .. "/bin/omarchy-hw-*", so we create a temporary
+# omarchy directory with a bin/ full of mock commands and point
+# OMARCHY_PATH at it. We symlink the default/ directory from the repo
+# so nvidia.lua can be dofile'd from the same OMARCHY_PATH.
+mock_hw_commands() {
+  local hybrid="$1"
+  local gsp="$2"
+  local without_gsp="$3"
+
+  MOCK_OMARCHY_DIR=$(mktemp -d)
+  mkdir -p "$MOCK_OMARCHY_DIR/bin"
+  ln -s "$ROOT/default" "$MOCK_OMARCHY_DIR/default"
+
+  for cmd in omarchy-hw-nvidia omarchy-hw-nvidia-gsp omarchy-hw-nvidia-without-gsp omarchy-hw-hybrid-gpu; do
+    local want=no
+    case "$cmd" in
+      omarchy-hw-nvidia) want=yes ;;
+      omarchy-hw-nvidia-gsp) want="$gsp" ;;
+      omarchy-hw-nvidia-without-gsp) want="$without_gsp" ;;
+      omarchy-hw-hybrid-gpu) want="$hybrid" ;;
+    esac
+    if [[ $want == "yes" ]]; then
+      printf '#!/bin/bash\nexit 0\n' >"$MOCK_OMARCHY_DIR/bin/$cmd"
+    else
+      printf '#!/bin/bash\nexit 1\n' >"$MOCK_OMARCHY_DIR/bin/$cmd"
+    fi
+    chmod +x "$MOCK_OMARCHY_DIR/bin/$cmd"
+  done
+}
+
+run_nvidia_env() {
+  OMARCHY_PATH="$MOCK_OMARCHY_DIR" lua "$ROOT/test/shell.d/fixtures/hybrid-gpu-vaapi-intel.lua"
+}
+
+assert_env() {
+  local description="$1" expected_libva="$2" expected_glx="$3"
+
+  local output
+  output=$(run_nvidia_env)
+
+  local actual
+  actual=$(echo "$output" | jq -r '.env.LIBVA_DRIVER_NAME // "unset"')
+  [[ "$actual" == "$expected_libva" ]] || fail "$description" "LIBVA_DRIVER_NAME: expected $expected_libva, got: $actual"
+  actual=$(echo "$output" | jq -r '.env.__GLX_VENDOR_LIBRARY_NAME // "unset"')
+  [[ "$actual" == "$expected_glx" ]] || fail "$description" "__GLX_VENDOR_LIBRARY_NAME: expected $expected_glx, got: $actual"
+  pass "$description"
+}
+
+# --- Case 1: non-hybrid desktop NVIDIA (GSP) ---------------------------
+mock_hw_commands "no" "yes" "no"
+assert_env "non-hybrid GSP desktop uses nvidia for both GL and VA-API" "nvidia" "nvidia"
+
+# --- Case 2: hybrid laptop (GSP) --------------------------------------
+mock_hw_commands "yes" "yes" "no"
+assert_env "hybrid GSP laptop uses Intel iHD for VA-API, nvidia for GL" "iHD" "nvidia"
+
+# --- Case 3: non-hybrid desktop NVIDIA (without GSP) ------------------
+mock_hw_commands "no" "no" "yes"
+assert_env "non-hybrid non-GSP desktop uses nvidia for both GL and VA-API" "nvidia" "nvidia"
+
+# --- Case 4: hybrid laptop (without GSP) ------------------------------
+mock_hw_commands "yes" "no" "yes"
+assert_env "hybrid non-GSP laptop uses Intel iHD for VA-API, nvidia for GL" "iHD" "nvidia"
+
+# --- Case 5: no NVIDIA GPU -------------------------------------------
+mock_hw_commands "no" "no" "no"
+assert_env "no NVIDIA GPU leaves both variables unset" "unset" "unset"
+
+# --- Case 6: ordering — LIBVA_DRIVER_NAME after __GLX_VENDOR_LIBRARY_NAME
+# in both branches, so a bare env dump that lists variables alphabetically or
+# insertion-ordered cannot reorder them to mask a regression.
+ordering() {
+  local mock_hybrid="$1" mock_gsp="$2" mock_without_gsp="$3" branch="$4"
+
+  mock_hw_commands "$mock_hybrid" "$mock_gsp" "$mock_without_gsp"
+  local output
+  output=$(run_nvidia_env)
+  local glx_index
+  glx_index=$(echo "$output" | jq -r '(.order | index("__GLX_VENDOR_LIBRARY_NAME")) // 0')
+  local libva_index
+  libva_index=$(echo "$output" | jq -r '(.order | index("LIBVA_DRIVER_NAME")) // 0')
+  (( glx_index > 0 && libva_index > 0 )) || fail "both env vars are set in $branch branch"
+  (( glx_index < libva_index )) || fail "__GLX_VENDOR_LIBRARY_NAME is set before LIBVA_DRIVER_NAME in $branch branch" "glx=$glx_index libva=$libva_index"
+  pass "$branch branch sets __GLX_VENDOR_LIBRARY_NAME before LIBVA_DRIVER_NAME"
+}
+
+ordering "yes" "yes" "no" "hybrid GSP"
+ordering "yes" "no" "yes" "hybrid non-GSP"


### PR DESCRIPTION
## Summary

Two related fixes for video playback on hybrid GPU laptops (Optimus):

1. **Wrong VA-API driver**: `nvidia.lua` set `LIBVA_DRIVER_NAME=nvidia` unconditionally, which breaks Chromium video decode on hybrid laptops where the panel scans out through Intel. The NVIDIA driver can decode frames but cannot hand them back to the Intel compositor over Wayland — resulting in black screen, spinner, or audio-only playback.

2. **Missing VA-API browser flags**: The default `chromium-flags.conf` did not enable VA-API video decode, so browsers fell back to software decode regardless of the driver.

## What changed

- `default/hypr/nvidia.lua` — check `omarchy-hw-hybrid-gpu` before setting `LIBVA_DRIVER_NAME`; use `iHD` on hybrid laptops, `nvidia` otherwise. Keep `__GLX_VENDOR_LIBRARY_NAME=nvidia` for GL rendering.
- `config/chromium-flags.conf` — add `--enable-features=VaapiVideoDecoder,VaapiIgnoreDriverChecks` and `--disable-features=UseChromeOSDirectVideoDecoder` to enable hardware video decode in Chromium-based browsers.
- `test/shell.d/hybrid-gpu-vaapi-intel-test.sh` — 7 test cases covering hybrid/non-hybrid, GSP/non-GSP, and no-NVIDIA branches for nvidia.lua.
- `test/shell.d/fixtures/hybrid-gpu-vaapi-intel.lua` — shared Lua harness that stubs `hl.env` and `o.shell_succeeds` to exercise nvidia.lua without Hyprland.
- `test/shell.d/default-apps-test.sh` — verify VA-API flags are present in `chromium-flags.conf`.

## Test plan

- [x] New test `hybrid-gpu-vaapi-intel-test.sh` passes (7/7)
- [x] Updated `default-apps-test.sh` passes (includes VA-API flag check)
- [x] Existing `test/cli` passes
- [x] Existing `test/shell` passes
- [x] Verified on hybrid NVIDIA laptop (MSI Titan GT77HX, RTX 4090 + Intel UHD):
  - `brave://gpu` shows **Video Decode: Hardware accelerated**
  - Full hardware decode support: H.264, VP9, HEVC, AV1 up to 16384x16384
  - `Optimus: true` confirmed
  - GL renderer using Intel (RPL-S) via ANGLE
  - YouTube plays correctly with `LIBVA_DRIVER_NAME=iHD`
- [x] Verified without fix (using `LIBVA_DRIVER_NAME=nvidia`):
  - `brave://gpu` shows Video Decode: Hardware accelerated (NVIDIA driver loads)
  - YouTube video **does not play** — black screen/spinner
  - Confirms the fix is necessary

Note: the non-hybrid NVIDIA desktop path is covered by unit tests (`hybrid-gpu-vaapi-intel-test.sh` cases 1, 3, 5) which assert `LIBVA_DRIVER_NAME=nvidia` is set when `omarchy-hw-hybrid-gpu` is not detected. No change to behavior on non-hybrid systems.