### PR TITLE
Add GitLab Duo CLI as a default coding agent

### DIFF
--- a/bin/omarchy-agent
+++ b/bin/omarchy-agent
@@ -46,7 +46,9 @@ if [[ -z $agent ]]; then
   exit 1
 fi
 
-if omarchy-cmd-missing "$agent"; then
+agent_command=$agent
+[[ $agent == "duo" ]] && agent_command=glab
+if omarchy-cmd-missing "$agent_command"; then
   echo "$agent is not installed. Choose an installed agent with: omarchy default agent <name>" >&2
   exit 1
 fi
@@ -54,6 +56,11 @@ fi
 # Agents launched from the keybinding or menu run unattended, so each one starts
 # with its own spelling of "don't stop to ask". Pi and Ori have none to skip.
 case "$agent" in
+duo)
+  command=(omarchy-launch-duo)
+  [[ $inline == "false" && -n ${prompt:-} ]] && command+=(--hold)
+  [[ -n ${prompt:-} ]] && command+=(--prompt "$prompt")
+  ;;
 opencode)
   command=(opencode --auto)
   [[ -n ${prompt:-} ]] && command+=(--prompt "$prompt")

--- a/bin/omarchy-default-agent
+++ b/bin/omarchy-default-agent
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # omarchy:summary=Set and launch the default coding agent
-# omarchy:args=[pi|omp|opencode|ori|claude|codex|grok|openclaw|agy|hermes|copilot|crush|cursor-agent|muse]
+# omarchy:args=[pi|omp|opencode|ori|claude|codex|duo|grok|openclaw|agy|hermes|copilot|crush|cursor-agent|muse]
 # omarchy:examples=omarchy default agent | omarchy default agent codex | omarchy default agent claude
 
 installing=false
@@ -30,6 +30,7 @@ opencode | open-code) agent="opencode"; name="OpenCode" ;;
 ori | openrouter) agent="ori"; name="Ori"; agent_package="github:OpenRouterLabs/ori-releases" ;;
 claude | claude-code) agent="claude"; name="Claude Code" ;;
 codex) agent="codex"; name="Codex" ;;
+duo) agent="duo"; name="GitLab Duo CLI"; agent_installer="omarchy-install-duo-cli" ;;
 crush) agent="crush"; name="Crush" ;;
 grok) agent="grok"; name="Grok"; agent_package="npm:@xai-official/grok" ;;
 openclaw) agent="openclaw"; name="OpenClaw"; agent_installer="omarchy-install-openclaw-cli" ;;
@@ -43,7 +44,7 @@ muse | muse-code | musecode)
   ;;
 cursor | cursor-agent) agent="cursor-agent"; name="Cursor CLI" ;;
 *)
-  echo "Usage: omarchy-default-agent <pi|omp|opencode|ori|claude|codex|grok|openclaw|agy|hermes|copilot|crush|cursor-agent|muse>"
+  echo "Usage: omarchy-default-agent <pi|omp|opencode|ori|claude|codex|duo|grok|openclaw|agy|hermes|copilot|crush|cursor-agent|muse>"
   exit 1
   ;;
 esac
@@ -79,7 +80,11 @@ fi
 
 if ! agent_install; then
   if [[ $installing == "true" ]]; then
-    echo "Could not install $name with mise" >&2
+    if [[ -n ${agent_installer:-} ]]; then
+      echo "Could not install $name using $agent_installer" >&2
+    else
+      echo "Could not install $name with mise" >&2
+    fi
   else
     echo "Could not set $name as the default coding agent" >&2
   fi

--- a/bin/omarchy-install-duo-cli
+++ b/bin/omarchy-install-duo-cli
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# omarchy:summary=Install GitLab Duo CLI through glab for the default agent
+# omarchy:args=[--check|--now]
+
+set -euo pipefail
+
+glab_supported() {
+  omarchy-cmd-present glab || return 1
+  local version
+  version=$(glab --version) || return 1
+  [[ $version =~ ^glab[[:space:]]([0-9]+\.[0-9]+\.[0-9]+) ]] || return 1
+  (( $(vercmp "${BASH_REMATCH[1]}" "1.107.0") >= 0 ))
+}
+
+duo_installed() {
+  glab_supported || return 1
+  local binary
+  binary=${GLAB_DUO_CLI_BINARY_PATH:-$(glab config get duo_cli_binary_path --global 2>/dev/null)}
+  [[ -n $binary && -x $binary ]]
+}
+
+case "${1:---now}" in
+--check)
+  duo_installed
+  ;;
+--now)
+  if ! glab_supported; then
+    mise use -g glab@latest
+    if ! glab_supported; then
+      echo "GitLab Duo CLI requires glab 1.107.0 or later on PATH." >&2
+      exit 1
+    fi
+  fi
+  if ! duo_installed; then
+    omarchy-setup-duo
+    glab duo cli --install --yes
+  fi
+  ;;
+*)
+  echo "Usage: omarchy-install-duo-cli [--check|--now]" >&2
+  exit 1
+  ;;
+esac

--- a/bin/omarchy-launch-duo
+++ b/bin/omarchy-launch-duo
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# omarchy:summary=Launch GitLab Duo CLI using glab authentication
+# omarchy:args=[--hold] [--prompt <prompt>]
+
+hold=false
+prompt=""
+while (($#)); do
+  case "$1" in
+  --hold) hold=true; shift ;;
+  --prompt) prompt=${2:?--prompt needs a value}; shift 2 ;;
+  *) echo "Usage: omarchy-launch-duo [--hold] [--prompt <prompt>]" >&2; exit 1 ;;
+  esac
+done
+
+if [[ -n $prompt ]]; then
+  # Duo's TUI has no initial-prompt option. Bind the goal with = so glab's own
+  # flag parser cannot consume a prompt consisting of --update, --yes, etc.
+  glab duo cli --yes --dangerously-skip-permissions run "--goal=$prompt"
+  status=$?
+  if [[ $hold == "true" ]]; then
+    printf '\nGitLab Duo CLI exited with status %s. Press Enter to close.\n' "$status"
+    read -r _
+  fi
+  exit "$status"
+else
+  exec glab duo cli --yes --dangerously-skip-permissions
+fi

--- a/bin/omarchy-setup-duo
+++ b/bin/omarchy-setup-duo
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# omarchy:summary=Choose a GitLab instance and authenticate Duo with browser OAuth
+# omarchy:args=[hostname]
+# omarchy:examples=omarchy setup duo | omarchy setup duo gitlab.example.com
+
+set -euo pipefail
+
+if (( $# > 1 )); then
+  echo "Usage: omarchy-setup-duo [hostname]" >&2
+  exit 1
+fi
+
+if omarchy-cmd-missing glab; then
+  echo "Install glab first, or choose GitLab Duo CLI with: omarchy default agent duo" >&2
+  exit 1
+fi
+
+host=${1:-}
+if [[ -z $host ]]; then
+  host=$(gum input --header "GitLab hostname (GitLab.com or Self-Managed/Dedicated)" --value "gitlab.com")
+fi
+if [[ ! $host =~ ^[a-zA-Z0-9][a-zA-Z0-9.-]*(:[0-9]+)?$ ]]; then
+  echo "Enter a hostname such as gitlab.com or gitlab.example.com, without https:// or a path." >&2
+  exit 1
+fi
+
+if [[ $host != "gitlab.com" ]]; then
+  client_id=$(glab config get client_id --host "$host" 2>/dev/null || true)
+  if [[ -z $client_id ]]; then
+    echo "Create a non-confidential OAuth application on https://$host."
+    echo "Redirect URI: http://localhost:7171/auth/redirect"
+    echo "Scopes: openid, profile, read_user, write_repository, api"
+    echo "https://docs.gitlab.com/cli/authentication/#oauth-gitlab-self-managed-gitlab-dedicated"
+    client_id=$(gum input --header "OAuth Application ID (not the client secret)")
+    [[ -n $client_id ]] || exit 1
+    glab config set client_id "$client_id" --host "$host"
+  fi
+  echo "GitLab 19.2+: Admin > GitLab Duo > Change configuration > Turn on GitLab Duo CLI access."
+  echo "GitLab 18.11–19.1 requires beta and experimental features to be enabled."
+fi
+
+glab auth login --hostname "$host" --web
+# Desktop launches may have no GitLab remote. Let glab's normal host resolution
+# use this instance as its fallback, while retaining per-repository selection.
+glab config set host "$host" --global
+echo "Duo also needs Agent Platform access and a default Duo namespace or an eligible project."

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -141,6 +141,7 @@
   "setup.default.agent.copilot": {"icon":"","label":"Copilot","checked":"[[ \"$(omarchy-default-agent)\" == \"copilot\" ]]","action":"omarchy-default-agent copilot"},
   "setup.default.agent.crush": {"icon":"󰋑","label":"Crush","checked":"[[ \"$(omarchy-default-agent)\" == \"crush\" ]]","action":"omarchy-default-agent crush"},
   "setup.default.agent.cursor-agent": {"icon":"","iconFont":"omarchy","label":"Cursor CLI","checked":"[[ \"$(omarchy-default-agent)\" == \"cursor-agent\" ]]","action":"omarchy-default-agent cursor-agent"},
+  "setup.default.agent.duo": {"icon":"","label":"GitLab Duo CLI","checked":"[[ \"$(omarchy-default-agent)\" == \"duo\" ]]","action":"omarchy-default-agent duo"},
   "setup.default.agent.grok": {"icon":"","iconFont":"omarchy","label":"Grok","checked":"[[ \"$(omarchy-default-agent)\" == \"grok\" ]]","action":"omarchy-default-agent grok"},
   "setup.default.agent.hermes": {"icon":"","iconFont":"omarchy","label":"Hermes","checked":"[[ \"$(omarchy-default-agent)\" == \"hermes\" ]]","action":"omarchy-default-agent hermes"},
   "setup.default.agent.muse": {"icon":"󰛤","label":"Muse Code","checked":"[[ \"$(omarchy-default-agent)\" == \"muse\" ]]","action":"omarchy-default-agent muse"},

--- a/manual/17-ai.md
+++ b/manual/17-ai.md
@@ -32,6 +32,18 @@ Once you've chosen, `Super + Shift + Ctrl + A` launches the default agent in a d
 
 There are terminal shortcuts too: `a` runs the default agent inline in the current terminal, while `c`, `cx`, and `cy` start OpenCode, Claude Code, and Codex directly (again in their auto-approving modes). Theme changes sync to the agents as well: Claude Code, Pi, OpenCode, and Hermes (once Hermes Desktop is installed) all follow along when you switch the Omarchy theme.
 
+### GitLab Duo CLI
+
+Select **GitLab Duo CLI** under _Setup > Defaults > Agent_, or run `omarchy default agent duo`. Omarchy installs `glab` through mise if needed, then installs Duo through `glab`. GitLab Duo CLI requires `glab` 1.107.0 or later and uses its OAuth credentials. To update Duo, run `glab duo cli --update`.
+
+During first-time setup, enter `gitlab.com` or your GitLab Self-Managed/Dedicated hostname and authorize access in your browser. Run `omarchy setup duo [hostname]` to authenticate again or choose another default instance. GitLab CLI retains credentials per host; its normal repository and environment-based host selection still applies, with the chosen instance as the fallback for desktop launches outside GitLab repositories.
+
+For Self-Managed/Dedicated, create an OAuth application with **Confidential** unchecked, redirect URI `http://localhost:7171/auth/redirect`, and scopes `openid`, `profile`, `read_user`, `write_repository`, and `api`. Setup asks for the Application ID if none is configured for the host. See [GitLab's OAuth instructions](https://docs.gitlab.com/cli/authentication/#oauth-gitlab-self-managed-gitlab-dedicated).
+
+On Self-Managed/Dedicated, GitLab 19.2 or later requires Duo CLI access under _Admin > GitLab Duo > Change configuration > Turn on GitLab Duo CLI access_ (enabled by default). GitLab 18.11–19.1 requires beta and experimental features. Your account also needs Duo Agent Platform access and either a default Duo namespace or a project with Duo access. For desktop launches outside GitLab projects, choose an eligible group under _GitLab Preferences > Default GitLab Duo group_. See [GitLab's setup prerequisites](https://docs.gitlab.com/user/gitlab_duo_cli/set_up/).
+
+`omarchy agent` opens Duo's interactive chat. Duo currently accepts initial prompts only in headless mode, so `omarchy agent prompt "Review this project"` runs a single workflow and keeps its terminal open until you press Enter. With `--inline`, it returns directly to your shell with Duo's exit status. These launches use Duo's automatic tool-approval mode, like Omarchy's other default agents.
+
 ### The agents panel
 
 The top bar grows an agents icon the first time Omarchy finds AI coding usage on the machine (and stays out of the way until then). The panel behind it tracks every subscription in one place: your plan, the percentage used of the 5-hour session and weekly limits (or the remaining prepaid balance), and token usage by day and by model. Claude Code, Codex, and Fireworks are covered out of the box.

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -108,7 +108,7 @@ Item {
   property int dividerHeight: Style.space(17)
   property bool searchDivider: false
   property int layoutSerial: 0
-  property int cardWidth: Math.min(root.dmenuActive ? Style.space(root.dmenuWidth) : ((root.activeMenu === "trigger.capture.screenrecord" || root.activeMenu === "style.font") ? Style.space(520) : Style.space(300)), panel.width - Style.gapsOut * 2)
+  property int cardWidth: Math.min(root.dmenuActive ? Style.space(root.dmenuWidth) : ((root.activeMenu === "trigger.capture.screenrecord" || root.activeMenu === "style.font") ? Style.space(520) : (root.activeMenu === "setup.default.agent" ? Style.space(340) : Style.space(300))), panel.width - Style.gapsOut * 2)
   property int visibleRowsHeight: root.dmenuActive ? dmenuRowListHeight(layoutSerial, displayModel.count, filterText) : rowListHeight(layoutSerial, displayModel.count, filterText, searchDivider)
   property int cardHeight: root.dmenuActive
     ? Math.min(contentMargin * 2 + headerHeight + (mode === "input" ? 0 : contentSpacing + visibleRowsHeight), panel.height - Style.gapsOut * 2)
@@ -156,9 +156,10 @@ Item {
     var available = panel.height - top - Style.gapsOut - root.contentMargin * 2 - root.headerHeight - root.contentSpacing
     // The starting menu sets the ceiling along with the offset: drilling into
     // a longer submenu scrolls behind the fold instead of growing the card.
-    if (panel.maxRowsHeight >= 0) available = Math.min(available, panel.maxRowsHeight)
+    if (panel.maxRowsHeight >= 0 && root.activeMenu !== "setup.default.agent") available = Math.min(available, panel.maxRowsHeight)
     // A card that swallows the whole screen reads as a page, not a menu.
-    return Math.min(available, Math.round(panel.height * 0.7))
+    var maxRatio = root.activeMenu === "setup.default.agent" ? 0.88 : 0.7
+    return Math.min(available, Math.round(panel.height * maxRatio))
   }
 
   // When every row fits, the list gets its full height. When they don't,
@@ -669,6 +670,20 @@ Item {
           return 0
         })
       }
+
+      if (active === "setup.default.agent") {
+        rows.sort(function(a, b) {
+          var aLabel = String(a.label || "").toLowerCase()
+          var bLabel = String(b.label || "").toLowerCase()
+          if (aLabel < bLabel) return -1
+          if (aLabel > bLabel) return 1
+          var aId = String(a.itemId || "")
+          var bId = String(b.itemId || "")
+          if (aId < bId) return -1
+          if (aId > bId) return 1
+          return 0
+        })
+      }
     }
 
     for (var k = 0; k < rows.length; k++) displayModel.append(rows[k])
@@ -1081,7 +1096,7 @@ Item {
     property int cardTop: -1
     property int maxRowsHeight: -1
     readonly property int centeredTop: Math.max(Style.gapsOut, Math.round((height - root.cardHeight) / 2))
-    readonly property int effectiveCardTop: cardTop >= 0 ? cardTop : centeredTop
+    readonly property int effectiveCardTop: cardTop >= 0 ? Math.max(Style.gapsOut, Math.min(cardTop, height - Style.gapsOut - root.cardHeight)) : centeredTop
     function freezeCardTop() {
       if (visible && cardTop < 0) {
         cardTop = effectiveCardTop

--- a/test/shell.d/duo-agent-test.sh
+++ b/test/shell.d/duo-agent-test.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+
+set -euo pipefail
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+export HOME="$test_tmp/home"
+export XDG_CONFIG_HOME="$HOME/.config"
+export XDG_DATA_HOME="$HOME/.local/share"
+export OMARCHY_PATH="$ROOT"
+export DUO_TEST_LOG="$test_tmp/calls"
+export DUO_TEST_ARGS="$test_tmp/args"
+export DUO_TEST_BINARY="$test_tmp/duo"
+unset GLAB_DUO_CLI_BINARY_PATH
+mkdir -p "$HOME/.config/omarchy/defaults" "$test_tmp/bin"
+export PATH="$test_tmp/bin:$ROOT/bin:$PATH"
+
+cat >"$test_tmp/bin/glab" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$DUO_TEST_LOG"
+case "$*" in
+  --version) echo "glab ${DUO_TEST_VERSION:-1.117.0} (test)" ;;
+  "config get duo_cli_binary_path --global") echo "$DUO_TEST_BINARY" ;;
+  "config get client_id"*) echo "${DUO_TEST_CLIENT_ID:-}" ;;
+  "auth login"*) exit "${DUO_TEST_AUTH_STATUS:-0}" ;;
+  "duo cli --install --yes")
+    [[ ${DUO_TEST_INSTALL_FAIL:-false} == "false" ]] || exit 1
+    touch "$DUO_TEST_BINARY"
+    chmod +x "$DUO_TEST_BINARY"
+    ;;
+  "duo cli"*)
+    printf '%s\0' "$@" >"$DUO_TEST_ARGS"
+    exit "${DUO_TEST_RUN_STATUS:-0}"
+    ;;
+esac
+SH
+cat >"$test_tmp/bin/mise" <<'SH'
+#!/bin/bash
+printf 'mise %s\n' "$*" >>"$DUO_TEST_LOG"
+exit 1
+SH
+cat >"$test_tmp/bin/gum" <<'SH'
+#!/bin/bash
+case "$*" in
+  *"Application ID"*) echo "test-application-id" ;;
+  *) echo "${DUO_TEST_HOST:-gitlab.com}" ;;
+esac
+SH
+cat >"$test_tmp/bin/omarchy-launch-tui" <<'SH'
+#!/bin/bash
+printf '%s\0' "$@" >"$DUO_TEST_ARGS"
+SH
+cat >"$test_tmp/bin/omarchy-launch-floating-terminal-with-presentation" <<'SH'
+#!/bin/bash
+printf '%s\0' "$@" >"$DUO_TEST_ARGS"
+SH
+chmod +x "$test_tmp/bin/"*
+
+assert_args() {
+  local actual=() expected=("$@") index
+  mapfile -d '' -t actual <"$DUO_TEST_ARGS"
+  (( ${#actual[@]} == ${#expected[@]} )) || fail "Duo argument count" "${actual[*]}"
+  for ((index = 0; index < ${#expected[@]}; index++)); do
+    [[ ${actual[index]} == "${expected[index]}" ]] || fail "Duo literal argument $index" "${actual[*]}"
+  done
+}
+
+if omarchy-install-duo-cli --check; then
+  fail "glab alone must not count as an installed Duo"
+fi
+touch "$DUO_TEST_BINARY"
+chmod +x "$DUO_TEST_BINARY"
+omarchy-install-duo-cli --check || fail "supported glab and executable Duo count as installed"
+if DUO_TEST_VERSION=1.106.0 omarchy-install-duo-cli --check; then
+  fail "old glab must not count as supported"
+fi
+if DUO_TEST_VERSION=invalid omarchy-install-duo-cli --check; then
+  fail "unrecognized glab version must not count as supported"
+fi
+pass "Duo presence checks its executable and glab version without installing"
+
+printf 'opencode\n' >"$HOME/.config/omarchy/defaults/agent"
+rm "$DUO_TEST_BINARY"
+omarchy-default-agent duo
+assert_args omarchy-default-agent --install duo
+[[ $(omarchy-default-agent) == "opencode" ]] || fail "cold Duo selection waits for setup"
+
+for failure in DUO_TEST_AUTH_STATUS=1 DUO_TEST_INSTALL_FAIL=true; do
+  : >"$DUO_TEST_ARGS"
+  if env "$failure" omarchy-default-agent --install duo >"$test_tmp/failure" 2>&1; then
+    fail "failed Duo setup must fail selection"
+  fi
+  [[ $(omarchy-default-agent) == "opencode" ]] || fail "failed Duo setup preserves the default"
+  [[ ! -s $DUO_TEST_ARGS ]] || fail "failed Duo setup must not launch"
+done
+pass "Duo setup failures preserve the default and do not launch"
+
+: >"$DUO_TEST_LOG"
+omarchy-default-agent --install duo >"$test_tmp/install-output"
+[[ $(omarchy-default-agent) == "duo" ]] || fail "successful setup selects Duo"
+grep -Fx 'auth login --hostname gitlab.com --web' "$DUO_TEST_LOG" >/dev/null || fail "setup uses OAuth"
+grep -Fx 'config set host gitlab.com --global' "$DUO_TEST_LOG" >/dev/null || fail "setup saves desktop fallback host"
+assert_args duo cli --yes --dangerously-skip-permissions
+pass "first selection installs Duo through glab and launches inline after OAuth"
+
+: >"$DUO_TEST_LOG"
+omarchy-default-agent duo
+assert_args --app-id=org.omarchy.agent omarchy-launch-duo
+if grep -Eq 'auth login|duo cli --install|mise use' "$DUO_TEST_LOG"; then
+  fail "installed Duo selection must not repeat setup"
+fi
+pass "installed Duo selects without repeating OAuth or installation"
+
+: >"$DUO_TEST_LOG"
+omarchy-setup-duo gitlab.example.com >"$test_tmp/self-managed-output"
+grep -Fx 'config set client_id test-application-id --host gitlab.example.com' "$DUO_TEST_LOG" >/dev/null || fail "self-managed saves application ID per host"
+grep -Fx 'auth login --hostname gitlab.example.com --web' "$DUO_TEST_LOG" >/dev/null || fail "self-managed uses browser OAuth"
+grep -Fx 'config set host gitlab.example.com --global' "$DUO_TEST_LOG" >/dev/null || fail "self-managed sets fallback host"
+: >"$DUO_TEST_LOG"
+DUO_TEST_CLIENT_ID=existing omarchy-setup-duo gitlab.example.com >/dev/null
+if grep -q 'config set client_id' "$DUO_TEST_LOG"; then
+  fail "setup must preserve an existing client ID"
+fi
+: >"$DUO_TEST_LOG"
+if DUO_TEST_AUTH_STATUS=1 omarchy-setup-duo gitlab.example.com >/dev/null; then
+  fail "failed OAuth must fail setup"
+fi
+if grep -q 'config set host' "$DUO_TEST_LOG"; then
+  fail "failed OAuth must preserve the fallback host"
+fi
+if omarchy-setup-duo 'https://gitlab.example.com/path' >/dev/null 2>&1; then
+  fail "setup must reject URLs where a hostname is required"
+fi
+pass "self-managed OAuth preserves existing client IDs and changes host only after success"
+
+for prompt in '--update' '--yes' 'help' $'--goal !Crash {$(touch must-not-run)}\ntrailing\\ '; do
+  omarchy-agent-prompt "$prompt"
+  assert_args --app-id=org.omarchy.agent omarchy-launch-duo --hold --prompt "$prompt"
+  omarchy-agent-prompt --inline "$prompt"
+  assert_args duo cli --yes --dangerously-skip-permissions run "--goal=$prompt"
+done
+pass "Duo keeps option-like and multiline prompts literal through both launch paths"
+
+status=0
+DUO_TEST_RUN_STATUS=65 omarchy-agent-prompt --inline "Review this project" || status=$?
+(( status == 65 )) || fail "inline prompt must preserve Duo's failure status"
+status=0
+DUO_TEST_RUN_STATUS=65 omarchy-launch-duo --hold --prompt "Review this project" <<<"" >"$test_tmp/held-output" || status=$?
+(( status == 65 )) || fail "held prompt must preserve Duo's failure status"
+grep -F 'Press Enter to close.' "$test_tmp/held-output" >/dev/null || fail "graphical prompt must retain the result"
+pass "prompt launches retain results and preserve exit status"

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -253,6 +253,18 @@ assertDeepEqual(
   ['Antigravity', 'Claude', 'Codex', 'Copilot', 'Crush', 'Cursor CLI', 'GitLab Duo CLI', 'Grok', 'Hermes', 'Muse Code', 'omp', 'OpenClaw', 'OpenCode', 'Ori', 'Pi'],
   'menu sorts coding agents alphabetically'
 )
+assert(
+  /if \(active === "setup\.default\.agent"\) \{[\s\S]*?rows\.sort\(function\(a, b\)/.test(menuQml),
+  'defaults agent menu enforces alphabetical display order'
+)
+assert(
+  /root\.activeMenu === "setup\.default\.agent" \? Style\.space\(340\) : Style\.space\(300\)/.test(menuQml),
+  'defaults agent menu has adjusted card width'
+)
+assert(
+  /root\.activeMenu === "setup\.default\.agent" \? 0\.88 : 0\.7/.test(menuQml),
+  'defaults agent menu allows expanded vertical budget to fit agent list'
+)
 const expectedDefaults = {
   browser: ['Chromium', 'Chrome', 'Brave', 'Brave Origin', 'Edge', 'Firefox', 'Zen'],
   terminal: ['Alacritty', 'Foot', 'Ghostty', 'Kitty'],

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -228,6 +228,7 @@ const expectedAgents = {
   openclaw: { icon: '\ue90c', iconFont: 'omarchy', label: 'OpenClaw' },
   copilot: { icon: '', label: 'Copilot' },
   crush: { icon: '󰋑', label: 'Crush' },
+  duo: { icon: '', label: 'GitLab Duo CLI' },
   muse: { icon: '󰛤', label: 'Muse Code' },
   'cursor-agent': { icon: '\ue90d', iconFont: 'omarchy', label: 'Cursor CLI' },
 
@@ -249,7 +250,7 @@ assertDeepEqual(
   defaultItems
     .filter(item => item.parent === 'setup.default.agent')
     .map(item => item.label),
-  ['Antigravity', 'Claude', 'Codex', 'Copilot', 'Crush', 'Cursor CLI', 'Grok', 'Hermes', 'Muse Code', 'omp', 'OpenClaw', 'OpenCode', 'Ori', 'Pi'],
+  ['Antigravity', 'Claude', 'Codex', 'Copilot', 'Crush', 'Cursor CLI', 'GitLab Duo CLI', 'Grok', 'Hermes', 'Muse Code', 'omp', 'OpenClaw', 'OpenCode', 'Ori', 'Pi'],
   'menu sorts coding agents alphabetically'
 )
 const expectedDefaults = {


### PR DESCRIPTION
Adds [GitLab Duo CLI](https://docs.gitlab.com/user/gitlab_duo_cli/) (`duo`) as a selectable default coding agent in Omarchy, sorts the default agents menu alphabetically, and adjusts the menu window to comfortably fit the complete list of agents.

### Changes
- `bin/omarchy-default-agent`: added `duo` provider mapping and installer resolution (`omarchy-install-duo-cli`).
- `bin/omarchy-agent`: added launch target for `duo` with prompt forwarding and `--hold` support for graphical launches.
- `bin/omarchy-install-duo-cli`: ensures `glab` >= 1.107.0 (via mise if missing) and installs `duo` via `glab duo cli --install --yes`.
- `bin/omarchy-setup-duo`: interactive setup wizard supporting browser OAuth for both GitLab.com and Self-Managed/Dedicated instances.
- `bin/omarchy-launch-duo`: launches Duo with `--dangerously-skip-permissions` to match other unattended default agents in Omarchy. Uses `glab duo cli run --goal="..."` for prompts and opens the interactive TUI otherwise.
- `default/omarchy/omarchy-menu.jsonc`: added GitLab Duo CLI to *Setup > Defaults > Agent* with the GitLab mark in alphabetical position.
- `shell/plugins/menu/Menu.qml`:
  - Enforce alphabetical display sorting for `setup.default.agent` in `rebuildDisplay()`.
  - Adjust `cardWidth` to `Style.space(340)` for `setup.default.agent` so labels with icons and checkmarks fit with generous padding.
  - Bypass `maxRowsHeight` cap for `setup.default.agent` and allow up to 88% screen height budget so all 15 agents fit without clipping.
  - Bound `effectiveCardTop` so taller menus shift up to `Style.gapsOut` if needed without running off the bottom edge.
- `manual/17-ai.md`: documented selection, OAuth, self-managed requirements, and prompt behavior.
- `test/shell.d/duo-agent-test.sh`: unit/integration coverage for presence checking, OAuth invocation, prompt binding, and failure preservation.
- `test/shell.d/menu-test.sh`: added `duo` to the agent catalog assertions and verified alphabetical sorting and window sizing rules.

### Verification
- Ran `./test/cli`: all 457 commands checked and all CLI tests passed.
- Ran `test/shell.d/duo-agent-test.sh`: all assertions passed.
- Ran `test/shell.d/menu-test.sh`: all menu assertions passed.
- Ran `test/shell.d/default-agent-test.sh`: all agent launcher assertions passed.
- Verified live OAuth flow on GitLab.com, menu rendering with checkmark, interactive TUI launch, and headless prompt execution (`omarchy agent prompt --inline "Reply with: OK"`).