### PR TITLE
Include windows from all visible displays in screenshot picker

### DIFF
--- a/bin/omarchy-capture-region
+++ b/bin/omarchy-capture-region
@@ -37,20 +37,19 @@ JQ_MONITOR_GEO='
     end;
 '
 
-active_workspace() {
-  hyprctl monitors -j | jq -r '.[] | select(.focused == true) | .activeWorkspace.id'
-}
-
-# Hidden group members and windows stacked at identical geometry collapse to
-# one rectangle: slurp cannot tell them apart, and duplicates would stall the
-# Tab cycle on the first copy.
+# Each independent display exposes a different active workspace.
+# Include visible special workspaces too, but never hidden workspace contents.
 window_rects() {
-  hyprctl clients -j | jq -r --arg ws "$(active_workspace)" \
-    '[.[] | select(.workspace.id == ($ws | tonumber) and .hidden != true) | "\(.at[0]),\(.at[1]) \(.size[0])x\(.size[1])"] | unique[]'
+  local visible
+  visible=$(hyprctl monitors -j | jq '[.[] | select(.disabled != true) |
+    .activeWorkspace.id, (.specialWorkspace.id // 0) | select(. != null and . != 0)]') || return
+  hyprctl clients -j | jq -r --argjson visible "$visible" \
+    '[.[] | select(.hidden != true) | select(.workspace.id as $id | $visible | index($id)) |
+      "\(.at[0]),\(.at[1]) \(.size[0])x\(.size[1])"] | unique[]'
 }
 
 monitor_rects() {
-  hyprctl monitors -j | jq -r --arg ws "$(active_workspace)" "${JQ_MONITOR_GEO} .[] | select(.activeWorkspace.id == (\$ws | tonumber)) | format_geo"
+  hyprctl monitors -j | jq -r "${JQ_MONITOR_GEO} .[] | select(.disabled != true) | format_geo"
 }
 
 get_rectangles() {

--- a/test/shell.d/capture-multiple-displays-test.sh
+++ b/test/shell.d/capture-multiple-displays-test.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -euo pipefail
+source "$(dirname -- "${BASH_SOURCE[0]}")/base-test.sh"
+require_command jq
+
+# Load the rectangle helpers without starting the interactive picker.
+source <(sed '/^if \[\[ ${1:-} == "--take-fullscreen"/,$d' "$ROOT/bin/omarchy-capture-region")
+
+hyprctl() {
+  case "$1" in
+  monitors)
+    cat <<'JSON'
+[{"focused":true,"x":0,"y":0,"width":2880,"height":1800,"scale":2,"transform":0,"activeWorkspace":{"id":1},"specialWorkspace":{"id":0}},
+ {"focused":false,"x":-1920,"y":-200,"width":1920,"height":1080,"scale":1,"transform":0,"activeWorkspace":{"id":6},"specialWorkspace":{"id":-99}}]
+JSON
+    ;;
+  clients)
+    cat <<'JSON'
+[{"workspace":{"id":1},"at":[10,20],"size":[700,800]},
+ {"workspace":{"id":6},"at":[-1900,-180],"size":[900,1000]},
+ {"workspace":{"id":6},"at":[-1900,-180],"size":[900,1000]},
+ {"workspace":{"id":2},"at":[100,100],"size":[400,400]},
+ {"workspace":{"id":6},"hidden":true,"at":[200,200],"size":[300,300]},
+ {"workspace":{"id":-99},"at":[-1000,0],"size":[500,500]},
+ {"workspace":{"id":-98},"at":[300,300],"size":[200,200]}]
+JSON
+    ;;
+  esac
+}
+
+actual=$(window_rects)
+expected=$(printf '%s\n' '-1000,0 500x500' '-1900,-180 900x1000' '10,20 700x800')
+[[ $actual == "$expected" ]] || fail "visible windows from every display, without hidden or duplicate rectangles" "$actual"
+pass "visible windows from every display, without hidden or duplicate rectangles"
+actual=$(monitor_rects)
+[[ $actual == $'0,0 1440x900\n-1920,-200 1920x1080' ]] || fail "all display rectangles retain logical scale and negative origins" "$actual"
+pass "all display rectangles retain logical scale and negative origins"
+[[ $(focused_monitor_geo) == "0,0 1440x900" ]] || fail "fullscreen still targets focused display"
+pass "fullscreen still targets focused display"
+resolve_rect_at -1800 -100 < <(window_rects)
+[[ $RESOLVED_RECT == '-1900,-180 900x1000' ]] || fail "click resolves a window on the unfocused display"
+pass "click resolves a window on the unfocused display"


### PR DESCRIPTION
With two displays showing different workspaces, the smart/windows screenshot picker only offers windows and the monitor rectangle from the focused display. Clicking a window on the other display cannot snap to it. This also affects the rectangle list used by keyboard window selection.

Collect visible workspace IDs from all active displays (including an open special workspace), and include every active monitor rectangle. Continue excluding hidden clients and deduplicating identical rectangles. Fullscreen capture still targets the focused monitor.

Validation:
- Added fixture-based regression coverage for an unfocused display, inactive/hidden clients, visible special workspaces, duplicate rectangles, mixed scales, negative origins, and click resolution.
- The new test fails against the original code and passes with the fix.
- Checked the live rectangle list on Hyprland 0.56.2 with a 2880×1800 display at scale 2 and a 3840×2160 display at scale 1.5: windows on both visible workspaces are included.
- Draft pending recorded end-to-end picker interaction. No personal desktop captures are attached.
- `./test/all` was started; observed failures so far are missing sibling `omarchy-pkgs` checkout coverage and `a roomy window animates`. The aggregate run is still in progress; no claim that the full suite passes.
