### PR TITLE
Run declared plugin cleanup before removal

### DIFF
--- a/bin/omarchy-plugin-remove
+++ b/bin/omarchy-plugin-remove
@@ -2,13 +2,14 @@
 
 # omarchy:summary=Remove an installed shell plugin
 # omarchy:group=plugin
-# omarchy:args=[id] [--yes]
+# omarchy:args=[id] [--yes] [--skip-cleanup]
 # omarchy:alias=omarchy plugin rm
 
 set -euo pipefail
 
 PLUGINS_DIR="$HOME/.config/omarchy/plugins"
 ASSUME_YES=0
+SKIP_CLEANUP=0
 
 fail() {
   echo "omarchy-plugin-remove: $*" >&2
@@ -41,8 +42,15 @@ while (( $# > 0 )); do
     ASSUME_YES=1
     shift
     ;;
+  --skip-cleanup)
+    SKIP_CLEANUP=1
+    shift
+    ;;
   -h | --help)
-    echo "Usage: omarchy plugin remove [id] [--yes]"
+    echo "Usage: omarchy plugin remove [id] [--yes] [--skip-cleanup]"
+    echo "Runs a declared uninstall entry point as your user before removing files."
+    echo "--yes also approves running cleanup and passes --yes to it."
+    echo "--skip-cleanup removes files without running plugin code; local setup may remain."
     exit 0
     ;;
   -*)
@@ -67,6 +75,7 @@ if [[ -z $id ]]; then
   [[ -n $id ]] || fail "nothing selected"
 fi
 valid_plugin_id "$id" || fail "invalid plugin id '$id'"
+[[ ${OMARCHY_PLUGIN_REMOVAL_ID:-} != "$id" ]] || fail "an uninstall hook must not recursively remove its own plugin"
 
 target="$PLUGINS_DIR/$id"
 [[ -e $target || -L $target ]] || fail "plugin '$id' is not installed"
@@ -81,19 +90,52 @@ fi
 
 cloned_from=""
 if [[ -f $target/manifest.json ]]; then
-  cloned_from=$(jq -r '.omarchy.clonedFrom // empty' "$target/manifest.json")
+  cloned_from=$(jq -r '.omarchy.clonedFrom // empty' "$target/manifest.json" 2>/dev/null || true)
+fi
+
+cleanup=""
+if (( SKIP_CLEANUP )); then
+  echo "Skipping plugin-provided cleanup. Local setup may remain."
+elif [[ ! -L $target && -f $target/manifest.json ]]; then
+  cleanup=$(omarchy-plugin-uninstall-path "$target") || fail "invalid uninstall entry point; inspect it or use --skip-cleanup to remove without running plugin code"
+fi
+
+cleanup_notice=""
+if [[ -n $cleanup ]]; then
+  cleanup_notice=" Run its uninstall entry point (${cleanup#"$target/"}) as your user first?"
+  echo "Cleanup executes unsandboxed plugin code. Review it before approving."
 fi
 
 if [[ -L $target ]]; then
+  echo "Symlinked plugins are unlinked without running cleanup. Local setup may remain."
   confirm "Unlink '$id' (symlink -> $(readlink "$target"))?" || fail "aborted"
 elif [[ -d $target/.git ]]; then
-  confirm "Delete '$id'? Its git repo remains upstream." || fail "aborted"
+  confirm "Delete '$id'? Its git repo remains upstream.$cleanup_notice" || fail "aborted"
 else
-  confirm "Remove '$id'? The folder will be backed up." || fail "aborted"
+  confirm "Remove '$id'? The folder will be backed up.$cleanup_notice" || fail "aborted"
 fi
 
 if [[ $was_enabled == "true" ]]; then
-  omarchy-shell shell setPluginEnabled "$id" false >/dev/null
+  disabled=$(omarchy-shell shell setPluginEnabled "$id" false)
+  [[ $disabled == "ok" ]] || fail "could not disable '$id'; cleanup was not run"
+fi
+
+if [[ -n $cleanup ]]; then
+  checked_cleanup=$(omarchy-plugin-uninstall-path "$target") || fail "uninstall entry point changed before execution; plugin files were kept"
+  [[ $checked_cleanup == "$cleanup" ]] || fail "uninstall entry point changed during confirmation; retry removal"
+  cleanup_args=()
+  (( ASSUME_YES )) && cleanup_args+=(--yes)
+  echo "Running cleanup for $id..."
+  if (
+    cd -- "$target"
+    export OMARCHY_PLUGIN_REMOVAL_ID="$id"
+    export OMARCHY_PLUGIN_DIR="$target"
+    "$cleanup" "${cleanup_args[@]}"
+  ); then
+    echo "Cleanup completed for $id."
+  else
+    fail "cleanup failed; plugin files were kept for retry. The plugin may be disabled. Use --skip-cleanup only to bypass cleanup knowingly"
+  fi
 fi
 
 if [[ -L $target ]]; then

--- a/bin/omarchy-plugin-uninstall-path
+++ b/bin/omarchy-plugin-uninstall-path
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# omarchy:summary=Validate and resolve a plugin's optional uninstall entry point
+# omarchy:args=<plugin-folder>
+# omarchy:hidden=true
+
+set -euo pipefail
+
+fail() {
+  echo "omarchy-plugin-uninstall-path: $*" >&2
+  exit 1
+}
+
+if [[ ${1:-} == "--help" || ${1:-} == "-h" ]]; then
+  echo "Usage: omarchy-plugin-uninstall-path <plugin-folder>"
+  exit 0
+fi
+
+target="${1:-}"
+[[ -d $target && ! -L $target ]] || fail "cleanup requires a real plugin directory; use --skip-cleanup to unlink without executing code"
+manifest="$target/manifest.json"
+[[ -f $manifest && ! -L $manifest ]] || fail "cleanup requires a regular manifest.json"
+jq -e 'type == "object" and (.entryPoints | type == "object")' "$manifest" >/dev/null || fail "invalid manifest"
+jq -e '.entryPoints | has("uninstall")' "$manifest" >/dev/null || exit 0
+jq -e '.entryPoints.uninstall | type == "string" and length > 0 and (explode | all(.[]; . >= 32 and . != 127))' \
+  "$manifest" >/dev/null || fail "entryPoints.uninstall must be a non-empty path without control characters"
+entry=$(jq -r '.entryPoints.uninstall' "$manifest")
+[[ $entry != /* && $entry != *..* && $entry != */ && $entry != *//* ]] || fail "uninstall entry point must be a safe relative path"
+
+# Check every component, not only the executable: a symlinked parent can also
+# escape the plugin directory. Never eval a manifest value or follow a link.
+current="$target"
+IFS=/ read -r -a components <<<"$entry"
+for component in "${components[@]}"; do
+  [[ -n $component && $component != "." ]] || fail "uninstall entry point contains an empty or dot component"
+  current="$current/$component"
+  [[ ! -L $current ]] || fail "uninstall entry point may not traverse symlinks"
+done
+[[ -f $current && -x $current ]] || fail "uninstall entry point is missing or not executable: $entry"
+printf '%s\n' "$current"

--- a/bin/omarchy-plugin-validate
+++ b/bin/omarchy-plugin-validate
@@ -115,4 +115,8 @@ done
 link=$(find "$PLUGIN_DIR" -name .git -prune -o -type l -print -quit 2>/dev/null)
 [[ -z $link ]] || fail "symlinks are not allowed inside a plugin folder: $link"
 
+if jq -e '.entryPoints | has("uninstall")' "$MANIFEST" >/dev/null; then
+  omarchy-plugin-uninstall-path "$PLUGIN_DIR" >/dev/null || fail "invalid uninstall entry point"
+fi
+
 exit 0

--- a/docs/plugin-uninstall.md
+++ b/docs/plugin-uninstall.md
@@ -1,0 +1,22 @@
+# Plugin uninstall entry point
+
+A plugin may declare an optional executable alongside its QML entry points:
+
+```json
+"entryPoints": {
+  "barWidget": "Widget.qml",
+  "uninstall": "bin/cleanup"
+}
+```
+
+The CLI validates the path during add/update and revalidates it immediately before removal. It must be a non-empty relative path to an executable regular file, without control characters, `..`, dot/empty components or symlinks. The same hidden path helper owns both checks. The shell registry treats it as an ordinary safe entry-point path; no new plugin kind or QML lifecycle callback is introduced.
+
+`omarchy plugin remove` obtains user confirmation, disables the plugin and runs the executable with the plugin directory as its working directory. `OMARCHY_PLUGIN_REMOVAL_ID` names the plugin and `OMARCHY_PLUGIN_DIR` names its directory. The hook runs synchronously with the caller's stdin/stdout/stderr and user privileges. `--yes` is passed to the hook only when supplied to removal; it explicitly approves executing the disclosed plugin code, including for a plugin that has never been enabled. No other command-line text is forwarded.
+
+The hook owns only its external local cleanup. It must not remove or move its own plugin directory or recursively call `omarchy plugin remove`: Omarchy owns disabling, deleting/unlinking/backing up the folder and rescanning the registry. Use the environment marker to share a cleanup implementation with a plugin's own uninstall UI without recursion.
+
+Exit zero only after cleanup completed and its outcomes were verified. Nonzero exits, including cancellation, abort file removal and leave the plugin directory available for retry. Cleanup is not transactional: earlier hook changes may have taken effect, and the plugin remains disabled if it was disabled before the failure. Make the hook idempotent, retain recovery information on partial failure, and explain how to retry. Do not claim that uninstallation succeeded until the outer command finishes.
+
+For non-interactive use, honor `--yes` without unexpectedly prompting. Preserve shared tools, credentials for unrelated integrations and SSH keys unless the user explicitly chose their removal. If a required privilege prompt cannot be shown, fail with instructions; Omarchy does not silently run the hook as root. Warn explicitly when billable cloud resources are left behind. A cleanup hook is unsandboxed plugin code, not a guarantee that any of these plugin-author policies are enforced by the host.
+
+`--skip-cleanup` bypasses hook parsing and execution for recovery or untrusted plugins, warning that external setup may remain. Symlinked plugin directories are always unlinked without executing code. Plugins without the entry point keep the existing removal behavior. No hook runs during add, update, disable, shell reload or logout.

--- a/manual/32-shell-plugins.md
+++ b/manual/32-shell-plugins.md
@@ -58,6 +58,12 @@ omarchy plugin remove acme.weather
 
 Removal disables the plugin first, then deletes it if it's a git checkout (the repo is still upstream) or unlinks it if it's a symlink. A hand-made plugin folder with no git repo gets moved to a timestamped backup inside the plugins directory instead of being deleted outright.
 
+Some plugins also install local services, account connections or tools outside their folder. A plugin can declare an uninstall entry point to clean up that local setup. Removal tells you when it will execute this plugin-provided code and asks for confirmation. The cleanup runs visibly as your user, after disabling the plugin but before removing its files. If it fails or is canceled, the files stay available for retry; the plugin may remain disabled.
+
+For automation, `omarchy plugin remove acme.weather --yes` also approves cleanup and passes `--yes` to it. Read the plugin's removal policy first: the hook must disclose what it removes or retains. Omarchy does not automatically elevate privileges or decide what should happen to cloud resources.
+
+If you do not trust the hook, or it is broken, use `omarchy plugin remove acme.weather --skip-cleanup`. This removes the plugin without executing its cleanup; services, credentials or other local setup may remain. Symlinked plugin folders are always unlinked without executing a hook.
+
 ## Cloning a built-in to modify it
 
 This is my favorite part. If you want to change how a built-in widget behaves, don't edit the files under `$OMARCHY_PATH` — those belong to the package and the next update will overwrite them. Clone it instead:
@@ -96,6 +102,8 @@ omarchy plugin validate ./my-plugin
 That runs the same checks the shell does at load time: the schema version, the required fields, an id that isn't reserved, entry points that are safe relative paths and actually exist, an entry point for every kind you claimed, and no symlinks anywhere inside the folder.
 
 For the full picture, the source is the documentation: `shell/README.md` in the Omarchy repo covers the manifest schema, the shell's IPC contract, and the exact shape of `shell.json`, and `shell/plugins/README.md` lists every first-party plugin with its id, kinds, and entry points.
+
+Plugins with external local setup can declare `entryPoints.uninstall` as a relative path to an executable in their repository. The [uninstall hook contract](https://github.com/omacom/omarchy/blob/quattro/docs/plugin-uninstall.md) explains confirmation, failure handling and automation. Adding or updating a plugin never executes this entry point.
 
 ## Sharing yours with the world
 

--- a/test/shell.d/plugin-remove-test.sh
+++ b/test/shell.d/plugin-remove-test.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+
+set -euo pipefail
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+require_command jq
+
+test_dir=$(mktemp -d)
+trap 'rm -rf -- "$test_dir"' EXIT
+stub_dir="$test_dir/stubs"
+mkdir -p "$stub_dir"
+cat >"$stub_dir/omarchy-shell" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$*" >>"$HOME/events"
+case "$2" in
+listPlugins) printf '[{"id":"acme.test","enabled":true}]\n' ;;
+setPluginEnabled) echo "${DISABLE_RESULT:-ok}" ;;
+rescanPlugins) echo ok ;;
+esac
+STUB
+cat >"$stub_dir/gum" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$*" >>"$HOME/prompts"
+exit "${GUM_STATUS:-0}"
+STUB
+chmod +x "$stub_dir/omarchy-shell" "$stub_dir/gum"
+
+fixture() {
+  test_home="$test_dir/$1"
+  plugin="$test_home/.config/omarchy/plugins/acme.test"
+  mkdir -p "$plugin/bin"
+  printf '%s\n' '{"schemaVersion":1,"id":"acme.test","name":"Test","version":"1","kinds":["bar-widget"],"entryPoints":{"barWidget":"Widget.qml","uninstall":"bin/cleanup"}}' >"$plugin/manifest.json"
+  touch "$plugin/Widget.qml" "$test_home/external-setup"
+  cat >"$plugin/bin/cleanup" <<'HOOK'
+#!/bin/bash
+set -euo pipefail
+[[ $PWD == "$OMARCHY_PLUGIN_DIR" && $OMARCHY_PLUGIN_REMOVAL_ID == "acme.test" ]]
+[[ -f $OMARCHY_PLUGIN_DIR/manifest.json ]]
+printf 'cleanup %s\n' "$*" >>"$HOME/events"
+exit_code=${HOOK_STATUS:-0}
+if (( exit_code == 0 )); then
+  rm -- "$HOME/external-setup"
+fi
+exit "$exit_code"
+HOOK
+  chmod +x "$plugin/bin/cleanup"
+}
+
+remove_plugin() {
+  HOME="$test_home" OMARCHY_PATH="$ROOT" PATH="$stub_dir:$ROOT/bin:$PATH" \
+    "$ROOT/bin/omarchy-plugin-remove" acme.test "$@" 2>&1
+}
+
+fixture success
+mkdir "$plugin/.git"
+output=$(remove_plugin --yes) || fail "cleanup succeeds" "$output"
+[[ ! -e $plugin && ! -e $test_home/external-setup ]] || fail "cleanup removes external setup before checkout removal"
+grep -qFx 'cleanup --yes' "$test_home/events" || fail "explicit approval is forwarded to cleanup"
+expected=$'shell listPlugins\nshell setPluginEnabled acme.test false\ncleanup --yes\nshell rescanPlugins'
+[[ $(<"$test_home/events") == "$expected" ]] || fail "disable, cleanup, removal and rescan are ordered" "$(<"$test_home/events")"
+grep -qF 'unsandboxed plugin code' <<<"$output" || fail "automation also sees the execution warning"
+pass "approved cleanup runs in the plugin directory before removal and rescan"
+
+fixture failure
+output=$(HOOK_STATUS=7 remove_plugin --yes) && fail "failed cleanup aborts removal"
+[[ -f $plugin/manifest.json && -f $test_home/external-setup ]] || fail "failed cleanup preserves files for retry"
+! grep -qF rescanPlugins "$test_home/events" || fail "failed cleanup never reaches rescan"
+grep -qF 'plugin files were kept' <<<"$output" || fail "failure explains retention"
+output=$(remove_plugin --yes) || fail "cleanup can be retried" "$output"
+[[ ! -e $plugin && ! -e $test_home/external-setup ]] || fail "retry finishes removal"
+pass "failed cleanup keeps the plugin for retry and a retry completes"
+
+fixture unconfirmed
+output=$(remove_plugin </dev/null) && fail "non-interactive cleanup requires approval"
+[[ -f $plugin/manifest.json && ! -e $test_home/prompts ]] || fail "unconfirmed removal preserves plugin"
+! grep -qF cleanup "$test_home/events" || fail "unconfirmed cleanup never runs"
+pass "non-interactive removal without --yes executes no plugin code"
+
+fixture disable-failed
+output=$(DISABLE_RESULT=failed remove_plugin --yes) && fail "failed widget unload aborts cleanup"
+[[ -f $plugin/manifest.json && -f $test_home/external-setup ]] || fail "failed widget unload preserves setup"
+! grep -qF cleanup "$test_home/events" || fail "failed widget unload never executes cleanup"
+pass "IPC-level disable failure cannot be mistaken for successful unload"
+
+fixture skipped
+printf 'not json\n' >"$plugin/manifest.json"
+output=$(remove_plugin --yes --skip-cleanup) || fail "explicit bypass works even with a broken manifest" "$output"
+[[ ! -e $plugin && -f $test_home/external-setup ]] || fail "bypass removes only plugin files"
+! grep -qF cleanup "$test_home/events" || fail "bypass does not run plugin code"
+grep -qF 'Local setup may remain' <<<"$output" || fail "bypass warns about retained setup"
+pass "explicit cleanup bypass removes broken plugins without running code"
+
+fixture no-hook
+jq 'del(.entryPoints.uninstall)' "$plugin/manifest.json" >"$plugin/next.json"
+mv "$plugin/next.json" "$plugin/manifest.json"
+output=$(remove_plugin --yes) || fail "legacy removal remains supported" "$output"
+[[ ! -e $plugin && -f $test_home/external-setup ]] || fail "legacy removal keeps external setup"
+compgen -G "$test_home/.config/omarchy/plugins/.acme.test.bak.*" >/dev/null || fail "hand-made plugin is backed up"
+pass "plugins without hooks retain existing backup behavior"
+
+fixture symlink
+mv "$plugin" "$test_home/source"
+ln -s "$test_home/source" "$plugin"
+output=$(remove_plugin --yes) || fail "symlink removal succeeds" "$output"
+[[ ! -L $plugin && -f $test_home/source/manifest.json && -f $test_home/external-setup ]] || fail "symlink removal only unlinks"
+! grep -qF cleanup "$test_home/events" || fail "symlink cleanup is not executed"
+pass "symlinked plugins are unlinked without executing their code"
+
+for entry in '"/tmp/outside"' '"../outside"' '"bin/../cleanup"' '"bin//cleanup"' '"bin/cleanup/"' '"bin/./cleanup"' '""' 'null' '[]' '123' '"bin/cleanup\n"' '"bin/cleanup\r"' '"bin/cleanup\u0000"'; do
+  fixture invalid
+  jq --argjson entry "$entry" '.entryPoints.uninstall = $entry' "$plugin/manifest.json" >"$plugin/next.json"
+  mv "$plugin/next.json" "$plugin/manifest.json"
+  output=$(remove_plugin --yes) && fail "unsafe hook path is rejected: $entry"
+  [[ -f $plugin/manifest.json && -f $test_home/external-setup ]] || fail "invalid hook preserves files"
+done
+pass "unsafe paths, control characters and invalid hook types are rejected"
+
+fixture linked-executable
+mv "$plugin/bin/cleanup" "$test_home/cleanup"
+ln -s "$test_home/cleanup" "$plugin/bin/cleanup"
+output=$(remove_plugin --yes) && fail "symlinked executable is rejected"
+[[ -f $test_home/external-setup ]] || fail "symlinked executable never runs"
+fixture linked-parent
+mv "$plugin/bin" "$test_home/outside"
+ln -s "$test_home/outside" "$plugin/bin"
+output=$(remove_plugin --yes) && fail "symlinked parent is rejected"
+pass "both executable and parent symlinks are rejected"
+
+fixture permissions
+chmod -x "$plugin/bin/cleanup"
+output=$(remove_plugin --yes) && fail "non-executable hook is rejected"
+PATH="$ROOT/bin:$PATH" "$ROOT/bin/omarchy-plugin-validate" "$plugin" >/dev/null 2>&1 && fail "install validation rejects non-executable hook"
+chmod +x "$plugin/bin/cleanup"
+PATH="$ROOT/bin:$PATH" "$ROOT/bin/omarchy-plugin-validate" "$plugin" >/dev/null || fail "install validation accepts executable hook"
+pass "install and removal enforce the same executable hook contract"
+
+fixture recursive
+output=$(OMARCHY_PLUGIN_REMOVAL_ID=acme.test remove_plugin --yes) && fail "recursive self-removal is rejected"
+[[ -f $plugin/manifest.json ]] || fail "recursive removal preserves plugin"
+pass "recursive self-removal fails before cleanup"
+
+if script -qec true /dev/null >/dev/null 2>&1; then
+  fixture canceled
+  output=$(HOME="$test_home" OMARCHY_PATH="$ROOT" PATH="$stub_dir:$ROOT/bin:$PATH" GUM_STATUS=1 \
+    script -qec 'omarchy-plugin-remove acme.test' /dev/null) && fail "cancellation aborts removal"
+  [[ -f $plugin/manifest.json && -f $test_home/external-setup ]] || fail "cancellation preserves setup"
+  grep -qF 'uninstall entry point' "$test_home/prompts" || fail "confirmation names the code to execute"
+  ! grep -qF cleanup "$test_home/events" || fail "cancellation never executes cleanup"
+  pass "interactive confirmation discloses execution and cancellation runs no code"
+else
+  pass "script -qec unavailable; skipping interactive confirmation case"
+fi


### PR DESCRIPTION
## Why

Plugins can create local state outside their checkout after the user enables and sets them up: user services, agent registrations, credentials and private runtime caches. Today `omarchy plugin remove` only unloads/removes the checkout, so removal from the menu or an agent can leave that setup behind even when the plugin provides its own complete uninstall UI.

## Proposed contract

- Optional `entryPoints.uninstall` names a repository-local executable. Add/update validate it but never run it.
- Removal discloses execution of unsandboxed plugin code and obtains confirmation. `--yes` explicitly approves cleanup and is the only argument passed through to the hook.
- Disable the plugin, run cleanup synchronously as the current user, then remove/back up its files and rescan. A failed disable or nonzero cleanup result stops removal; the checkout remains available for retry. Cleanup itself is not transactional and may already have made changes.
- `OMARCHY_PLUGIN_REMOVAL_ID` and `OMARCHY_PLUGIN_DIR` let a plugin share an implementation with its own uninstall UI without recursively removing itself.
- `--skip-cleanup` is an explicit recovery/untrusted-code escape hatch and warns about leftovers. Symlinked checkouts are unlinked without executing a hook.

The shared path validator rejects absolute/traversing paths, control characters, non-string values, missing/non-executable files and symlink components. Removal revalidates the approved entry point before execution. No install, update, disable or shell-reload hooks are added, and Omarchy never elevates the hook itself.

The documentation asks plugin authors to make cleanup idempotent, preserve shared tools and access keys by default, disclose cloud-resource/billing boundaries, and return nonzero on cancellation. These are author responsibilities, not a new sandbox or a guarantee enforced by the host.

## Tests

- New removal suite: 12 passing checks, including the interactive confirmation/cancellation path through a private PTY, failure/retry, IPC-level disable failure, explicit bypass, symlinks, malformed paths and recursive removal.
- Existing plugin validation and other plugin suites pass; CLI routing/metadata suite passes.
- Ran `./test/all` on Linux in an isolated home with no graphical session: 231/237 shell test files passed. The six failures reproduce on unmodified base `31bd80daa4613ffdee995ac27467fce5a2990806`: `ascii-test`, `branding-about-animation-test`, three suites requiring a sibling `omarchy-pkgs` checkout (`config`, `snapper`, `unowned-system-paths`), and `locate-test` after the agent-scanner tests create `.pyc` files under `bin/`. The focused removal/validation suites were rerun after the final disable-result check.
- Cross-repository smoke tests with the Nebius plugin exercise the real remove command plus the same uninstaller from its panel command and stdio MCP agent tool, using temporary homes and fake shell IPC/services/cloud data. All three routes clean the declared local state and preserve access keys/unrelated data. Canceling the plugin cleanup retains its files.

No running desktop, installed Omarchy files or real cloud resources were changed by these tests. This PR proposes the host API; downstream plugins must opt in, and existing Omarchy releases do not gain cleanup behavior until it ships.
