### PR TITLE
Allow Dropbox bar quota override via quotaGB

### DIFF
--- a/shell/plugins/panels/dropbox/Service.qml
+++ b/shell/plugins/panels/dropbox/Service.qml
@@ -32,6 +32,16 @@ Item {
   property string lastError: ""
 
   readonly property int refreshIntervalSec: intSetting("refreshIntervalSec", 60, 10, 3600)
+  // Bind through `settings` so quotaGB updates when the bar injects shell.json
+  // entry settings (function-only reads are not tracked as QML dependencies).
+  readonly property int quotaGB: {
+    var s = settings
+    var n = parseInt(String(s && s.quotaGB !== undefined && s.quotaGB !== null ? s.quotaGB : 0), 10)
+    if (!isFinite(n)) n = 0
+    if (n < 0) n = 0
+    if (n > 5000) n = 5000
+    return n
+  }
   readonly property bool busy: statusProcess.running || loginProcess.running || controlProcess.running
   readonly property string helperPath: (omarchyPath || "") + "/shell/plugins/panels/dropbox/status.py"
 
@@ -83,6 +93,15 @@ Item {
     quotaBytes = Number(parsed.quotaBytes || 0)
     usagePercent = Number(parsed.usagePercent || 0)
     quotaKnown = parsed.quotaKnown === true
+    // Manual override for account extras (referrals) not present in info.json.
+    // Read settings at apply-time (not a stale bound property) so the first
+    // refresh after inject still sees quotaGB from shell.json.
+    var overrideGb = intSetting("quotaGB", 0, 0, 5000)
+    if (overrideGb > 0) {
+      quotaBytes = overrideGb * 1000000000
+      quotaKnown = true
+      usagePercent = quotaBytes > 0 ? (usedBytes / quotaBytes * 100) : 0
+    }
     files = parsed.files || []
     lastError = ""
   }

--- a/shell/plugins/panels/dropbox/manifest.json
+++ b/shell/plugins/panels/dropbox/manifest.json
@@ -19,7 +19,8 @@
     "allowMultiple": false,
     "defaultSection": "right",
     "defaults": {
-      "refreshIntervalSec": 60
+      "refreshIntervalSec": 60,
+      "quotaGB": 0
     },
     "schema": [
       {
@@ -30,6 +31,16 @@
         "max": 3600,
         "step": 5,
         "defaultValue": 60
+      },
+      {
+        "key": "quotaGB",
+        "type": "integer",
+        "label": "Storage quota (GB)",
+        "description": "Real Dropbox quota from dropbox.com/account, including referral bonus space. The Basic plan default of 2 GB ignores bonuses. Set 0 to use the plan default.",
+        "min": 0,
+        "max": 5000,
+        "step": 1,
+        "defaultValue": 0
       }
     ]
   }


### PR DESCRIPTION
## Summary
- Adds an optional `quotaGB` setting on `omarchy.dropbox` so referral bonus (and other non-plan) storage can be reflected in the Stored line.
- Default `0` keeps today’s plan-table behavior (`Basic` → 2 GB).
- Settings binding is reactive, and the override is also applied at status refresh time so the first paint after inject is correct.

Related discussion: https://github.com/omacom/omarchy/discussions/11422

## Usage
```bash
omarchy bar set omarchy.dropbox quotaGB 14
```

## Test plan
- [x] Local clone with `quotaGB: 14` shows ~10.9 GB of 14 GB (was of 2 GB)
- [x] `./test/shell.d/dropbox-test.sh` passes
- [x] `./test/all` run; remaining shell failures are environment (missing `omarchy-pkgs`, multi-monitor IPC count, window animation) and unrelated to this change
- [ ] Reviewer: set `quotaGB`, open Dropbox panel, confirm Stored / percentage match dropbox.com/account