### PR TITLE
Extract crash cores on disk instead of tmpfs

### DIFF
--- a/default/agents/skills/diagnose-crash/SKILL.md
+++ b/default/agents/skills/diagnose-crash/SKILL.md
@@ -53,10 +53,14 @@ that it is actually implicated.
 
 ## Symbolize when you can
 
+Check the `COREFILE` column in `coredumpctl list` before extracting. A truncated core may be missing the stack needed for a backtrace; inspect the existing journal trace first.
+
+Use a disk-backed directory for extraction. On a stock Omarchy install, `/var/tmp` is on disk and `/tmp` is tmpfs. Do not inherit `TMPDIR` here: expanding a compressed core can consume tens of gigabytes, which is especially harmful while diagnosing memory exhaustion. Check available space with `df -h /var/tmp`; the compressed size reported by `coredumpctl` is not the space needed for extraction. If `/var/tmp` is also tmpfs on a customized system, choose another disk-backed directory with enough space.
+
 This is Arch, which runs a public debuginfod server:
 
 ```bash
-core=$(mktemp -t crash-XXXXXX.core)
+core=$(mktemp -p /var/tmp crash-XXXXXX.core)
 trap 'rm -f "$core"' EXIT
 coredumpctl dump <pid> --output="$core"
 DEBUGINFOD_URLS="https://debuginfod.archlinux.org" \
@@ -66,7 +70,7 @@ DEBUGINFOD_URLS="https://debuginfod.archlinux.org" \
 
 A core is a verbatim copy of the process's memory and can hold passwords, tokens,
 and private documents. Write it to a fresh `mktemp` path rather than a predictable
-shared one, and delete it when you are done — never leave it lying in `/tmp`.
+shared one, and delete it when you are done.
 
 Many packages publish no debug symbols. When frames stay unresolved, say so —
 never invent function names to fill the gap. An unsymbolized stack still has


### PR DESCRIPTION
Keeps large crash dumps out of RAM-backed temporary storage while diagnosing a crash. Fixes #8914.

<<<< AI wording below >>>>

## Problem

The crash-diagnosis example extracts cores through `mktemp -t`, which normally chooses RAM-backed `/tmp`. Expanding a large core can exhaust memory on the same machine being investigated for a memory-related crash.

Fixes #8914.

## Fix

Use `/var/tmp` explicitly for core extraction instead of inheriting `TMPDIR`. Explain how to check disk space and account for customized mounts and the difference between compressed and extracted size. Check the truncated-core marker before spending space on an extraction. Keep the private temporary file and cleanup trap.

## Verification

The skill passes `quick_validate.py`. The extraction command was checked with `TMPDIR=/tmp`: it creates a mode-600 file under `/var/tmp`, which was removed afterward. No core dump was extracted.

`git diff --check` passes.
