### PR TITLE
Support per-monitor background image variants

### DIFF
--- a/docs/theming.md
+++ b/docs/theming.md
@@ -15,6 +15,29 @@ ship `backgrounds/` (users overlay their own via
 
 A theme installed from a git repo is held to a much shorter list; see [What an installed theme may not ship](#what-an-installed-theme-may-not-ship).
 
+## Background image variants
+
+A still image can have alternatives in a sibling directory named after the image without its extension:
+
+```text
+backgrounds/
+  01-ink-signature.webp
+  01-ink-signature/
+    5120x2160.webp
+    portrait.png
+  02-paper-signature.webp
+  02-paper-signature/
+    5120x2160.webp
+```
+
+The top-level file is both the default image and the design's identity. The existing picker, cycling commands, and current-background symlink continue to refer to that file. Nested alternatives do not add picker entries. Themes therefore work without variant support, using their default images.
+
+The desktop background plugin considers the default plus JPG, JPEG, PNG, WebP, and BMP files immediately inside its matching directory. It reads actual image dimensions; filenames do not declare dimensions. Choose distinct default basenames within a background directory. GIF and video wallpapers retain their existing behavior and do not participate in variant selection.
+
+Each output independently chooses the least-cropped aspect ratio, then the smallest sufficient resolution at that aspect ratio, or the largest available if all would require enlargement. Logical output dimensions multiplied by pixel density account for scaling and rotation. Screen changes reevaluate selection without rescanning images. Metadata is cached under `~/.cache/omarchy/background-dimensions` (or `$XDG_CACHE_HOME`) by path, size, modification time, and change time. Selecting a different background or applying a theme refreshes its candidate list; unreadable alternatives are skipped.
+
+The same convention works for additional user backgrounds. The lock screen and picker previews continue to use the default image. Selecting an alternative file directly displays that file normally unless it also has a matching sibling directory.
+
 ## Theme activation flow
 
 `omarchy-theme-set <name>` builds a clean staging directory at

--- a/manual/43-making-your-own-theme.md
+++ b/manual/43-making-your-own-theme.md
@@ -16,6 +16,22 @@ Everything else still works exactly as the theme author wrote it — `btop.theme
 
 Omarchy tells the two apart by whether the theme has its own git repo inside it, which is what `omarchy theme install` leaves behind when it clones. So a theme you wrote stays yours, and one you pulled off the internet stays colours.
 
+### Background sizes
+
+You can provide different sizes or compositions of a background for ordinary, ultrawide, and portrait screens. Keep one default image directly in `backgrounds/`, then put alternatives in a directory with the same name without the file extension:
+
+```text
+backgrounds/
+  01-landscape.webp
+  01-landscape/
+    ultrawide.webp
+    portrait.png
+```
+
+Only the default appears in the background picker. Omarchy automatically chooses the image that best fits each monitor's shape and resolution. Alternative filenames are up to you: Omarchy reads the dimensions from the files. JPG, JPEG, PNG, WebP, and BMP alternatives are supported; put them directly inside the matching directory.
+
+The default also supplies the picker preview and lock-screen background, and remains usable on older versions of Omarchy. Themes without alternatives work as before.
+
 ### Light mode
 
 If you're making a light mode theme, set `mode = "light"` at the top of your `colors.toml`. Then it'll automatically be paired with light mode for all the apps. (The old way of dropping an empty file called `light.mode` in the root of your theme still works too.)

--- a/shell/Ui/BackgroundMedia.qml
+++ b/shell/Ui/BackgroundMedia.qml
@@ -22,7 +22,7 @@ Item {
   // loader a video, or the player a still, in the moment before it unloads.
   // Both test the path directly: going through `video` lets a URL evaluate
   // against the stale flag and leak the wrong file for one pass.
-  readonly property url imageUrl: path && !Util.isVideoPath(path) ? Util.fileUrl(path) + (version ? "?v=" + version : "") : ""
+  readonly property url imageUrl: path && !Util.isVideoPath(path) ? Util.fileUrl(path) + (version || reloads ? "?v=" + version + "&r=" + reloads : "") : ""
   readonly property url videoUrl: path && Util.isVideoPath(path) ? Util.fileUrl(path) : ""
 
   Loader {
@@ -79,7 +79,7 @@ Item {
       source: root.imageUrl
       fillMode: Image.PreserveAspectCrop
       asynchronous: true
-      cache: root.version === 0
+      cache: root.version === 0 && root.reloads === 0
       sourceSize.width: root.version > 0 ? width : 0
       sourceSize.height: root.version > 0 ? height : 0
     }

--- a/shell/plugins/background/Background.qml
+++ b/shell/plugins/background/Background.qml
@@ -7,6 +7,7 @@ import QtQuick.Effects
 import QtQuick.Shapes
 import qs.Commons
 import qs.Ui
+import "BackgroundVariants.js" as BackgroundVariants
 
 Item {
   id: root
@@ -27,6 +28,17 @@ Item {
   property string pendingColorsRaw: ""
   property string pendingShellRaw: ""
   property real revealProgress: 1
+  property var displayedCandidates: []
+  signal captureBackground()
+
+  BackgroundVariantCatalog {
+    id: variantCatalog
+    path: root.currentBackground
+    revision: root.backgroundVersion
+    onResolved: {
+      if (!root.incomingBackground) root.displayedCandidates = candidates
+    }
+  }
 
   // Injected by the first-party service loader; used to reach the lock and idle
   // services so playback can stop whenever nothing can see the wallpaper.
@@ -66,6 +78,9 @@ Item {
     finalPath = String(finalPath || path).trim()
     fromPath = String(fromPath || "").trim()
     if (!path || (!force && finalPath === currentBackground)) return
+    // Capture what each output actually shows, including its selected variant.
+    // The theme command's old snapshot contains only the default image.
+    captureBackground()
     currentBackground = finalPath
     backgroundVersion += 1
     revealStartedVersion = -1
@@ -81,6 +96,7 @@ Item {
       // A theme switch can replace the file behind an unchanged path, which
       // an unchanged property would never pick up.
       if (displayedBackground === finalPath) displayedReloads += 1
+      displayedCandidates = []
       displayedBackground = finalPath
       revealProgress = 1
       return
@@ -126,6 +142,16 @@ Item {
     revealStartedVersion = backgroundVersion
     applyPendingTheme()
     revealAnimation.restart()
+  }
+
+  function finishTransition() {
+    if (!finishingTransition) return
+    for (var i = 0; i < backgroundPanels.instances.length; i++) {
+      if (!backgroundPanels.instances[i].backgroundReady) return
+    }
+    incomingBackground = ""
+    oldBackground = ""
+    finishingTransition = false
   }
 
   function openSelector() {
@@ -197,17 +223,22 @@ Item {
     easing.type: Easing.InOutCubic
     onFinished: {
       if (root.incomingBackground) {
+        root.displayedReloads += 1
+        root.displayedCandidates = variantCatalog.candidates
         root.displayedBackground = root.currentBackground || root.incomingBackground
         root.finishingTransition = true
       }
       root.revealProgress = 1
+      Qt.callLater(root.finishTransition)
     }
   }
 
   Component.onCompleted: refreshBackground()
 
   Variants {
+    id: backgroundPanels
     model: Quickshell.screens
+    onInstancesChanged: Qt.callLater(root.finishTransition)
 
     PanelWindow {
       id: panel
@@ -243,12 +274,27 @@ Item {
         && String(Quickshell.screens[0].name || "") === String(modelData.name || "")
 
       property bool maskReady: false
+      readonly property bool backgroundReady: base.ready
+      property var failedVariants: []
+      readonly property real pixelScale: modelData.devicePixelRatio
+      readonly property string displayedPath: BackgroundVariants.choose(
+        root.displayedCandidates.filter(function(candidate) { return panel.failedVariants.indexOf(candidate.path) === -1 }),
+        root.displayedBackground, modelData.width, modelData.height, pixelScale)
+      readonly property string incomingPath: BackgroundVariants.choose(
+        variantCatalog.candidates.filter(function(candidate) { return panel.failedVariants.indexOf(candidate.path) === -1 }),
+        root.incomingBackground, modelData.width, modelData.height, pixelScale)
+
+      function rejectVariant(path) {
+        if (failedVariants.indexOf(path) === -1) failedVariants = failedVariants.concat([path])
+      }
 
       function maybeStartReveal() {
         if (!root.incomingBackground || root.revealProgress !== 0 || maskReady) return
+        if (variantCatalog.busy) return
         if (incomingFrame.status !== Image.Ready) return
         Qt.callLater(function() {
           if (!root.incomingBackground || root.revealProgress !== 0 || maskReady) return
+          if (variantCatalog.busy) return
           if (incomingFrame.status !== Image.Ready) return
           root.startReveal(panel)
         })
@@ -262,30 +308,30 @@ Item {
       BackgroundMedia {
         id: base
         anchors.fill: parent
-        path: root.displayedBackground
+        path: panel.displayedPath
         reloads: root.displayedReloads
         playbackEnabled: !root.sessionObscured && !root.powerSaverActive && !panel.fullscreenHere
         audioEnabled: panel.firstScreen
         onReadyChanged: {
-          if (ready && root.finishingTransition) {
-            root.incomingBackground = ""
-            root.oldBackground = ""
-            root.finishingTransition = false
-          }
+          if (ready) Qt.callLater(root.finishTransition)
         }
       }
 
-      Image {
+      Connections {
+        target: base.current
+        ignoreUnknownSignals: true
+        function onStatusChanged() {
+          if (base.current && base.current.status === Image.Error) panel.rejectVariant(panel.displayedPath)
+        }
+      }
+
+      ShaderEffectSource {
         id: oldFrame
         anchors.fill: parent
-        source: root.imageUrl(root.oldBackground)
-        fillMode: Image.PreserveAspectCrop
-        asynchronous: true
-        cache: false
+        sourceItem: root.oldBackground !== "" ? base : null
+        live: false
         smooth: true
-        mipmap: true
         visible: root.oldBackground !== "" && root.revealProgress < 1
-        onStatusChanged: panel.maybeStartReveal()
       }
 
       Item {
@@ -304,13 +350,16 @@ Item {
         Image {
           id: incomingFrame
           anchors.fill: parent
-          source: root.imageUrl(root.incomingBackground)
+          source: root.incomingBackground && !variantCatalog.busy ? root.imageUrl(panel.incomingPath) : ""
           fillMode: Image.PreserveAspectCrop
           asynchronous: true
           cache: false
           smooth: true
           mipmap: true
-          onStatusChanged: panel.maybeStartReveal()
+          onStatusChanged: {
+            if (status === Image.Error) panel.rejectVariant(panel.incomingPath)
+            panel.maybeStartReveal()
+          }
         }
       }
 
@@ -344,10 +393,19 @@ Item {
 
       Connections {
         target: root
+        function onCaptureBackground() {
+          oldFrame.scheduleUpdate()
+          panel.failedVariants = []
+        }
         function onIncomingBackgroundChanged() {
           panel.maskReady = false
           panel.maybeStartReveal()
         }
+      }
+
+      Connections {
+        target: variantCatalog
+        function onResolved() { panel.maybeStartReveal() }
       }
 
       MouseArea {

--- a/shell/plugins/background/BackgroundVariantCatalog.qml
+++ b/shell/plugins/background/BackgroundVariantCatalog.qml
@@ -1,0 +1,49 @@
+import QtQuick
+import Quickshell.Io
+
+Item {
+  id: root
+
+  property string path: ""
+  property int revision: 0
+  property var candidates: []
+  property bool busy: false
+  property int generation: 0
+  signal resolved()
+
+  function refresh() {
+    generation += 1
+    busy = true
+    if (!scan.running) Qt.callLater(root.start)
+  }
+
+  function start() {
+    if (scan.running) return
+    scan.generation = generation
+    scan.command = ["timeout", "10", "python",
+      decodeURIComponent(Qt.resolvedUrl("variant-images.py").toString().replace(/^file:\/\//, "")), path]
+    scan.running = true
+  }
+
+  onPathChanged: refresh()
+  onRevisionChanged: refresh()
+
+  Process {
+    id: scan
+    property int generation: 0
+    stdout: StdioCollector { id: output; waitForEnd: true }
+    onExited: function(exitCode, exitStatus) {
+      if (generation !== root.generation) {
+        root.start()
+        return
+      }
+      var next = []
+      if (exitCode === 0) {
+        try { next = JSON.parse(output.text) } catch (error) {}
+      }
+      root.candidates = next
+      root.busy = false
+      root.resolved()
+    }
+  }
+}

--- a/shell/plugins/background/BackgroundVariants.js
+++ b/shell/plugins/background/BackgroundVariants.js
@@ -1,0 +1,34 @@
+// The default image remains the selected design; rendering never changes its
+// symlink. Screen dimensions are already rotated and expressed in logical pixels.
+function choose(candidates, fallback, width, height, scale) {
+  width *= scale || 1
+  height *= scale || 1
+  if (!(width > 0 && height > 0)) return fallback
+
+  var best = null
+  var bestFit = -1
+  var bestScale = Infinity
+  for (var i = 0; i < candidates.length; i++) {
+    var candidate = candidates[i]
+    if (!(candidate.width > 0 && candidate.height > 0)) continue
+    var ratio = candidate.width / candidate.height
+    var target = width / height
+    var fit = Math.min(ratio / target, target / ratio)
+    var enlargement = Math.max(width / candidate.width, height / candidate.height)
+    var tied = Math.abs(fit - bestFit) < 0.000000001
+    // At the same shape, choose the smallest sufficient image. If none is
+    // sufficient, choose the largest available one.
+    var betterSize = enlargement <= 1
+      ? bestScale > 1 || enlargement > bestScale
+      : bestScale > 1 && enlargement < bestScale
+    if (!best || fit > bestFit + 0.000000001 || (tied && (betterSize
+        || (enlargement === bestScale && candidate.path < best.path)))) {
+      best = candidate
+      bestFit = fit
+      bestScale = enlargement
+    }
+  }
+  return best ? best.path : fallback
+}
+
+if (typeof module !== "undefined") module.exports = { choose: choose }

--- a/shell/plugins/background/variant-images.py
+++ b/shell/plugins/background/variant-images.py
@@ -1,0 +1,62 @@
+#!/usr/bin/python
+"""List still-image variants without decoding wallpapers into the shell."""
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+
+EXTENSIONS = {".jpg", ".jpeg", ".png", ".webp", ".bmp"}
+
+
+def dimensions(path, cache):
+  try:
+    stat = path.stat()
+    signature = f"{path}\0{stat.st_size}\0{stat.st_mtime_ns}\0{stat.st_ctime_ns}"
+    key = hashlib.sha256(signature.encode()).hexdigest()
+    cached = cache / key
+    if cached.is_file():
+      width, height = json.loads(cached.read_text())
+    else:
+      width, height = (
+        int(subprocess.check_output(
+          ["vipsheader", "-f", field, str(path)],
+          stderr=subprocess.DEVNULL, timeout=2,
+        ))
+        for field in ("width", "height")
+      )
+      if width <= 0 or height <= 0:
+        return None
+      cache.mkdir(parents=True, exist_ok=True)
+      temporary = cached.with_suffix(f".{os.getpid()}.tmp")
+      temporary.write_text(json.dumps([width, height]))
+      temporary.replace(cached)
+    return {"path": str(path), "width": width, "height": height}
+  except (OSError, ValueError, subprocess.SubprocessError):
+    return None
+
+
+def candidates(default, cache):
+  # The sibling directory opts an image into the convention. A directly
+  # selected variant without its own sibling directory stays an ordinary file.
+  if default.suffix.lower() not in EXTENSIONS:
+    return []
+  directory = default.with_suffix("")
+  if not directory.is_dir():
+    return []
+  files = [default]
+  files.extend(sorted(p for p in directory.iterdir()
+            if p.is_file() and p.suffix.lower() in EXTENSIONS))
+  return [result for p in files if (result := dimensions(p, cache))]
+
+
+if __name__ == "__main__":
+  default = Path(sys.argv[1])
+  cache = Path(os.environ.get("XDG_CACHE_HOME", str(Path.home() / ".cache"))) / "omarchy/background-dimensions"
+  try:
+    print(json.dumps(candidates(default, cache)))
+  except OSError:
+    print("[]")

--- a/test/shell.d/background-variants-test.sh
+++ b/test/shell.d/background-variants-test.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+
+set -euo pipefail
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+run_node_test <<'JS'
+const { choose } = requireFromRoot('shell/plugins/background/BackgroundVariants.js')
+const image = (path, width, height) => ({ path, width, height })
+const choices = [image('default', 3840, 2160), image('wide', 5120, 2160), image('portrait', 2160, 3840)]
+assertEqual(choose(choices, 'default', 1920, 1080, 1), 'default', '16:9 output keeps the default')
+assertEqual(choose(choices, 'default', 2560, 1080, 2), 'wide', 'scaled ultrawide output chooses its authored variant')
+assertEqual(choose(choices, 'default', 1080, 1920, 2), 'portrait', 'rotated output chooses portrait artwork')
+assertEqual(choose(choices, 'default', 1920, 1080, 1), 'default', 'selection on another monitor remains independent')
+const resolutions = [image('1080', 1920, 1080), image('4k', 3840, 2160), image('8k', 7680, 4320)]
+assertEqual(choose(resolutions, 'default', 1920, 1080, 1), '1080', 'smallest sufficient image wins at equal aspect ratio')
+assertEqual(choose(resolutions, 'default', 1920, 1080, 2), '4k', 'physical pixel density controls resolution selection')
+assertEqual(choose(resolutions, 'default', 10000, 5625, 1), '8k', 'largest image wins when all require enlargement')
+assertEqual(choose([image('huge', 8000, 8000), image('right-shape', 1280, 720)], 'default', 1920, 1080, 1), 'right-shape', 'aspect ratio takes precedence over resolution')
+assertEqual(choose([], 'default', 1920, 1080, 1), 'default', 'empty groups fall back to the default')
+assertEqual(choose([image('invalid', 0, 0)], 'default', 1920, 1080, 1), 'default', 'invalid dimensions are ignored')
+assertEqual(choose(choices, 'default', 0, 0, 1), 'default', 'disconnected output has a safe fallback')
+assertEqual(choose([image('b', 1920, 1080), image('a', 1920, 1080)], 'default', 1920, 1080, 1), 'a', 'equal candidates have a deterministic tie break')
+JS
+
+require_command python
+require_command vipsheader
+python - <<'PY'
+import importlib.util
+import os
+from pathlib import Path
+import struct
+import subprocess
+import tempfile
+from unittest.mock import patch
+import zlib
+
+spec = importlib.util.spec_from_file_location('variants', Path(os.environ['ROOT']) / 'shell/plugins/background/variant-images.py')
+variants = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(variants)
+
+def png(path, width, height):
+  def chunk(name, data):
+    return struct.pack('!I', len(data)) + name + data + struct.pack('!I', zlib.crc32(name + data))
+  path.write_bytes(b'\x89PNG\r\n\x1a\n' + chunk(b'IHDR', struct.pack('!2I5B', width, height, 8, 2, 0, 0, 0))
+          + chunk(b'IDAT', zlib.compress((b'\0' + b'\x00\x88\xff' * width) * height)) + chunk(b'IEND', b''))
+
+with tempfile.TemporaryDirectory(prefix='omarchy-variant-test-') as temporary:
+  root = Path(temporary)
+  default = root / '01 image $(untouched).png'
+  cache = root / 'cache'
+  png(default, 160, 90)
+  assert variants.candidates(default, cache) == [], 'flat backgrounds should need no probing'
+  folder = default.with_suffix('')
+  folder.mkdir()
+  alternate = folder / 'arbitrary name.PNG'
+  png(alternate, 210, 90)
+  (folder / 'broken.webp').write_text('invalid')
+  (folder / 'video.mp4').write_text('not a still')
+  (folder / 'nested').mkdir()
+  png(folder / 'nested' / 'ignored.png', 90, 160)
+  expected = [{'path': str(default), 'width': 160, 'height': 90},
+        {'path': str(alternate), 'width': 210, 'height': 90}]
+  assert variants.candidates(default, cache) == expected
+  print('ok - discovery reads actual dimensions, handles special paths, skips broken images and ignores deeper nesting')
+  with patch.object(variants.subprocess, 'check_output', side_effect=AssertionError('cache miss')):
+    assert variants.dimensions(alternate, cache) == expected[1]
+  png(alternate, 90, 160)
+  assert variants.dimensions(alternate, cache)['width'] == 90
+  print('ok - dimension cache avoids repeat probes and detects replaced images')
+  assert variants.candidates(alternate, cache) == []
+  assert variants.candidates(folder / 'video.mp4', cache) == []
+  print('ok - direct variant and video selection retain ordinary file behavior')
+
+  backgrounds = root / 'backgrounds'
+  backgrounds.mkdir()
+  for index in range(4):
+    png(backgrounds / f'{index}.png', 160, 90)
+    (backgrounds / str(index)).mkdir()
+    png(backgrounds / str(index) / 'wide.png', 210, 90)
+  picker_cache = root / 'picker-cache'
+  subprocess.run(['bash', str(Path(os.environ['ROOT']) / 'bin/omarchy-menu-images'), '--prepare-only', str(backgrounds)],
+         env=dict(os.environ, XDG_CACHE_HOME=str(picker_cache)), check=True)
+  rows = list((picker_cache / 'omarchy/image-selector').glob('*.rows'))
+  assert len(rows) == 1 and len(rows[0].read_text().splitlines()) == 4
+  print('ok - the real picker lists four designs from eight files without listing variants')
+PY
+
+# This fixture exercises the real asynchronous Process lifecycle without
+# creating any desktop surfaces or requiring a running compositor.
+if command -v quickshell >/dev/null && command -v magick >/dev/null; then
+  variant_test_dir=$(mktemp -d /tmp/omarchy-variants.XXXXXX)
+  trap 'rm -rf "$variant_test_dir"' EXIT
+  mkdir -p "$variant_test_dir/config" "$variant_test_dir/images/design" "$variant_test_dir/runtime"
+  chmod 700 "$variant_test_dir/runtime"
+  ln -s "$ROOT/shell/plugins/background" "$variant_test_dir/config/background"
+  cp "$ROOT/test/shell.d/fixtures/background-variant-catalog.qml" "$variant_test_dir/config/shell.qml"
+  magick -size 160x90 xc:red "$variant_test_dir/images/design.png"
+  magick -size 210x90 xc:blue "$variant_test_dir/images/design/wide.png"
+  ulimit -c 0 2>/dev/null || true
+  env -u WAYLAND_DISPLAY QT_QPA_PLATFORM=offscreen QT_QPA_PLATFORMTHEME=basic \
+    XDG_RUNTIME_DIR="$variant_test_dir/runtime" XDG_CACHE_HOME="$variant_test_dir/cache" \
+    VARIANT_TEST_DIR="$variant_test_dir/images" \
+    timeout 15 quickshell -p "$variant_test_dir/config" --no-color >"$variant_test_dir/runtime.log" 2>&1 ||
+    fail "variant catalog runtime fixture exits" "$(cat "$variant_test_dir/runtime.log")"
+  if ! rg -q 'PASS variant catalog' "$variant_test_dir/runtime.log" || rg -q 'FAIL variant catalog' "$variant_test_dir/runtime.log"; then
+    fail "variant catalog rejects stale scans" "$(cat "$variant_test_dir/runtime.log")"
+  fi
+  pass "variant catalog resolves real files and rejects stale asynchronous scans"
+else
+  pass "quickshell or ImageMagick unavailable; skipping catalog runtime fixture"
+fi

--- a/test/shell.d/fixtures/background-variant-catalog.qml
+++ b/test/shell.d/fixtures/background-variant-catalog.qml
@@ -1,0 +1,36 @@
+import Quickshell
+import QtQuick
+import "background"
+
+ShellRoot {
+  BackgroundVariantCatalog {
+    id: catalog
+    path: Quickshell.env("VARIANT_TEST_DIR") + "/design.png"
+    property int step: 0
+    onResolved: {
+      if (candidates.length !== 2 || candidates[1].width !== 210) {
+        console.error("FAIL variant catalog: " + JSON.stringify(candidates))
+        Qt.quit()
+      } else if (step === 0) {
+        step = 1
+        // Begin a scan, then supersede it while its Process is still running.
+        path = Quickshell.env("VARIANT_TEST_DIR") + "/missing.png"
+        catalog.start()
+        path = Quickshell.env("VARIANT_TEST_DIR") + "/design.png"
+        revision++
+      } else {
+        console.log("PASS variant catalog")
+        Qt.quit()
+      }
+    }
+  }
+
+  Timer {
+    running: true
+    interval: 12000
+    onTriggered: {
+      console.error("FAIL variant catalog: timeout")
+      Qt.quit()
+    }
+  }
+}

--- a/test/shell.d/video-background-test.sh
+++ b/test/shell.d/video-background-test.sh
@@ -32,7 +32,7 @@ assert(
   videoQml.includes('loops: MediaPlayer.Infinite') &&
     videoQml.includes('autoPlay: root.playbackEnabled') &&
     videoQml.includes('fillMode: VideoOutput.PreserveAspectCrop') &&
-    /imageUrl: path && !Util\.isVideoPath\(path\) \? Util\.fileUrl\(path\) \+ \(version \? "\?v=" \+ version : ""\) : ""/.test(mediaQml) &&
+    /imageUrl: path && !Util\.isVideoPath\(path\) \? Util\.fileUrl\(path\) \+ \(version \|\| reloads \? "\?v=" \+ version \+ "&r=" \+ reloads : ""\) : ""/.test(mediaQml) &&
     /videoUrl: path && Util\.isVideoPath\(path\) \? Util\.fileUrl\(path\) : ""/.test(mediaQml),
   'background media plays aspect-cropped videos on a loop, and hands each loader only its own kind of file'
 )


### PR DESCRIPTION
Themes that ship ordinary and ultrawide versions of the same artwork currently show each file as a separate background. This adds per-monitor variant selection to the built-in background plugin, while keeping one picker entry per design.

Keep a default image at the top level and place alternatives in a sibling directory named after its basename:

```text
backgrounds/
  01-ink-signature.webp
  01-ink-signature/
    5120x2160.webp
    portrait.png
  02-paper-signature.webp
```

Each monitor selects the least-cropped aspect ratio using actual image dimensions, then the smallest sufficient resolution at that ratio (or the largest available). Selection accounts for output scaling and updates when screens change. Dimension metadata is cached, and stale asynchronous scans are discarded when backgrounds change rapidly. Transitions retain the previously rendered variant on each output.

The top-level image remains the picker entry and saved selection, supplies the lock-screen background and picker preview, and works on older installations. Alternatives support JPG, JPEG, PNG, WebP, and BMP. GIF and video backgrounds keep their existing behavior. Includes theme-author documentation and automated coverage.

Related discussion: https://github.com/omacom/omarchy/discussions/11443

This is a draft for feedback on the folder convention and selection policy.

Validation:

- Background variant tests pass: selection, scaling, real image dimensions, cache invalidation, four picker entries from eight images, and the actual asynchronous QML catalog.
- Existing background and video-background tests pass.
- Isolated nested-compositor checks verified ordinary, ultrawide and portrait outputs; scaling, output reconnection, transitions, and refreshing a variant at the same filename. Full disposable-VM acceptance testing has not been run.
- `./test/all` completed: CLI suite passed; six of 237 shell test files initially failed. `config`, `snapper`, and `unowned-system-paths` pass with the required packaging/installer checkouts; `launch-about` passes with `NO_COLOR` unset. The remaining `locate` and `network-qr` failures also reproduce on the unchanged base commit in this environment.
- `git diff --check` passes.
