### PR TITLE
Show command failures in the presentation terminal

### DIFF
--- a/bin/omarchy-launch-floating-terminal-with-presentation
+++ b/bin/omarchy-launch-floating-terminal-with-presentation
@@ -8,6 +8,14 @@
 source omarchy-restart-gum
 
 cmd="$*"
-presentation_script="omarchy-show-logo; $cmd; if (( \$? != 130 )); then omarchy-show-done; fi"
+presentation_script="omarchy-show-logo
+(
+$cmd
+)
+status=\$?
+if (( status != 130 )); then
+  omarchy-show-done \"\$status\"
+fi
+exit \"\$status\""
 
 exec setsid uwsm-app -- xdg-terminal-exec --app-id=org.omarchy.terminal --title=Omarchy -e bash -c "$presentation_script"

--- a/bin/omarchy-show-done
+++ b/bin/omarchy-show-done
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-# omarchy:summary=Display a "Done!" message and wait for user to press any key.
+# omarchy:summary=Display command completion and wait for user to press any key.
+# omarchy:args=[exit-code]
 
 # The device node is there whether or not a terminal is behind it, so opening
 # it is the only test that means anything.
@@ -13,6 +14,10 @@ while read -rsn 1 -t 0.1 _ </dev/tty; do :; done
 
 # Prompt on the terminal rather than stdout, or a caller that redirects us
 # leaves the user waiting on a prompt they were never shown.
-printf '\n\033[32m● \033[0mDone! Press any key to close...' >/dev/tty
+if [[ ${1:-0} == "0" ]]; then
+  printf '\n\033[32m● \033[0mDone! Press any key to close...' >/dev/tty
+else
+  printf '\n\033[31m● \033[0mFailed (exit %s). Press any key to close...' "$1" >/dev/tty
+fi
 read -rsn 1 </dev/tty
 echo >/dev/tty

--- a/test/shell.d/presentation-status-test.sh
+++ b/test/shell.d/presentation-status-test.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+export TEST_LOG="$test_tmp/log"
+export PATH="$test_tmp:$ROOT/bin:$PATH"
+printf '#!/bin/bash\n:\n' >"$test_tmp/omarchy-restart-gum"
+cp "$test_tmp/omarchy-restart-gum" "$test_tmp/omarchy-show-logo"
+cat >"$test_tmp/setsid" <<'STUB'
+#!/bin/bash
+while (( $# >= 3 )); do
+  if [[ $1 == "bash" && $2 == "-c" ]]; then
+    exec bash -c "$3"
+  fi
+  shift
+done
+exit 97
+STUB
+cat >"$test_tmp/omarchy-show-done" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$1" >>"$TEST_LOG"
+STUB
+chmod +x "$test_tmp"/omarchy-* "$test_tmp/setsid"
+
+for status in 0 7 19 130; do
+  : >"$TEST_LOG"
+  actual=0
+  "$ROOT/bin/omarchy-launch-floating-terminal-with-presentation" "exit $status" || actual=$?
+  (( actual == status )) || fail "presentation preserves exit status $status" "got $actual"
+  if (( status == 130 )); then
+    [[ ! -s $TEST_LOG ]] || fail "cancellation closes without a completion prompt"
+  else
+    [[ $(cat "$TEST_LOG") == "$status" ]] || fail "completion receives the command status"
+  fi
+done
+pass "success, failure, explicit exits and cancellation retain their status"
+
+actual=0
+"$ROOT/bin/omarchy-launch-floating-terminal-with-presentation" 'false && echo unreachable' || actual=$?
+(( actual == 1 )) || fail "compound commands retain their failure status"
+pass "shell command lists still work inside the presentation"


### PR DESCRIPTION
Shows a failure when a setup command aborts, instead of leaving the user with a misleading Done prompt. Addresses the false-success reporting in #10117.

<<<< AI wording below >>>>

## Problem

The presentation launcher shows `Done!` after every command status except cancellation. A failed Quattro upgrade therefore displays a success prompt even when its configuration steps stop early.

Addresses the false-success reporting in #10117. The underlying upgrade abort needs separate diagnosis.

## Fix

Capture the command's status, pass it to the completion prompt and preserve it on exit. Successful commands retain `Done!`; failed commands show their exit code and keep the terminal open until a key is pressed. Cancellation still closes without a prompt. Run the supplied command in a subshell so an explicit `exit` also reaches the status handler.

## Verification

`bash test/shell.d/presentation-status-test.sh` covers success, nonzero exits, cancellation, explicit `exit` and compound commands. `bash test/shell.d/floating-terminal-test.sh` passes.

The real completion prompt was exercised in a pseudo-terminal for success and failure, including the keypress to close. No graphical Omarchy session was available for a window screenshot. The related Plymouth suite passed launcher argument checks but could not complete its publisher check because the temporary checkout is not root-owned.

`git diff --check` passes. Changed shell files pass `bash -n`, and the command style checks pass.
