### PR TITLE
Detach nightlight startup from captured command output

### DIFF
--- a/bin/omarchy-toggle-nightlight
+++ b/bin/omarchy-toggle-nightlight
@@ -36,7 +36,7 @@ fi
 
 # Ensure hyprsunset is running
 if ! pgrep -x hyprsunset >/dev/null; then
-  setsid uwsm-app -- hyprsunset &
+  setsid uwsm-app -- hyprsunset </dev/null >/dev/null 2>&1 &
 fi
 
 # Query the current temperature

--- a/test/shell.d/nightlight-test.sh
+++ b/test/shell.d/nightlight-test.sh
@@ -90,3 +90,27 @@ if rg -q 'omarchy.indicators' "$ROOT/bin/omarchy-toggle-nightlight"; then
   fail "nightlight toggle leaves indicator refresh to the nightlight service"
 fi
 pass "nightlight toggle leaves indicator refresh to the nightlight service"
+
+# A long-lived daemon must not keep a captured toggle's output pipe open.
+cat >"$TMPDIR/bin/pgrep" <<'SH'
+#!/bin/bash
+exit 1
+SH
+cat >"$TMPDIR/bin/uwsm-app" <<'SH'
+#!/bin/bash
+[[ $* == "-- hyprsunset" ]] || exit 1
+printf '%s\n' "$$" >"$DAEMON_PID_FILE"
+exec sleep 30
+SH
+chmod +x "$TMPDIR/bin/uwsm-app"
+trap '[[ ! -s $TMPDIR/daemon-pid ]] || kill "$(<"$TMPDIR/daemon-pid")" 2>/dev/null || true; rm -rf "$TMPDIR"' EXIT
+
+if PATH="$TMPDIR/bin:$PATH" HYPRSUNSET_STATE="$STATE" OMARCHY_SHELL_LOG="$SHELL_LOG" \
+  DAEMON_PID_FILE="$TMPDIR/daemon-pid" \
+  timeout 3 bash -c '"$1" 2>&1 | cat' _ "$ROOT/bin/omarchy-toggle-nightlight" >"$TMPDIR/captured"; then
+  [[ -s $TMPDIR/daemon-pid ]] || fail "nightlight starts the missing daemon"
+  kill -0 "$(<"$TMPDIR/daemon-pid")" || fail "nightlight leaves its daemon running"
+  pass "nightlight closes captured output while the daemon stays running"
+else
+  fail "nightlight closes captured output without waiting for its daemon"
+fi


### PR DESCRIPTION
Stops nightlight from hanging settings plugins that capture its output. Fixes #11457.

<<<< AI wording below >>>>

## Problem

When nightlight starts hyprsunset, the daemon inherits the caller's output pipes. A plugin that captures the toggle's output can wait indefinitely for EOF and block later settings changes.

Fixes #11457.

## Fix

Detach stdin, stdout and stderr when starting hyprsunset. The toggle keeps its own output while the daemon can outlive the caller.

## Verification

`bash test/shell.d/nightlight-test.sh` passes, including a captured-output regression that must finish within three seconds while a stub daemon remains alive. Existing nightlight state tests pass. Hyprland and the daemon are stubbed; no desktop settings were changed.

`git diff --check` passes. Changed shell files pass `bash -n`, and the command style checks pass.
