### PR TITLE
Make power profiles change the CPU on Intel machines without HWP

### DIFF
--- a/bin/omarchy-hw-intel-no-hwp
+++ b/bin/omarchy-hw-intel-no-hwp
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# omarchy:summary=Detect an Intel CPU without hardware P-states (pre-Skylake)
+
+# power-profiles-daemon steers the CPU through energy_performance_preference,
+# which only exists with HWP. Without it every profile is a no-op.
+
+cpuinfo="${OMARCHY_CPUINFO:-/proc/cpuinfo}"
+pstate="${OMARCHY_CPU_ROOT:-/sys/devices/system/cpu}/intel_pstate"
+
+omarchy-hw-intel &&
+  [[ -d $pstate ]] &&
+  ! grep -qEm1 "^flags.* hwp( |$)" "$cpuinfo"

--- a/bin/omarchy-powerprofiles-intel-no-hwp-apply
+++ b/bin/omarchy-powerprofiles-intel-no-hwp-apply
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# omarchy:summary=Apply CPU frequency limits for a power profile
+# omarchy:args=[performance|balanced|power-saver]
+# omarchy:hidden=true
+
+# On Intel CPUs without HWP (pre-Skylake) there is no energy_performance_preference
+# for power-profiles-daemon to write, so every profile leaves the CPU identical and
+# turbo stays unrestricted on battery. Supply the missing backend by mapping each
+# profile onto no_turbo and scaling_max_freq.
+
+CPU_ROOT="${OMARCHY_CPU_ROOT:-/sys/devices/system/cpu}"
+PSTATE="$CPU_ROOT/intel_pstate"
+
+if [[ ! -w $PSTATE/no_turbo ]]; then
+  exit 0
+fi
+
+profile="${1:-}"
+
+if [[ -z $profile ]]; then
+  profile=$(busctl get-property net.hadess.PowerProfiles /net/hadess/PowerProfiles \
+    net.hadess.PowerProfiles ActiveProfile 2>/dev/null | awk '{gsub(/"/, ""); print $2}')
+fi
+
+if [[ -z $profile ]]; then
+  exit 0
+fi
+
+# This unconditionally overwrites scaling_max_freq, which sounds like it could
+# fight a thermal daemon (thermald's Processor cooling devices, RAPL power
+# limits) that lowered it independently. It doesn't: those act as an
+# additional, separate ceiling via the kernel's cpufreq QoS layer, which the
+# governor intersects with whatever is written here -- the lower of the two
+# always wins, so this can only ever request a limit, never actually exceed a
+# thermal one.
+set_max_freq() {
+  local cpu
+  for cpu in "$CPU_ROOT"/cpu[0-9]*/cpufreq/scaling_max_freq; do
+    echo "$1" >"$cpu" 2>/dev/null
+  done
+}
+
+# Ask the kernel for the base clock rather than deriving it from a model table:
+# with turbo disabled scaling_max_freq reports the non-turbo maximum.
+max_freq=$(<"$CPU_ROOT/cpu0/cpufreq/cpuinfo_max_freq")
+echo 1 >"$PSTATE/no_turbo"
+base_freq=$(<"$CPU_ROOT/cpu0/cpufreq/scaling_max_freq")
+
+case $profile in
+  performance)
+    echo 0 >"$PSTATE/no_turbo"
+    set_max_freq "$max_freq"
+    ;;
+  balanced)
+    # Midway between base and full turbo: keeps headroom while trimming the top
+    # of the voltage curve, where the last few hundred MHz cost the most power.
+    echo 0 >"$PSTATE/no_turbo"
+    set_max_freq $(((base_freq + max_freq) / 2))
+    ;;
+  power-saver)
+    # no_turbo already clamps scaling_max_freq to the base clock.
+    set_max_freq "$max_freq"
+    ;;
+  *)
+    echo "Unknown power profile: $profile" >&2
+    exit 1
+    ;;
+esac
+
+logger -t omarchy-powerprofiles-intel-no-hwp \
+  "profile=$profile no_turbo=$(<"$PSTATE/no_turbo") max_freq=$(<"$CPU_ROOT/cpu0/cpufreq/scaling_max_freq")"

--- a/bin/omarchy-powerprofiles-intel-no-hwp-watch
+++ b/bin/omarchy-powerprofiles-intel-no-hwp-watch
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# omarchy:summary=Track the active power profile and apply CPU frequency limits
+# omarchy:hidden=true
+
+# power-profiles-daemon exposes no hook mechanism, so follow ActiveProfile over
+# D-Bus. Watching the property rather than wrapping omarchy-powerprofiles-set
+# also catches powerprofilesctl invoked directly.
+
+BUS="net.hadess.PowerProfiles"
+OBJECT="/net/hadess/PowerProfiles"
+
+omarchy-powerprofiles-intel-no-hwp-apply
+
+# Re-query on each signal instead of parsing the payload, so gdbus output
+# formatting is not load-bearing.
+gdbus monitor --system --dest "$BUS" --object-path "$OBJECT" 2>/dev/null |
+  while read -r line; do
+    if [[ $line == *ActiveProfile* ]]; then
+      omarchy-powerprofiles-intel-no-hwp-apply
+    fi
+  done

--- a/default/systemd/system-sleep/powerprofiles-intel-no-hwp
+++ b/default/systemd/system-sleep/powerprofiles-intel-no-hwp
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Reapply the CPU frequency limits for the active power profile after resume.
+# Resuming re-registers cpufreq and drops the limits omarchy-powerprofiles-intel-no-hwp-apply
+# set, and the D-Bus watcher only reacts to an actual profile change -- not to
+# resume -- so without this hook the previous profile's limits silently
+# disappear until the user switches profiles again.
+
+if [[ $1 == "post" ]]; then
+  omarchy-powerprofiles-intel-no-hwp-apply
+fi

--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -14,6 +14,7 @@ run_logged "$OMARCHY_INSTALL/hardware/vulkan.sh"
 run_logged "$OMARCHY_INSTALL/hardware/intel/video-acceleration.sh"
 run_logged "$OMARCHY_INSTALL/hardware/intel/lpmd.sh"
 run_logged "$OMARCHY_INSTALL/hardware/intel/thermald.sh"
+run_logged "$OMARCHY_INSTALL/hardware/intel/cpu-profile-limits.sh"
 # Swap in the Panther Lake kernel before anything pulls DKMS modules in.
 # intel-ipu7-camera drags in ipu7-drivers, vision-drivers and v4l2loopback,
 # and building all three against the stock kernel only to rebuild them against

--- a/install/hardware/intel/cpu-profile-limits.sh
+++ b/install/hardware/intel/cpu-profile-limits.sh
@@ -1,0 +1,45 @@
+# Make power profiles change the CPU on Intel machines without hardware P-states.
+#
+# power-profiles-daemon drives the CPU through energy_performance_preference,
+# which only exists with HWP (Skylake and newer). On older Intel laptops the
+# file is absent, so every profile leaves the CPU in an identical state and
+# turbo stays unrestricted on battery. Map the profiles onto no_turbo and
+# scaling_max_freq instead.
+
+if omarchy-hw-intel-no-hwp && omarchy-battery-present; then
+  echo "Detected Intel CPU without HWP, enabling CPU frequency limits for power profiles"
+
+  sudo tee /etc/systemd/system/omarchy-powerprofiles-intel-no-hwp-watch.service >/dev/null <<'EOF'
+[Unit]
+Description=Omarchy CPU Frequency Limits for Power Profiles (Intel, no HWP)
+# power-profiles-daemon is D-Bus activated (Type=dbus, BusName=...), so
+# querying or watching its ActiveProfile starts it on demand -- this only
+# needs D-Bus itself to be up. Do not add After=/Wants=power-profiles-daemon
+# here: the packaged unit is itself After=multi-user.target, while this unit
+# is (implicitly, via WantedBy=multi-user.target) Before=multi-user.target,
+# so ordering directly after it creates a cycle that systemd breaks by
+# dropping this unit's start job.
+After=dbus.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/omarchy-powerprofiles-intel-no-hwp-watch
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+  sudo systemctl enable omarchy-powerprofiles-intel-no-hwp-watch.service
+
+  # Resuming re-registers cpufreq and drops the limits, and the watcher only
+  # fires on an actual profile change, not on resume. A service ordered
+  # After=/WantedBy= the sleep targets is not a post-resume hook (that
+  # ordering fires around entering sleep, not waking from it, and can itself
+  # cycle against those targets) -- system-sleep is the real, kernel-driven
+  # pre/post hook mechanism, and this repo already uses it elsewhere.
+  sudo install -m 0755 -o root -g root \
+    "$OMARCHY_PATH/default/systemd/system-sleep/powerprofiles-intel-no-hwp" \
+    /usr/lib/systemd/system-sleep/powerprofiles-intel-no-hwp
+fi

--- a/migrations/1788983548.sh
+++ b/migrations/1788983548.sh
@@ -1,0 +1,6 @@
+echo "Enable CPU frequency limits for power profiles on Intel CPUs without HWP"
+
+if omarchy-hw-intel-no-hwp && omarchy-battery-present; then
+  source "$OMARCHY_PATH/install/hardware/intel/cpu-profile-limits.sh"
+  sudo systemctl start omarchy-powerprofiles-intel-no-hwp-watch.service
+fi

--- a/test/shell.d/cpu-profile-limits-test.sh
+++ b/test/shell.d/cpu-profile-limits-test.sh
@@ -1,0 +1,256 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+detector="$ROOT/bin/omarchy-hw-intel-no-hwp"
+apply="$ROOT/bin/omarchy-powerprofiles-intel-no-hwp-apply"
+leaf="$ROOT/install/hardware/intel/cpu-profile-limits.sh"
+all="$ROOT/install/hardware/all.sh"
+migration=$(grep -l "cpu-profile-limits" "$ROOT"/migrations/*.sh | head -1)
+
+grep -q 'run_logged .*hardware/intel/cpu-profile-limits.sh' "$all" ||
+  fail "the CPU profile limits run during hardware setup"
+pass "the CPU profile limits run during hardware setup"
+
+[[ -n $migration ]] || fail "a migration enables the limits on existing installs"
+pass "a migration enables the limits on existing installs"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+mkdir -p "$test_tmp/bin"
+
+cat >"$test_tmp/bin/omarchy-hw-intel" <<'SH'
+#!/bin/bash
+[[ ${TEST_IS_INTEL:-1} == 1 ]]
+SH
+
+cat >"$test_tmp/bin/logger" <<'SH'
+#!/bin/bash
+exit 0
+SH
+
+chmod +x "$test_tmp/bin"/*
+
+# --- detector -------------------------------------------------------------
+
+make_cpuinfo() {
+  local flags="$1"
+  printf 'vendor_id\t: GenuineIntel\nflags\t\t: %s\n' "$flags" >"$test_tmp/cpuinfo"
+}
+
+make_cpu_root() {
+  local root="$test_tmp/cpu"
+  rm -rf "$root"
+  mkdir -p "$root/intel_pstate" "$root/cpu0/cpufreq" "$root/cpu1/cpufreq"
+  printf '0\n' >"$root/intel_pstate/no_turbo"
+  printf '%s\n' "${1:-4000000}" >"$root/cpu0/cpufreq/cpuinfo_max_freq"
+  printf '%s\n' "${2:-2800000}" >"$root/cpu0/cpufreq/scaling_max_freq"
+  printf '%s\n' "${2:-2800000}" >"$root/cpu1/cpufreq/scaling_max_freq"
+  echo "$root"
+}
+
+run_detector() {
+  PATH="$test_tmp/bin:$PATH" \
+    TEST_IS_INTEL="${1:-1}" \
+    OMARCHY_CPUINFO="$test_tmp/cpuinfo" \
+    OMARCHY_CPU_ROOT="${2:-$(make_cpu_root)}" \
+    bash "$detector"
+}
+
+make_cpuinfo "fpu vme de pse tsc msr"
+run_detector || fail "the detector matches an Intel CPU without HWP"
+pass "the detector matches an Intel CPU without HWP"
+
+make_cpuinfo "fpu vme de hwp hwp_notify hwp_act_window"
+run_detector && fail "the detector rejects a CPU with HWP"
+pass "the detector rejects a CPU with HWP"
+
+make_cpuinfo "fpu vme de pse tsc msr"
+run_detector 0 && fail "the detector rejects a non-Intel CPU"
+pass "the detector rejects a non-Intel CPU"
+
+run_detector 1 "$test_tmp/missing" && fail "the detector rejects a CPU without intel_pstate"
+pass "the detector rejects a CPU without intel_pstate"
+
+# --- apply ----------------------------------------------------------------
+
+run_apply() {
+  local root="$1" profile="$2"
+  PATH="$test_tmp/bin:$PATH" OMARCHY_CPU_ROOT="$root" bash "$apply" "$profile"
+}
+
+root=$(make_cpu_root 4000000 2800000)
+run_apply "$root" performance || fail "performance applies cleanly"
+[[ $(<"$root/intel_pstate/no_turbo") == 0 ]] || fail "performance re-enables turbo"
+[[ $(<"$root/cpu0/cpufreq/scaling_max_freq") == 4000000 ]] || fail "performance uses full turbo"
+pass "performance uses full turbo"
+
+root=$(make_cpu_root 4000000 2800000)
+run_apply "$root" balanced || fail "balanced applies cleanly"
+[[ $(<"$root/intel_pstate/no_turbo") == 0 ]] || fail "balanced keeps turbo enabled"
+[[ $(<"$root/cpu0/cpufreq/scaling_max_freq") == 3400000 ]] ||
+  fail "balanced caps midway between base and turbo"
+pass "balanced caps midway between base and turbo"
+
+root=$(make_cpu_root 4000000 2800000)
+run_apply "$root" power-saver || fail "power-saver applies cleanly"
+[[ $(<"$root/intel_pstate/no_turbo") == 1 ]] || fail "power-saver disables turbo"
+pass "power-saver disables turbo"
+
+# Every core must be capped, not just cpu0.
+root=$(make_cpu_root 4000000 2800000)
+run_apply "$root" balanced
+[[ $(<"$root/cpu1/cpufreq/scaling_max_freq") == 3400000 ]] ||
+  fail "the cap applies to every core"
+pass "the cap applies to every core"
+
+# A different SKU must derive its own frequencies rather than reuse constants.
+root=$(make_cpu_root 3600000 2400000)
+run_apply "$root" balanced
+[[ $(<"$root/cpu0/cpufreq/scaling_max_freq") == 3000000 ]] ||
+  fail "the frequencies derive from the CPU rather than a model table"
+pass "the frequencies derive from the CPU rather than a model table"
+
+root=$(make_cpu_root 4000000 2800000)
+run_apply "$root" nonsense 2>/dev/null && fail "an unknown profile fails"
+pass "an unknown profile fails"
+
+root=$(make_cpu_root 4000000 2800000)
+chmod -w "$root/intel_pstate/no_turbo"
+run_apply "$root" balanced || fail "a read-only pstate is a no-op rather than an error"
+pass "a read-only pstate is a no-op rather than an error"
+chmod +w "$root/intel_pstate/no_turbo"
+
+# --- leaf -----------------------------------------------------------------
+#
+# Grep-only coverage caught none of the ordering bugs this branch shipped
+# with: a watch unit that cycled against multi-user.target through the real
+# power-profiles-daemon.service unit, and a "resume" unit that was never
+# actually a post-resume hook. Actually run the leaf against a faked root and
+# inspect what it generates, then hand the real generated unit to
+# `systemd-analyze verify` together with the real target units, the same way
+# the original cycle was found and confirmed fixed by hand.
+
+grep -q 'omarchy-hw-intel-no-hwp' "$leaf" || fail "the leaf gates on the detector"
+grep -q 'omarchy-battery-present' "$leaf" || fail "the leaf gates on a battery"
+pass "the leaf gates on the detector and a battery"
+
+sleep_hook="$ROOT/default/systemd/system-sleep/powerprofiles-intel-no-hwp"
+[[ -x $sleep_hook ]] || fail "the resume hook exists and is executable"
+grep -qE '^\s*if \[\[ \$1 == "post" \]\]; then$' "$sleep_hook" ||
+  fail "the resume hook only fires on the post-resume call, not pre-suspend"
+pass "the resume hook exists, is executable, and only fires post-resume"
+
+leaf_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp" "$leaf_tmp"' EXIT
+mkdir -p "$leaf_tmp/bin" "$leaf_tmp/etc/systemd/system" "$leaf_tmp/usr/lib/systemd/system-sleep"
+calls="$leaf_tmp/calls.log"
+
+cat >"$leaf_tmp/bin/omarchy-hw-intel-no-hwp" <<'SH'
+#!/bin/bash
+[[ ${LEAF_MATCH:-1} == 1 ]]
+SH
+
+cat >"$leaf_tmp/bin/omarchy-battery-present" <<'SH'
+#!/bin/bash
+[[ ${LEAF_BATTERY:-1} == 1 ]]
+SH
+
+cat >"$leaf_tmp/bin/sudo" <<'SH'
+#!/bin/bash
+printf 'sudo' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+exec "$@"
+SH
+
+cat >"$leaf_tmp/bin/systemctl" <<'SH'
+#!/bin/bash
+printf 'systemctl' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+SH
+
+# The real `install -o root -g root` fails for a non-root test user; log the
+# call and copy the file, dropping ownership (mode is what the test cares
+# about) rather than chowning.
+cat >"$leaf_tmp/bin/install" <<'SH'
+#!/bin/bash
+printf 'install' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+
+mode=0644
+args=("$@")
+last=$((${#args[@]} - 1))
+src="${args[$((last - 1))]}"
+dst="${args[$last]}"
+
+for ((i = 0; i < last - 1; i++)); do
+  [[ ${args[$i]} == -m ]] && mode="${args[$((i + 1))]}"
+done
+
+cp -f -- "$src" "$dst" && chmod "$mode" -- "$dst"
+SH
+
+chmod +x "$leaf_tmp/bin"/*
+
+unit="$leaf_tmp/etc/systemd/system/omarchy-powerprofiles-intel-no-hwp-watch.service"
+installed_hook="$leaf_tmp/usr/lib/systemd/system-sleep/powerprofiles-intel-no-hwp"
+
+run_leaf() {
+  local script="$leaf_tmp/leaf.sh"
+  rm -f "$unit" "$installed_hook"
+  : >"$calls"
+  sed -e "s|/etc/systemd/system|$leaf_tmp/etc/systemd/system|g" \
+    -e "s|/usr/lib/systemd/system-sleep|$leaf_tmp/usr/lib/systemd/system-sleep|g" \
+    "$leaf" >"$script"
+  LEAF_MATCH="${1:-1}" LEAF_BATTERY="${2:-1}" OMARCHY_PATH="$ROOT" \
+    TEST_LOG="$calls" PATH="$leaf_tmp/bin:$PATH" \
+    bash -eE -o pipefail -c 'source "$1"' bash "$script" </dev/null
+}
+
+run_leaf 0 1 >/dev/null
+[[ ! -f $unit ]] || fail "the leaf is a no-op without matching hardware"
+pass "the leaf is a no-op without matching hardware"
+
+run_leaf 1 0 >/dev/null
+[[ ! -f $unit ]] || fail "the leaf is a no-op without a battery"
+pass "the leaf is a no-op without a battery"
+
+run_leaf 1 1 >/dev/null
+[[ -f $unit ]] || fail "matching hardware gets the watch unit installed"
+grep -qE '^After=dbus\.service$' "$unit" ||
+  fail "the generated unit orders after dbus.service"
+grep -qE '^(After|Wants)=.*power-profiles-daemon' "$unit" &&
+  fail "the generated unit must not order after/want power-profiles-daemon.service directly: the packaged unit is itself After=multi-user.target while this unit is (implicitly) Before=multi-user.target, so that ordering is a cycle systemd breaks by dropping this unit's start job" "$(cat "$unit")"
+grep -q $'systemctl\tenable\tomarchy-powerprofiles-intel-no-hwp-watch.service' "$calls" ||
+  fail "the watch unit gets enabled" "$(cat "$calls")"
+[[ -x $installed_hook ]] || fail "the resume hook is installed and made executable"
+cmp -s "$installed_hook" "$sleep_hook" ||
+  fail "the installed hook is the repo's copy, not a divergent inline one"
+pass "matching hardware installs the watch unit (ordered after dbus, not PPD) and the resume hook"
+
+# Re-running must not fail or duplicate anything -- an existing install
+# running the migration, or a fresh install re-running hardware setup.
+run_leaf 1 1 >/dev/null
+[[ -f $unit && -x $installed_hook ]] || fail "re-running the leaf is idempotent"
+pass "re-running the leaf is idempotent"
+
+if command -v systemd-analyze >/dev/null; then
+  check_unit="$leaf_tmp/check.service"
+  sed 's#^ExecStart=.*#ExecStart=/usr/bin/true#' "$unit" >"$check_unit"
+
+  # Force the real power-profiles-daemon.service and its targets into the
+  # graph: verifying the generated unit in isolation resolves referenced
+  # units too shallowly to reproduce the cycle this test guards against.
+  cycle_output=$(systemd-analyze verify multi-user.target graphical.target \
+    power-profiles-daemon.service "$check_unit" 2>&1) || true
+  [[ $cycle_output != *"ordering cycle"* ]] ||
+    fail "the generated unit has an ordering cycle against the real power-profiles-daemon.service unit" "$cycle_output"
+  pass "the generated unit has no ordering cycle against the real power-profiles-daemon.service unit"
+else
+  pass "systemd-analyze unavailable; skipping the live ordering-cycle check"
+fi


### PR DESCRIPTION
Targets older Intel CPUs without hardware P-states (anything pre-Skylake without the `hwp` CPU flag), verified on a **MacBookPro11,5 (15-inch MacBook Pro, Mid 2015, i7-4980HQ)**.

`power-profiles-daemon` steers Intel CPUs through `energy_performance_preference`, which only exists with HWP. On this hardware, `powerprofilesctl` itself reports `PlatformDriver: placeholder` for balanced and power-saver — PPD has no active backend here, so every profile leaves the CPU identical and turbo stays unrestricted on battery.

This maps the three profiles onto `no_turbo`/`scaling_max_freq` instead, watched over D-Bus so it reacts to `powerprofilesctl` too, plus a `system-sleep` hook to reapply the limits after resume (which otherwise drops them silently). Covered by a migration for existing installs, and an integration test that runs the install leaf against a faked root and validates the generated systemd unit with `systemd-analyze verify` against the real `power-profiles-daemon` unit graph.