### PR TITLE
Keep the caller's editor across sudo for vipw and vigr

### DIFF
--- a/bin/omarchy-launch-editor
+++ b/bin/omarchy-launch-editor
@@ -12,6 +12,10 @@ else
   inline=false
 fi
 
+# vipw and vigr keep only the first word of $EDITOR, so --inline never reaches
+# here under sudo. Without a Wayland session there is no window to open anyway.
+[[ -n ${WAYLAND_DISPLAY:-} ]] || inline=true
+
 if [[ -f $default_editor ]]; then
   read -r editor <"$default_editor"
 else

--- a/etc/sudoers.d/omarchy-vipw
+++ b/etc/sudoers.d/omarchy-vipw
@@ -1,0 +1,4 @@
+# vipw and vigr read $EDITOR and otherwise hardcode /usr/bin/vi, which Omarchy
+# does not ship. Carry the caller's editor across sudo the way the stock
+# sudoers already does for visudo.
+Defaults!/usr/bin/vipw,/usr/bin/vigr env_keep += "EDITOR"

--- a/test/shell.d/vipw-editor-test.sh
+++ b/test/shell.d/vipw-editor-test.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+launch_editor="$ROOT/bin/omarchy-launch-editor"
+sudoers_file="$ROOT/etc/sudoers.d/omarchy-vipw"
+rule='Defaults!/usr/bin/vipw,/usr/bin/vigr env_keep += "EDITOR"'
+
+# vipw and vigr fall back to /usr/bin/vi, which Omarchy does not ship, so the
+# caller's EDITOR has to survive sudo for exactly these two commands.
+rules=$(grep -vE '^[[:space:]]*(#|$)' "$sudoers_file")
+[[ $rules == "$rule" ]] ||
+  fail "vipw sudoers file keeps EDITOR for vipw and vigr and nothing else" "got: $rules"
+
+if command -v visudo >/dev/null; then
+  visudo -cf "$sudoers_file" >/dev/null || fail "vipw sudoers rule parses"
+fi
+
+pass "vipw sudoers rule keeps EDITOR for vipw and vigr"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+mkdir -p "$stub_bin" "$test_tmp/home"
+
+printf '#!/bin/bash\necho "inline $*"\n' >"$stub_bin/nvim"
+printf '#!/bin/bash\necho "window $*"\n' >"$stub_bin/omarchy-launch-tui"
+printf '#!/bin/bash\nexit 0\n' >"$stub_bin/omarchy-cmd-present"
+chmod +x "$stub_bin"/*
+
+launch() {
+  HOME="$test_tmp/home" PATH="$stub_bin:$PATH" bash "$launch_editor" "$@"
+}
+
+# vipw and vigr keep only the first word of EDITOR, so the --inline flag is
+# lost by the time the script runs as root; the missing session has to stand in
+# for it.
+result=$(WAYLAND_DISPLAY= launch /etc/group)
+[[ $result == "inline /etc/group" ]] ||
+  fail "launch-editor edits inline when there is no Wayland session" "got: $result"
+
+result=$(WAYLAND_DISPLAY=wayland-1 launch /etc/group)
+[[ $result == "window nvim /etc/group" ]] ||
+  fail "launch-editor still opens a window inside a session" "got: $result"
+
+result=$(WAYLAND_DISPLAY=wayland-1 launch --inline /etc/group)
+[[ $result == "inline /etc/group" ]] ||
+  fail "launch-editor still honors --inline inside a session" "got: $result"
+
+pass "launch-editor falls back to inline editing without a Wayland session"


### PR DESCRIPTION
## Problem

`sudo vigr` (and `sudo vipw`) fail on a stock install:

```
$ sudo vigr
vigr: failed to execute /usr/bin/vi: No such file or directory
vigr: /usr/bin/vi: unsuccessful execution
vigr: /etc/group unchanged
```

Both commands come from util-linux. They read `$EDITOR` and otherwise hardcode `/usr/bin/vi`, which nothing in the base package set provides (neovim does not ship a `vi` symlink). `sudo` resets the environment, and the stock sudoers only preserves `EDITOR` for `visudo`, so `vigr` never sees Omarchy's editor and falls through to the missing `vi`.

## Fix

Two small pieces, since the visudo pattern alone is not enough:

1. **`etc/sudoers.d/omarchy-vipw`** keeps `EDITOR` across sudo for exactly `/usr/bin/vipw` and `/usr/bin/vigr`, mirroring the `Defaults!/usr/bin/visudo env_keep` line in the stock sudoers.

2. **`bin/omarchy-launch-editor`** falls back to inline editing when there is no Wayland session. util-linux keeps only the first whitespace-separated word of `EDITOR`, so `omarchy-launch-editor --inline` arrives as plain `omarchy-launch-editor` and would otherwise try to open a terminal window as root through a user bus it cannot reach. `sudo` strips `WAYLAND_DISPLAY`, so root lands on the inline path; every existing caller runs inside the Hyprland session and is unchanged. This also makes `EDITOR` usable over SSH, where it failed for the same reason.

The result is that `sudo vigr` opens neovim in the current terminal, which is what `sudo visudo` already does.

## Verification

- `visudo -cf` accepts the drop-in.
- With the drop-in installed, `sudo vigr` launches `nvim` inline as root on the vipw temp file (tested on a live 4.0.3 machine).
- New `test/shell.d/vipw-editor-test.sh` checks the drop-in's single rule and parse, and that `omarchy-launch-editor` edits inline without `WAYLAND_DISPLAY`, still opens a window with it, and still honors `--inline`.
- `./test/shell` and `./test/cli` pass.

The drop-in ships through `omarchy-settings` like the other `etc/sudoers.d/` files, so existing installs pick it up on the next package update and no migration is needed.
