### PR TITLE
Ship fcitx5 wayland.conf so layouts are not pushed to the compositor

### DIFF
--- a/config/fcitx5/conf/wayland.conf
+++ b/config/fcitx5/conf/wayland.conf
@@ -1,0 +1,1 @@
+Allow Overriding System XKB Settings=False


### PR DESCRIPTION
## Summary

Fixes #10474.

`config/fcitx5/conf/xcb.conf` already ships `Allow Overriding System XKB Settings=False` for the X11 addon, but the Wayland addon has no counterpart, so it still runs with the override enabled. This adds `config/fcitx5/conf/wayland.conf` with the same single line.

### Why this is the cause

Measured on two Omarchy 4.0.3 (quattro, stable) machines with fcitx5 5.1.22, Hyprland 0.56.2 and a single German system layout:

- `hyprctl devices` and `localectl` report `de`, but XWayland reports `us` (`DISPLAY=:0 setxkbmap -query`) on both machines.
- Without a `~/.config/fcitx5/profile`, fcitx5 reads both and builds two groups on first start (`fcitx5 --verbose '*=5'`):
  ```
  xcbkeyboard.cpp:294 evdev pc105 us
  inputmethodmanager.cpp:135 No valid input method group in configuration. Building a default one
  instance.cpp:405 Items in group 1: [InputMethodGroupItem(keyboard-us,layout=)]
  instance.cpp:405 Items in group 2: [InputMethodGroupItem(keyboard-de,layout=)]
  ```
- With two groups fcitx5 tries to push the layout to the compositor. The Wayland addon's setting for that is `Allow Overriding System XKB Settings` (described in `libwayland.so` as "Only support KDE5+ and GNOME"). On Hyprland the attempt raises the "Wayland Diagnose — Sending keyboard layout configuration to wayland compositor from Fcitx is not yet supported on current desktop" notification from the issue.
- A machine that already has a one-group profile never shows it, which is why the notification looks intermittent across installs. The reporter in #10474 had two layouts configured; here it was one, so the trigger is fcitx5's own default profile, not the user's layout choice.

### Evidence

`dbus-monitor "interface='org.freedesktop.Notifications',member='Notify'"` while deleting the profile and restarting `omarchy-fcitx5.service`:

| | Notify calls |
|---|---|
| without `conf/wayland.conf` | 1 |
| with `conf/wayland.conf` | 0 |

Cross-checked in both directions.

### Relation to #10578

#10578 disables the whole `notifications` addon, which hides this message but also every other fcitx5 notification. This change stops the layout push itself and leaves the notification channel alone. Both can coexist; this one addresses the cause.

### Test plan

- [x] `bash test/shell.d/config-test.sh`: all shell.json checks pass; the run stops at the omarchy-pkgs PKGBUILD coverage check because no omarchy-pkgs checkout is present here
- [x] Delete `~/.config/fcitx5/profile`, restart `omarchy-fcitx5.service`, `dbus-monitor` shows 0 Notify calls
- [ ] CapsLock compose after the change
- [ ] Fresh install: no notification on first login

🤖 Generated with [Claude Code](https://claude.com/claude-code)

