### PR TITLE
Keep Voxtype on CPU for Intel Haswell GPUs

### DIFF
--- a/bin/omarchy-hw-intel-haswell-gpu
+++ b/bin/omarchy-hw-intel-haswell-gpu
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# omarchy:summary=Returns true when an Intel Haswell GPU is present
+# omarchy:hidden=true
+
+for device in "${OMARCHY_PCI_DEVICES_PATH:-/sys/bus/pci/devices}"/*; do
+  [[ -r $device/vendor && -r $device/device && -r $device/class ]] || continue
+  [[ $(<"$device/vendor") == "0x8086" && $(<"$device/class") == "0x03"* ]] || continue
+  # Intel's HSW GT1/GT2/GT3 PCI IDs, including ULT, SDV and Crystal Well.
+  case "$(<"$device/device")" in
+    0x0[4acd][012][26abe]) exit 0 ;;
+  esac
+done
+
+exit 1

--- a/bin/omarchy-voxtype-install
+++ b/bin/omarchy-voxtype-install
@@ -15,7 +15,12 @@ if gum confirm "Install Voxtype + AI model (~150MB) to enable dictation?"; then
   cp "$OMARCHY_PATH/default/voxtype/config.toml" ~/.config/voxtype/
 
   voxtype setup --download --no-post-install
-  if omarchy-hw-vulkan; then
+  if omarchy-hw-intel-haswell-gpu; then
+    # hasvk advertises Vulkan, but ggml cannot load models without 16-bit
+    # storage. Reset an existing Vulkan selection too when reinstalling.
+    echo "Using CPU dictation: Intel Haswell Vulkan lacks the required 16-bit storage."
+    sudo voxtype setup gpu --disable
+  elif omarchy-hw-vulkan; then
     voxtype setup gpu --enable || true
   fi
   voxtype setup systemd

--- a/test/shell.d/voxtype-gpu-selection-test.sh
+++ b/test/shell.d/voxtype-gpu-selection-test.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -euo pipefail
+source "$(dirname "$0")/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+mkdir -p "$test_tmp/bin" "$test_tmp/pci/gpu" "$test_tmp/home"
+export OMARCHY_PCI_DEVICES_PATH="$test_tmp/pci" TEST_LOG="$test_tmp/calls"
+export HOME="$test_tmp/home" OMARCHY_PATH="$ROOT" PATH="$test_tmp/bin:$ROOT/bin:$PATH"
+for command in gum omarchy-pkg-add omarchy-restart-shell omarchy-notification-send hyprctl omarchy-hw-vulkan; do
+  printf '#!/bin/bash\nexit 0\n' >"$test_tmp/bin/$command"
+done
+cat >"$test_tmp/bin/voxtype" <<'STUB'
+#!/bin/bash
+printf 'voxtype %s\n' "$*" >>"$TEST_LOG"
+STUB
+cat >"$test_tmp/bin/sudo" <<'STUB'
+#!/bin/bash
+printf 'sudo %s\n' "$*" >>"$TEST_LOG"
+"$@"
+STUB
+chmod +x "$test_tmp/bin/"*
+
+printf '0x8086\n' >"$test_tmp/pci/gpu/vendor"
+printf '0x030000\n' >"$test_tmp/pci/gpu/class"
+for id in 0x0402 0x0416 0x0a26 0x0d26; do
+  printf '%s\n' "$id" >"$test_tmp/pci/gpu/device"
+  omarchy-hw-intel-haswell-gpu || fail "Haswell GPU $id is detected"
+done
+bash "$ROOT/bin/omarchy-voxtype-install" >"$test_tmp/output"
+grep -qx 'sudo voxtype setup gpu --disable' "$TEST_LOG" || fail "Haswell switches to the CPU backend with privileges"
+if grep -q -- '--enable' "$TEST_LOG"; then fail "Haswell must not enable Vulkan"; fi
+pass "Haswell and Crystal Well keep CPU dictation even when Vulkan is installed"
+
+printf '0x9a49\n' >"$test_tmp/pci/gpu/device"
+: >"$TEST_LOG"
+bash "$ROOT/bin/omarchy-voxtype-install" >"$test_tmp/output"
+grep -qx 'voxtype setup gpu --enable' "$TEST_LOG" || fail "modern Intel retains GPU setup"
+pass "modern Intel GPUs retain the existing acceleration path"
+
+printf '0x0d26\n' >"$test_tmp/pci/gpu/device"
+printf '0x1002\n' >"$test_tmp/pci/gpu/vendor"
+if omarchy-hw-intel-haswell-gpu; then fail "other vendors do not match Intel IDs"; fi
+printf '0x8086\n' >"$test_tmp/pci/gpu/vendor"
+printf '0x028000\n' >"$test_tmp/pci/gpu/class"
+if omarchy-hw-intel-haswell-gpu; then fail "non-display devices do not match"; fi
+pass "the detector requires both Intel ownership and a display-class device"


### PR DESCRIPTION
Keeps dictation on the CPU on Haswell machines where the Vulkan backend crashes during model loading. Addresses #11370.

<<<< AI wording below >>>>

## Problem

The dictation installer treats an installed Vulkan ICD as sufficient GPU support. On Haswell, the reported ggml backend aborts because the device lacks the required 16-bit storage, and the service restarts repeatedly.

Addresses the Haswell crash loop in #11370.

## Fix

Add a hidden hardware helper that identifies Intel Haswell display devices from PCI IDs. Select the CPU backend on those machines, including resetting an existing Vulkan selection during reinstall. Other devices keep the existing detection path.

The PCI pattern follows the [Linux Intel Haswell device definitions](https://github.com/torvalds/linux/blob/master/include/drm/intel/pciids.h). This conservatively selects CPU when Haswell is present alongside another GPU; it does not choose a specific Vulkan device.

## Verification

`bash test/shell.d/voxtype-gpu-selection-test.sh` covers several Haswell IDs, modern Intel, AMD and a non-display device. It verifies CPU reset through sudo and the existing GPU path for other hardware. `bash test/shell.d/voxtype-invitation-test.sh` and `bash test/cli` pass. Installation and service commands are stubbed. An affected Haswell machine was not available for live dictation testing.

`git diff --check` passes. Changed shell files pass `bash -n`, and the command style checks pass.
