### PR TITLE
Detect damaged package records before updating

### DIFF
--- a/bin/omarchy-update-system-pkgs
+++ b/bin/omarchy-update-system-pkgs
@@ -5,6 +5,22 @@
 
 set -e
 
+# Pacman can accept an empty local desc record after an interrupted write,
+# even with -Dk. Check the records themselves before trusting an upgrade.
+database=$(pacman-conf DBPath)
+if [[ ! -d $database/local || ! -r $database/local ]]; then
+  echo "Cannot read the local package database at $database/local" >&2
+  exit 1
+fi
+for record in "$database"/local/*/; do
+  [[ -d $record ]] || continue
+  if [[ ! -s ${record}desc || ! -f ${record}files ]]; then
+    echo "Damaged package database record: $record" >&2
+    echo "Restore this package's database entry and reinstall it before retrying omarchy update." >&2
+    exit 1
+  fi
+done
+
 # The conflict handler's last resort: pacman puts its questions to the person
 # running the update instead of answering them itself. Nothing here may capture
 # a stream, because an upgrade without --noconfirm prompts on stderr. The

--- a/test/shell.d/update-file-conflict-test.sh
+++ b/test/shell.d/update-file-conflict-test.sh
@@ -9,6 +9,9 @@ trap 'rm -rf "$test_tmp"' EXIT
 
 stub_bin="$test_tmp/bin"
 mkdir -p "$stub_bin"
+mkdir -p "$test_tmp/database/local"
+printf '#!/bin/bash\nprintf "%%s\\n" %q\n' "$test_tmp/database" >"$stub_bin/pacman-conf"
+chmod +x "$stub_bin/pacman-conf"
 
 cat >"$stub_bin/sudo" <<'STUB'
 #!/bin/bash

--- a/test/shell.d/update-package-conflict-test.sh
+++ b/test/shell.d/update-package-conflict-test.sh
@@ -11,6 +11,9 @@ trap 'rm -rf "$test_tmp"' EXIT
 
 stub_bin="$test_tmp/bin"
 mkdir -p "$stub_bin"
+mkdir -p "$test_tmp/database/local"
+printf '#!/bin/bash\nprintf "%%s\\n" %q\n' "$test_tmp/database" >"$stub_bin/pacman-conf"
+chmod +x "$stub_bin/pacman-conf"
 
 cat >"$stub_bin/sudo" <<'STUB'
 #!/bin/bash

--- a/test/shell.d/update-package-database-test.sh
+++ b/test/shell.d/update-package-database-test.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+set -euo pipefail
+source "$(dirname "$0")/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+mkdir -p "$test_tmp/bin" "$test_tmp/database/local/example-1.0-1"
+export TEST_LOG="$test_tmp/calls" TEST_DATABASE="$test_tmp/database"
+cat >"$test_tmp/bin/pacman-conf" <<'STUB'
+#!/bin/bash
+[[ $1 == "DBPath" ]] || exit 99
+printf '%s\n' "$TEST_DATABASE"
+STUB
+cat >"$test_tmp/bin/sudo" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$*" >>"$TEST_LOG"
+[[ $* == *'pacman -Syu '* ]]
+STUB
+cat >"$test_tmp/bin/omarchy-update-system-pkgs-when-conflicted" <<'STUB'
+#!/bin/bash
+echo conflict-handler >>"$TEST_LOG"
+exit 0
+STUB
+chmod +x "$test_tmp/bin/"*
+export PATH="$test_tmp/bin:$PATH"
+record="$TEST_DATABASE/local/example-1.0-1"
+
+for damage in empty-desc missing-desc missing-files; do
+  printf '%%NAME%%\nexample\n\n%%VERSION%%\n1.0-1\n' >"$record/desc"
+  : >"$record/files"
+  case "$damage" in
+    empty-desc) : >"$record/desc" ;;
+    missing-desc) rm "$record/desc" ;;
+    missing-files) rm "$record/files" ;;
+  esac
+  for interactive in 0 1; do
+    : >"$TEST_LOG"
+    if OMARCHY_UPDATE_CONFLICT=1 OMARCHY_UPDATE_INTERACTIVE="$interactive" \
+      bash "$ROOT/bin/omarchy-update-system-pkgs" >"$test_tmp/output" 2>&1; then
+      fail "$damage stops the update"
+    fi
+    [[ ! -s $TEST_LOG ]] || fail "broken records never reach upgrades or conflict recovery"
+    grep -Fq "$record/" "$test_tmp/output" || fail "failure identifies the damaged record"
+    grep -q 'reinstall it' "$test_tmp/output" || fail "failure explains the repair needed"
+  done
+done
+pass "empty or missing records stop automatic and interactive upgrades"
+
+printf '%%NAME%%\nexample\n\n%%VERSION%%\n1.0-1\n' >"$record/desc"
+: >"$record/files"
+for interactive in 0 1; do
+  : >"$TEST_LOG"
+  OMARCHY_UPDATE_CONFLICT=1 OMARCHY_UPDATE_INTERACTIVE="$interactive" \
+    bash "$ROOT/bin/omarchy-update-system-pkgs" >"$test_tmp/output" 2>&1
+  grep -q 'pacman -Syu' "$TEST_LOG" || fail "valid records still upgrade"
+done
+pass "valid records allow upgrades, including packages that own no files"


### PR DESCRIPTION
Stops updates when an interrupted package transaction has left empty or missing database records. Addresses #11316.

<<<< AI wording below >>>>

## Problem

After an interrupted package transaction, a local package record can have an empty `desc` file. Pacman can accept that state and let a later update complete while the package remains damaged.

Addresses the damaged database records reported in #11316.

## Fix

Read the configured database path with `pacman-conf` and reject empty or missing descriptions and missing file-list records before starting either automatic or interactive upgrades. Identify the damaged record and tell the user to restore its metadata and reinstall the package.

This checks database records. It does not claim to detect all truncated installed payloads.

## Verification

A temporary database containing empty `desc` and `files` records returned success from pacman 7.1.0 `-Dk`, confirming why that check alone is insufficient.

`bash test/shell.d/update-package-database-test.sh`, `bash test/shell.d/update-file-conflict-test.sh` and `bash test/shell.d/update-package-conflict-test.sh` pass. Fixtures cover missing/empty records, valid packages that own no files, both upgrade modes and existing conflict recovery. No installed packages were changed.

`git diff --check` passes. Changed shell files pass `bash -n`, and the command style checks pass.
