### PR TITLE
Reject root-run updates before changing user state

### DIFF
--- a/bin/omarchy-update
+++ b/bin/omarchy-update
@@ -7,6 +7,11 @@
 
 set -e
 
+if (( EUID == 0 )); then
+  echo "Run omarchy update as your normal desktop user, without sudo. Individual update steps request privileges when needed." >&2
+  exit 1
+fi
+
 if [[ -z ${OMARCHY_UPDATE_LOGGED:-} ]]; then
   script_command=$(printf '%q ' "$0" "$@")
   exec env OMARCHY_UPDATE_LOGGED=1 script -qefc "$script_command" "/tmp/omarchy-update.log"

--- a/test/shell.d/update-root-test.sh
+++ b/test/shell.d/update-root-test.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -euo pipefail
+source "$(dirname "$0")/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+mkdir -p "$test_tmp/bin"
+# Substitute only the identity check, without requiring root or a user namespace.
+sed 's/(( EUID == 0 ))/(( TEST_EUID == 0 ))/' "$ROOT/bin/omarchy-update" >"$test_tmp/update"
+cat >"$test_tmp/bin/script" <<'STUB'
+#!/bin/bash
+echo logging >>"$TEST_LOG"
+exit 0
+STUB
+chmod +x "$test_tmp/bin/script"
+export PATH="$test_tmp/bin:$PATH" TEST_LOG="$test_tmp/calls"
+unset OMARCHY_UPDATE_LOGGED
+
+for logged in '' 1; do
+  if TEST_EUID=0 OMARCHY_UPDATE_LOGGED="$logged" bash "$test_tmp/update" -y >"$test_tmp/output" 2>&1; then
+    fail "root-run updates fail"
+  fi
+  [[ ! -e $TEST_LOG ]] || fail "root updates never start logging or mutate user state"
+  grep -q 'without sudo' "$test_tmp/output" || fail "root updates explain the correct invocation"
+done
+pass "root is rejected before logging, locking, packages and migrations"
+
+TEST_EUID=1000 bash "$test_tmp/update" -y
+[[ $(<"$TEST_LOG") == logging ]] || fail "normal desktop users enter the update flow"
+pass "normal users retain the update entry point"


### PR DESCRIPTION
Catches updates run with sudo before user migrations start looking for configuration in root's home. Addresses #11257.

<<<< AI wording below >>>>

## Problem

Running `sudo omarchy update` gives user-scoped migration steps root's home directory. Theme handover can then look for Hermes configuration under `/root`, fail, and leave a partially updated user setup.

Addresses the root-run update in #11257.

## Fix

Reject effective UID 0 before opening the update log or running any update steps. Explain that the command must run as the desktop user and that individual steps request privileges when needed.

## Verification

`bash test/shell.d/update-root-test.sh` covers both logged and initial root invocations and the normal-user logging path. The effective UID is substituted in a fixture copy so the test needs no root access. `bash test/shell.d/update-sequence-test.sh` and `bash test/shell.d/update-lock-test.sh` also pass.

`git diff --check` passes. Changed shell files pass `bash -n`, and the command style checks pass.
