### PR TITLE
Allow mouse wheel to cycle choices in image pickers (background and theme choosers)

### DIFF
--- a/shell/plugins/image-picker/ImagePicker.qml
+++ b/shell/plugins/image-picker/ImagePicker.qml
@@ -404,6 +404,19 @@ Item {
 
           readonly property real itemStep: root.sliceWidth + root.sliceSpacing
           readonly property real previewX: (width - root.expandedWidth) / 2
+          property real wheelAccumulator: 0
+
+          MouseArea {
+            anchors.fill: parent
+            onWheel: function(wheel) {
+              var steps = Util.wheelSteps(carousel.wheelAccumulator, wheel.angleDelta.y)
+              carousel.wheelAccumulator = steps.remainder
+              if (steps.steps !== 0) {
+                var dir = steps.steps > 0 ? -1 : 1
+                root.selectAdjacent(dir)
+              }
+            }
+          }
 
           Keys.priority: Keys.BeforeItem
           Keys.onPressed: function(event) {


### PR DESCRIPTION
Add mouse wheel navigation to , enabling users to cycle through choices using their mouse wheel in both the background chooser and the theme switcher, matching the left/right keyboard navigation.