### PR TITLE
Support mounting and unlocking internal and LVM-backed storage in UDisks

### DIFF
--- a/etc/polkit-1/rules.d/10-udisks2.rules
+++ b/etc/polkit-1/rules.d/10-udisks2.rules
@@ -1,0 +1,8 @@
+// Allow users in the wheel group to mount and unlock internal/system devices without entering an administrator password
+polkit.addRule(function(action, subject) {
+  if ((action.id == "org.freedesktop.udisks2.filesystem-mount-system" ||
+       action.id == "org.freedesktop.udisks2.encrypted-unlock-system") &&
+      subject.isInGroup("wheel")) {
+    return polkit.Result.YES;
+  }
+});

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -130,6 +130,7 @@ ttf-ia-writer
 ttf-jetbrains-mono-nerd-basic
 tzupdate
 udiskie
+udisks2-lvm2
 ufw
 ufw-docker
 unzip

--- a/migrations/1789167572.sh
+++ b/migrations/1789167572.sh
@@ -1,0 +1,12 @@
+echo "Support unlocking and mounting internal and LVM-backed drives"
+
+omarchy-pkg-add udisks2-lvm2
+
+if [[ ! -f /etc/polkit-1/rules.d/10-udisks2.rules ]]; then
+  sudo mkdir -p /etc/polkit-1/rules.d
+  sudo install -Dm644 "$OMARCHY_PATH/etc/polkit-1/rules.d/10-udisks2.rules" /etc/polkit-1/rules.d/10-udisks2.rules
+fi
+
+if systemctl is-active --quiet udisks2.service 2>/dev/null; then
+  sudo systemctl restart udisks2.service
+fi


### PR DESCRIPTION
## Summary

- **Single password prompt for internal encrypted drives**: When unlocking or mounting internal drives (e.g. secondary internal NVMe/SATA disks) via the UI file manager (Nautilus / UDisks2), UDisks flags internal disks as system devices (`HintSystem=true`). By default in Polkit, `org.freedesktop.udisks2.encrypted-unlock-system` and `org.freedesktop.udisks2.filesystem-mount-system` require admin authentication. For encrypted disks, this results in two simultaneous password prompts: one for the LUKS passphrase, and one from the Polkit agent for the user's account password. This PR adds `/etc/polkit-1/rules.d/10-udisks2.rules` allowing users in `wheel` to unlock and mount system disks without an admin password prompt.
- **LVM2 support in UDisks**: Adds `udisks2-lvm2` to `install/omarchy-base.packages` and includes an idempotent migration script. Many users dual-booting or migrating storage from distributions like Fedora or Ubuntu have disks partitioned with LVM or LVM-on-LUKS. Without `udisks2-lvm2`, decrypted LUKS containers containing LVM physical volumes are not scanned or activated into logical volumes, leaving them unmountable in the file manager.

## Discussion / Design Question

**Core default vs. dedicated setup wizard?**
We implemented this directly in core defaults so that secondary internal disks and LVM-on-LUKS drives "just work" in the desktop environment without manual post-install configuration. 

However, would maintainers prefer keeping the base package set lean and having this as an opt-in setup command instead (for example, `omarchy setup storage lvm` or `omarchy setup storage internal-disks`)? Happy to adapt this into a setup wizard command if preferred!

## Test Plan

- [x] Tested on Omarchy Quattro with internal NVMe disks containing LUKS2 + LVM2 volumes.
- [x] Verified Polkit rule eliminates the redundant admin password prompt when unlocking and mounting volumes via Nautilus/udisks2.
- [x] Verified `udisks2-lvm2` automatically activates LVM volume groups inside unlocked containers and exposes logical volume filesystems for mounting.
- [x] `./test/cli` passes cleanly.
