### PR TITLE
Reconcile hibernation resume parameters with the swapfile

### DIFF
--- a/bin/omarchy-hibernation-setup
+++ b/bin/omarchy-hibernation-setup
@@ -59,17 +59,66 @@ safe_stage_path() {
   [[ $suffix =~ ^[[:alnum:]]{6}$ ]]
 }
 
-# Check if hibernation is already configured
+reconcile_resume_parameters() {
+  local device offset desired current staged
+  RESUME_CHANGED=false
+  RESUME_PREVIOUS=""
+
+  if ! device=$(findmnt -no SOURCE -T "$SWAP_FILE") || [[ -z $device ]]; then
+    echo "Could not determine the device containing $SWAP_FILE" >&2
+    return 1
+  fi
+  device=${device%%\[*}
+  if [[ ! $device =~ ^/dev/[[:alnum:]_./:+-]+$ ]] ||
+    ! offset=$(sudo btrfs inspect-internal map-swapfile -r "$SWAP_FILE") ||
+    [[ ! $offset =~ ^[0-9]+$ ]]; then
+    echo "Could not determine valid resume parameters for $SWAP_FILE" >&2
+    return 1
+  fi
+
+  desired="KERNEL_CMDLINE[default]+=\" resume=$device resume_offset=$offset\""
+  if [[ -f $RESUME_DROP_IN ]]; then
+    current=$(<"$RESUME_DROP_IN")
+    [[ $current != "$desired" ]] || return 0
+    # Only replace the single line this command owns. Custom drop-ins need
+    # manual reconciliation so unrelated kernel parameters are not discarded.
+    if [[ ! $current =~ ^KERNEL_CMDLINE\[default\]\+=\"[[:space:]]resume=[^\"[:space:]]+[[:space:]]resume_offset=[0-9]*\"$ ]]; then
+      echo "Custom resume configuration in $RESUME_DROP_IN; update its resume parameters manually." >&2
+      return 1
+    fi
+  fi
+
+  RESUME_PREVIOUS=${current:-}
+  staged=$(mktemp) || return 1
+  printf '%s\n' "$desired" >"$staged"
+  if sudo mkdir -p "${RESUME_DROP_IN%/*}" && install_root_file "$staged" "$RESUME_DROP_IN" 0644; then
+    rm -f "$staged"
+    RESUME_CHANGED=true
+    echo "Updated resume parameters for $SWAP_FILE"
+  else
+    rm -f "$staged"
+    return 1
+  fi
+}
+
+# Recreated swapfiles can move even when hibernation is already configured.
 if [[ -f $MKINITCPIO_CONF ]] && grep -q "^HOOKS+=(resume)$" "$MKINITCPIO_CONF"; then
-  # Fix empty resume_offset if btrfs map-swapfile failed during initial setup
-  if [[ -f $RESUME_DROP_IN ]] && grep -q 'resume_offset="$' "$RESUME_DROP_IN" && [[ -f $SWAP_FILE ]]; then
-    RESUME_OFFSET=$(sudo btrfs inspect-internal map-swapfile -r "$SWAP_FILE" 2>/dev/null)
-    if [[ -n $RESUME_OFFSET ]]; then
-      echo "Fixing empty resume_offset ($RESUME_OFFSET)"
-      sudo sed -i "s/resume_offset=\"$/resume_offset=$RESUME_OFFSET\"/" "$RESUME_DROP_IN"
-      if ! $NO_REBUILD; then
-        sudo limine-mkinitcpio
+  reconcile_resume_parameters || exit 1
+  if $RESUME_CHANGED && ! $NO_REBUILD; then
+    if ! sudo limine-mkinitcpio; then
+      # Leave the old configuration in place so the next setup retries the
+      # rebuild instead of mistaking an unchanged drop-in for an updated UKI.
+      if [[ -n $RESUME_PREVIOUS ]]; then
+        previous=$(mktemp) || exit 1
+        printf '%s\n' "$RESUME_PREVIOUS" >"$previous"
+        install_root_file "$previous" "$RESUME_DROP_IN" 0644 ||
+          echo "Could not restore $RESUME_DROP_IN; rebuild the initramfs manually." >&2
+        rm -f "$previous"
+      else
+        sudo rm -f -- "$RESUME_DROP_IN"
       fi
+      echo "Could not rebuild the initramfs; retry hibernation setup after fixing the build error." >&2
+      exit 1
     fi
   fi
   echo "Hibernation is already set up"
@@ -121,25 +170,13 @@ if ! install_root_file "$OMARCHY_PATH/default/systemd/system-sleep/keyboard-back
   exit 1
 fi
 
+# Validate and install resume parameters before writing the setup marker.
+reconcile_resume_parameters || exit 1
+
 # Add resume hook to mkinitcpio
 sudo mkdir -p /etc/mkinitcpio.conf.d
 echo "Adding resume hook to $MKINITCPIO_CONF"
 echo "HOOKS+=(resume)" | sudo tee "$MKINITCPIO_CONF" >/dev/null
-
-# Add resume= kernel parameters so the initramfs resume hook knows where to find the
-# hibernation image. Without these, resume happens late (after GPU drivers load) and fails.
-if [[ ! -f $RESUME_DROP_IN ]]; then
-  echo "Adding resume kernel parameters"
-  sudo swapon -p 0 "$SWAP_FILE" 2>/dev/null
-  RESUME_DEVICE=$(findmnt -no SOURCE -T "$SWAP_FILE" | sed 's/\[.*\]//')
-  RESUME_OFFSET=$(sudo btrfs inspect-internal map-swapfile -r "$SWAP_FILE")
-  if [[ -n $RESUME_OFFSET ]]; then
-    sudo mkdir -p /etc/limine-entry-tool.d
-    echo "KERNEL_CMDLINE[default]+=\" resume=$RESUME_DEVICE resume_offset=$RESUME_OFFSET\"" | sudo tee "$RESUME_DROP_IN" >/dev/null
-  else
-    echo "Warning: Could not determine resume offset for $SWAP_FILE" >&2
-  fi
-fi
 
 # Use ACPI alarm for RTC wakeup on s2idle systems (needed for suspend-then-hibernate)
 if grep -q "\[s2idle\]" /sys/power/mem_sleep 2>/dev/null; then

--- a/test/shell.d/hibernation-resume-reconcile-test.sh
+++ b/test/shell.d/hibernation-resume-reconcile-test.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+set -euo pipefail
+source "$(dirname "$0")/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+export test_tmp
+mkdir -p "$test_tmp/bin"
+printf 'HOOKS+=(resume)\n' >"$test_tmp/mkinitcpio.conf"
+touch "$test_tmp/image_size" "$test_tmp/swapfile"
+# Execute the already-configured path with every writable path redirected.
+sed '/^if ! $FORCE; then/,$d' "$ROOT/bin/omarchy-hibernation-setup" |
+  sed -e "s|/sys/power/image_size|$test_tmp/image_size|g" \
+    -e "s|/etc/mkinitcpio.conf.d/omarchy_resume.conf|$test_tmp/mkinitcpio.conf|g" \
+    -e "s|/etc/limine-entry-tool.d/resume.conf|$test_tmp/resume.conf|g" \
+    -e "s|/swap/swapfile|$test_tmp/swapfile|g" >"$test_tmp/setup"
+
+sudo() {
+  case "$1" in
+    btrfs) printf '%s\n' "${TEST_OFFSET:-456}" ;;
+    limine-mkinitcpio) echo rebuild >>"$test_tmp/rebuilds"; return "${TEST_REBUILD_STATUS:-0}" ;;
+    /usr/bin/install) cp -- "${@: -2}" ;;
+    *) "$@" ;;
+  esac
+}
+findmnt() { printf '%s\n' '/dev/mapper/root[/swap]'; }
+omarchy-cmd-missing() { return 1; }
+export -f sudo findmnt omarchy-cmd-missing
+
+printf 'KERNEL_CMDLINE[default]+=" resume=/dev/mapper/old resume_offset=123"\n' >"$test_tmp/resume.conf"
+bash "$test_tmp/setup" >"$test_tmp/output"
+grep -Fqx 'KERNEL_CMDLINE[default]+=" resume=/dev/mapper/root resume_offset=456"' "$test_tmp/resume.conf" || fail "resume device and stale offset are reconciled"
+[[ $(wc -l <"$test_tmp/rebuilds") == 1 ]] || fail "changed resume parameters rebuild once"
+pass "existing hibernation follows a relocated swapfile and rebuilds"
+
+bash "$test_tmp/setup" >"$test_tmp/output"
+[[ $(wc -l <"$test_tmp/rebuilds") == 1 ]] || fail "unchanged parameters avoid another rebuild"
+pass "reconciliation is idempotent"
+
+TEST_OFFSET=789 bash "$test_tmp/setup" --no-rebuild >"$test_tmp/output"
+grep -q 'resume_offset=789' "$test_tmp/resume.conf" || fail "no-rebuild still repairs the offset"
+[[ $(wc -l <"$test_tmp/rebuilds") == 1 ]] || fail "no-rebuild leaves rebuilding to the caller"
+pass "no-rebuild repairs parameters without rebuilding"
+
+cp "$test_tmp/resume.conf" "$test_tmp/before"
+if TEST_OFFSET=invalid bash "$test_tmp/setup" >"$test_tmp/output" 2>&1; then
+  fail "invalid swapfile mappings fail setup"
+fi
+cmp -s "$test_tmp/before" "$test_tmp/resume.conf" || fail "mapping failures preserve the previous parameters"
+pass "invalid mappings fail without replacing boot configuration"
+
+printf '# Custom setting\n' >>"$test_tmp/resume.conf"
+cp "$test_tmp/resume.conf" "$test_tmp/before"
+if bash "$test_tmp/setup" >"$test_tmp/output" 2>&1; then
+  fail "custom resume drop-ins require manual reconciliation"
+fi
+cmp -s "$test_tmp/before" "$test_tmp/resume.conf" || fail "custom settings survive"
+pass "custom drop-ins are preserved"
+
+rm "$test_tmp/resume.conf"
+if TEST_REBUILD_STATUS=1 bash "$test_tmp/setup" >"$test_tmp/output" 2>&1; then
+  fail "rebuild failures are reported"
+fi
+[[ ! -e $test_tmp/resume.conf ]] || fail "failed rebuild restores the missing drop-in state"
+bash "$test_tmp/setup" >"$test_tmp/output"
+[[ -s $test_tmp/resume.conf ]] || fail "missing resume drop-in is recreated"
+[[ $(wc -l <"$test_tmp/rebuilds") == 3 ]] || fail "retry rebuilds after a failed first attempt"
+pass "missing drop-ins are repaired and failed rebuilds remain retryable"
+
+cp "$test_tmp/resume.conf" "$test_tmp/before"
+if TEST_OFFSET=999 TEST_REBUILD_STATUS=1 bash "$test_tmp/setup" >"$test_tmp/output" 2>&1; then
+  fail "failed rebuild returns failure for an existing drop-in"
+fi
+cmp -s "$test_tmp/before" "$test_tmp/resume.conf" || fail "failed rebuild restores previous parameters"
+TEST_OFFSET=999 bash "$test_tmp/setup" >"$test_tmp/output"
+[[ $(wc -l <"$test_tmp/rebuilds") == 5 ]] || fail "retry rebuilds existing configuration after failure"
+pass "existing parameters survive failed rebuilds and retries rebuild again"


### PR DESCRIPTION
Repairs stale resume settings when a swapfile has been recreated, so rerunning hibernation setup can fix the boot configuration. Fixes #11437.

<<<< AI wording below >>>>

## Problem

Recreating a swapfile changes its physical offset, but rerunning hibernation setup only repairs an empty offset. A stale nonempty offset survives while the command reports that hibernation is already configured.

Fixes #11437.

## Fix

Read the current swapfile device and Btrfs resume offset on setup. Update the Omarchy-generated drop-in when they differ and rebuild the boot image only when needed. Preserve custom drop-ins for manual reconciliation and reject invalid mappings before writing configuration.

A failed rebuild restores the previous drop-in so a later attempt retries the rebuild. `--no-rebuild` still leaves that step to the caller.

## Verification

`bash test/shell.d/hibernation-resume-reconcile-test.sh` covers changed device/offset, unchanged configuration, missing drop-ins, invalid mappings, custom settings, `--no-rebuild`, failed rebuilds and successful retries. Files and privileged commands use temporary fixtures. Actual hibernation and boot-image generation were not exercised.

`git diff --check` passes. Changed shell files pass `bash -n`, and the command style checks pass.
