### PR TITLE
Skip browser help probe for non-private launches

### DIFF
--- a/bin/omarchy-launch-browser
+++ b/bin/omarchy-launch-browser
@@ -9,17 +9,28 @@ if [[ -z $default_browser ]]; then
 fi
 browser_exec=$(sed -n 's/^Exec=\([^ ]*\).*/\1/p' {~/.local,~/.nix-profile,/usr}/share/applications/$default_browser 2>/dev/null | head -1)
 
-if $browser_exec --help 2>/dev/null | grep -q MOZ_LOG; then
-  private_flag="--private-window"
-elif [[ $browser_exec =~ edge ]]; then
-  private_flag="--inprivate"
-else
-  private_flag="--incognito"
-fi
+# Browser help can start a process (or render a man page). Only inspect it when
+# a private window needs a browser-specific flag.
+args=("$@")
+private_flag=""
+for i in "${!args[@]}"; do
+  if [[ ${args[i]} == "--private" ]]; then
+    if [[ -z $private_flag ]]; then
+      if "$browser_exec" --help 2>/dev/null | grep -q MOZ_LOG; then
+        private_flag="--private-window"
+      elif [[ $browser_exec =~ edge ]]; then
+        private_flag="--inprivate"
+      else
+        private_flag="--incognito"
+      fi
+    fi
+    args[i]=$private_flag
+  fi
+done
 
 systemd-run --user --quiet --collect --unit="omarchy-browser-$(date +%s%N)" \
   --property=StandardOutput=null --property=StandardError=null \
-  uwsm-app -- "$browser_exec" "${@/--private/$private_flag}"
+  uwsm-app -- "$browser_exec" "${args[@]}"
 
 url=""
 for argument in "$@"; do

--- a/test/shell.d/launch-browser-private-test.sh
+++ b/test/shell.d/launch-browser-private-test.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+set -euo pipefail
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+mock_bin="$test_tmp/bin"
+test_home="$test_tmp/home"
+mkdir -p "$mock_bin" "$test_home/.local/share/applications"
+
+cat >"$mock_bin/xdg-settings" <<'MOCK'
+#!/bin/bash
+echo test-browser.desktop
+MOCK
+cat >"$mock_bin/test-browser" <<'MOCK'
+#!/bin/bash
+printf '%s\n' "$*" >>"$OMARCHY_TEST_HELP_LOG"
+[[ ${OMARCHY_TEST_BROWSER_FAMILY:-} == "mozilla" ]] && echo MOZ_LOG
+exit 0
+MOCK
+cp "$mock_bin/test-browser" "$mock_bin/test-edge"
+cat >"$mock_bin/systemd-run" <<'MOCK'
+#!/bin/bash
+while (( $# )) && [[ $1 != "uwsm-app" ]]; do shift; done
+shift 3 # uwsm-app -- browser
+if (( $# )); then
+  printf '%s\0' "$@" >"$OMARCHY_TEST_ARGS_LOG"
+else
+  : >"$OMARCHY_TEST_ARGS_LOG"
+fi
+MOCK
+cat >"$mock_bin/omarchy-hyprland-focus-app" <<'MOCK'
+#!/bin/bash
+exit 0
+MOCK
+chmod +x "$mock_bin"/*
+
+run_launcher() {
+  local browser=$1 family=$2
+  shift 2
+  printf '[Desktop Entry]\nExec=%s %%U\n' "$browser" >"$test_home/.local/share/applications/test-browser.desktop"
+  rm -f "$test_tmp/help" "$test_tmp/args"
+  HOME="$test_home" PATH="$mock_bin:$PATH" HYPRLAND_INSTANCE_SIGNATURE="" \
+    OMARCHY_TEST_BROWSER_FAMILY="$family" OMARCHY_TEST_HELP_LOG="$test_tmp/help" \
+    OMARCHY_TEST_ARGS_LOG="$test_tmp/args" bash "$ROOT/bin/omarchy-launch-browser" "$@"
+}
+
+assert_args() {
+  local actual=() expected=("$@")
+  mapfile -d '' -t actual <"$test_tmp/args"
+  (( ${#actual[@]} == ${#expected[@]} )) || fail "argument count is preserved"
+  for i in "${!expected[@]}"; do
+    [[ ${actual[i]} == "${expected[i]}" ]] || fail "argument $i is preserved" "actual: ${actual[i]}"
+  done
+}
+
+for family in chromium mozilla; do
+  run_launcher test-browser "$family"
+  [[ ! -e $test_tmp/help ]] || fail "normal $family launch skips browser help"
+  assert_args
+
+  url='https://example.test/--private?q=two words&literal=$HOME'
+  run_launcher test-browser "$family" "$url" --profile-directory='Work profile'
+  [[ ! -e $test_tmp/help ]] || fail "URL launch skips browser help"
+  assert_args "$url" --profile-directory='Work profile'
+done
+pass "normal windows and URLs skip browser help and preserve arguments"
+
+for family in chromium mozilla edge; do
+  browser=test-browser
+  case $family in
+  chromium) flag=--incognito ;;
+  mozilla) flag=--private-window ;;
+  edge) browser=test-edge; flag=--inprivate ;;
+  esac
+  run_launcher "$browser" "$family" "$url" --private --profile-directory='Work profile' --private
+  assert_args "$url" "$flag" --profile-directory='Work profile' "$flag"
+  [[ $(cat "$test_tmp/help") == "--help" ]] || fail "private $family launch probes help exactly once"
+done
+pass "private windows retain browser-specific flags without rewriting URLs"


### PR DESCRIPTION
Ordinary browser launches currently run `browser --help` before launching through systemd/uwsm, even though the result is only needed to translate `--private`. Chrome's help path renders a man page, adding avoidable work to every new window and URL launch.

Only probe help when an argument is exactly `--private`, and reuse the result for repeated private flags. Pass an argument array to the launcher so URLs containing `--private` remain intact instead of having that substring rewritten. Existing Mozilla, Edge, and Chromium private flags are preserved.

On Arch Linux with Chrome 152.0.7977.82, 12 paired runs reduced median launcher preparation time from **200.0 ms to 82.7 ms (59%)**. These measurements use the real XDG lookup and browser help command with only `systemd-run` replaced by a no-op; they measure preparation, not total window creation time.

Validation:

- Existing browser-launch tests and the new private-flag/argument regression tests pass. The new regression test fails against the base revision on the unconditional help probe.
- Coverage includes ordinary windows, URLs, literal `--private` inside URLs, arguments containing spaces, repeated private flags, and Mozilla/Edge/Chromium private modes. Existing tests cover XDG fallback, clearing `BROWSER` for lookup, and URL focus behavior.
- Live Chrome before/after check and recording reviewed: each launcher opens one window on the current workspace.
- `bash -n` and `git diff --check` pass.
- `./test/all`: CLI suite passes; 231 of 237 shell test files pass. The six failures also reproduce on the base revision: `config`, `snapper`, and `unowned-system-paths` require a separate `omarchy-pkgs` checkout; `launch-about` inherits `NO_COLOR` (passes with it unset); `locate` tries to read suite-generated `.pyc` files as UTF-8; `network-qr` exits during its automatic interface-detection case. All browser tests pass.
