### PR TITLE
Show installation duration in About

### DIFF
--- a/bin/omarchy-install-duration
+++ b/bin/omarchy-install-duration
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# omarchy:summary=Print how long the original Omarchy installation took
+# omarchy:hidden=true
+
+timing_file=${OMARCHY_INSTALL_TIMING_FILE:-/var/log/omarchy-install-timing.json}
+
+[[ -r $timing_file ]] || exit 0
+
+duration=$(jq -ser '
+  select(length == 1)
+  | .[0]
+  | select(
+    (.started_at | type) == "number" and
+    (.finished_at | type) == "number" and
+    .started_at > 0 and
+    .finished_at >= .started_at
+  )
+  | ((.finished_at - .started_at) | round) as $seconds
+  | if $seconds >= 3600 then
+      "\($seconds / 3600 | floor)h \($seconds % 3600 / 60 | floor)m \($seconds % 60)s"
+    elif $seconds >= 60 then
+      "\($seconds / 60 | floor)m \($seconds % 60)s"
+    else
+      "\($seconds)s"
+    end
+' "$timing_file" 2>/dev/null) || exit 0
+
+printf '%s\n' "$duration"

--- a/etc/fastfetch/config.jsonc
+++ b/etc/fastfetch/config.jsonc
@@ -133,13 +133,19 @@
     "break",
     {
       "type": "custom",
-      "format": "\u001b[90m┌────────────────Age / Uptime / Update───────────────┐"
+      "format": "\u001b[90m┌───────────Age / Install / Uptime / Update──────────┐"
     },
     {
       "type": "command",
       "key": "󱦟 OS Age",
       "keyColor": "magenta",
       "text": "echo $(( ($(date +%s) - $(stat -c %W /)) / 86400 )) days"
+    },
+    {
+      "type": "command",
+      "key": "󰔟 Installed In",
+      "keyColor": "magenta",
+      "text": "omarchy-install-duration 2>/dev/null"
     },
     {
       "type": "uptime",

--- a/test/shell.d/install-duration-test.sh
+++ b/test/shell.d/install-duration-test.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command jq
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+timing_file="$tmp_dir/omarchy-install-timing.json"
+duration_command="$ROOT/bin/omarchy-install-duration"
+
+install_duration() {
+  OMARCHY_INSTALL_TIMING_FILE="$timing_file" "$duration_command"
+}
+
+assert_duration() {
+  local expected="$1" description="$2" actual
+  actual=$(install_duration)
+  [[ $actual == $expected ]] || fail "$description" "expected: $expected; actual: ${actual:-<empty>}"
+  pass "$description"
+}
+
+assert_omitted() {
+  local description="$1" output status
+
+  if output=$(install_duration 2>&1); then
+    status=0
+  else
+    status=$?
+  fi
+
+  (( status == 0 )) || fail "$description" "exited with status $status"
+  [[ -z $output ]] || fail "$description" "unexpected output: $output"
+  pass "$description"
+}
+
+printf '{"started_at":1000,"finished_at":1042}\n' >"$timing_file"
+assert_duration "42s" "installation durations under one minute show seconds"
+
+printf '{"started_at":1000.1,"finished_at":1068.4}\n' >"$timing_file"
+assert_duration "1m 8s" "installation durations over one minute show minutes and seconds"
+
+printf '{"started_at":1000,"finished_at":4723}\n' >"$timing_file"
+assert_duration "1h 2m 3s" "installation durations over one hour show hours, minutes, and seconds"
+
+rm "$timing_file"
+assert_omitted "a missing timing file omits the installation duration"
+
+printf 'not json\n' >"$timing_file"
+assert_omitted "malformed timing JSON omits the installation duration"
+
+chmod 000 "$timing_file"
+assert_omitted "an unreadable timing file omits the installation duration"
+chmod 600 "$timing_file"
+
+printf '{"started_at":1000}\n' >"$timing_file"
+assert_omitted "a missing finish timestamp omits the installation duration"
+
+printf '{"started_at":"yesterday","finished_at":1042}\n' >"$timing_file"
+assert_omitted "nonnumeric timestamps omit the installation duration"
+
+printf '{"started_at":1042,"finished_at":1000}\n' >"$timing_file"
+assert_omitted "a finish before the start omits the installation duration"
+
+jq -e '
+  .modules[]
+  | select(type == "object" and .type == "command" and .key == "󰔟 Installed In")
+  | .text == "omarchy-install-duration 2>/dev/null"
+' "$ROOT/etc/fastfetch/config.jsonc" >/dev/null || fail "Fastfetch includes the installation duration helper"
+pass "Fastfetch includes the installation duration helper"


### PR DESCRIPTION
What

- Add an `Installed In` row to the default Fastfetch/About output when Omarchy installation timing data is available.
- Add a small hidden helper command to read `/var/log/omarchy-install-timing.json`, validate it, and format the duration.

Why

- The ISO installer already records successful install start/end timing, but the default About output does not surface it.
- Showing the duration helps make fresh installs feel complete without adding another timer or state file.

How

- Reuses the persisted `started_at` and `finished_at` values from `/var/log/omarchy-install-timing.json`.
- Uses `jq`, which is already part of the default Omarchy package set, for JSON parsing and validation.
- Omits the Fastfetch row naturally when timing data is missing, unreadable, malformed, incomplete, nonnumeric, or backwards.

Testing

- `./test/shell.d/install-duration-test.sh`
- `env -u NO_COLOR ./test/shell.d/launch-about-test.sh`
- `./test/cli`
- `./test/shell`
- `./bin/omarchy commands --check`
- `bash -n bin/omarchy-install-duration test/shell.d/install-duration-test.sh`
- `git diff --check`

Backward compatibility

- Older installations without `/var/log/omarchy-install-timing.json` continue to render Fastfetch/About normally.
- Invalid or unreadable timing data produces no row and no shell/jq errors in the About output.
