### PR TITLE
Preserve custom launchers when installing mise wrappers

### DIFF
--- a/bin/omarchy-mise-install
+++ b/bin/omarchy-mise-install
@@ -3,6 +3,8 @@
 # omarchy:summary=Install a small mise-backed wrapper for a given tool.
 # omarchy:args=<package> [command-name [bin-name]]
 
+set -e
+
 if [[ -z $1 ]]; then
   echo "Usage: omarchy-mise-install <package> [command-name [bin-name]]"
   exit 1
@@ -13,7 +15,7 @@ command=${2:-$1}
 bin=${3:-$command}
 
 # The command name becomes a file name under ~/.local/bin, so a slash in it
-# writes the wrapper somewhere else and the rm below deletes somewhere else. A
+# writes the wrapper somewhere else. A
 # leading dot hides it or walks up, and a leading dash makes a name that reads
 # as an option to whatever picks it up. Checked before anything is removed or
 # written, and kept to those shapes so package names like npm:playwright still
@@ -26,6 +28,14 @@ case "$command" in
 esac
 
 mkdir -p "$HOME/.local/bin"
+launcher="$HOME/.local/bin/$command"
+if [[ -e $launcher && ! -f $launcher && ! -L $launcher ]]; then
+  echo "omarchy-mise-install: '$launcher' is not a file or symlink" >&2
+  exit 1
+fi
+
+wrapper=$(mktemp "$HOME/.local/bin/.mise-wrapper.XXXXXX")
+trap 'rm -f -- "$wrapper"' EXIT
 
 # The heredoc below is unquoted, so whatever these hold is written into the
 # wrapper as shell source. Quote them the way omarchy-install-and-launch does, so
@@ -48,12 +58,24 @@ esac
 # hold a new version back for days after it ships. Exported rather than set on
 # the install line alone, so resolving the version to execute agrees with the
 # one just installed.
-rm -f "$HOME/.local/bin/$command"
-cat >"$HOME/.local/bin/$command" <<EOF
+cat >"$wrapper" <<EOF
 #!/bin/bash
 export MISE_MINIMUM_RELEASE_AGE=0
 mise use -g --quiet $package_arg || exit 1
 exec mise x $package_arg -- $bin_arg "\$@"
 EOF
 
-chmod +x "$HOME/.local/bin/$command"
+chmod 755 "$wrapper"
+
+# Keep customized launchers, including symlinks, recoverable across migrations.
+# An unchanged regular wrapper needs no backup on repeated installs.
+if [[ -L $launcher ]] || { [[ -e $launcher ]] && ! cmp -s "$launcher" "$wrapper"; }; then
+  backup=$(mktemp "$launcher.bak.XXXXXX")
+  if ! cp -pP -- "$launcher" "$backup"; then
+    rm -f -- "$backup"
+    exit 1
+  fi
+  echo "Saved existing launcher to $backup"
+fi
+
+mv -fT -- "$wrapper" "$launcher"

--- a/test/shell.d/mise-install-preservation-test.sh
+++ b/test/shell.d/mise-install-preservation-test.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+export HOME="$test_tmp/home"
+mkdir -p "$HOME/.local/bin" "$test_tmp/bin"
+launcher="$HOME/.local/bin/tool"
+printf '#!/bin/bash\nexport MY_TOKEN=private\nexec custom-tool "$@"\n' >"$launcher"
+chmod 700 "$launcher"
+cp -p "$launcher" "$test_tmp/original"
+
+"$ROOT/bin/omarchy-mise-install" tool >/dev/null
+backups=("$launcher".bak.*)
+(( ${#backups[@]} == 1 )) || fail "one backup is created"
+cmp -s "${backups[0]}" "$test_tmp/original" || fail "custom launcher is preserved verbatim"
+[[ $(stat -c %a "${backups[0]}") == "700" ]] || fail "backup retains private permissions"
+[[ -x $launcher ]] || fail "replacement wrapper is executable"
+grep -Fq 'mise use -g --quiet "tool"' "$launcher" || fail "replacement is the requested wrapper"
+pass "custom launchers are backed up with their permissions"
+
+"$ROOT/bin/omarchy-mise-install" tool >/dev/null
+backups=("$launcher".bak.*)
+(( ${#backups[@]} == 1 )) || fail "identical reinstalls do not accumulate backups"
+pass "reinstalling the same wrapper creates no extra backup"
+
+ln -s "$test_tmp/original" "$HOME/.local/bin/linked"
+"$ROOT/bin/omarchy-mise-install" tool linked >/dev/null
+links=("$HOME/.local/bin/linked".bak.*)
+[[ -L ${links[0]} && ! -L $HOME/.local/bin/linked ]] || fail "symlink itself is saved"
+cmp -s "$test_tmp/original" "${backups[0]}" || fail "symlink target is untouched"
+ln -s "$test_tmp/missing" "$HOME/.local/bin/dangling"
+"$ROOT/bin/omarchy-mise-install" tool dangling >/dev/null
+links=("$HOME/.local/bin/dangling".bak.*)
+[[ -L ${links[0]} && ! -e $test_tmp/missing ]] || fail "dangling link is backed up without creating its target"
+pass "symlinks are replaced without changing their targets"
+
+cp "$test_tmp/original" "$launcher"
+cat >"$test_tmp/bin/cp" <<'STUB'
+#!/bin/bash
+exit 1
+STUB
+chmod +x "$test_tmp/bin/cp"
+if PATH="$test_tmp/bin:$PATH" "$ROOT/bin/omarchy-mise-install" tool; then
+  fail "backup failure aborts installation"
+fi
+cmp -s "$launcher" "$test_tmp/original" || fail "backup failure leaves the original launcher intact"
+[[ -z $(find "$HOME/.local/bin" -name '.mise-wrapper.*' -print) ]] || fail "staged wrapper is cleaned up"
+pass "failed backups leave the original launcher intact"


### PR DESCRIPTION
Saves custom launchers before mise replaces them, so an update does not erase someone's wrapper without a backup. Fixes #7101.

<<<< AI wording below >>>>

## Problem

Mise wrapper installation unconditionally removes an existing launcher. Migrations that refresh these wrappers can erase a custom executable or wrapper in `~/.local/bin`, and a default root snapshot does not recover that home-directory file.

Fixes #7101.

## Fix

Stage the new wrapper before replacing the launcher. Save a differing existing launcher to a unique sibling backup, preserve its permissions, and print the backup location. Identical reinstalls create no extra backup. Symlinks are backed up as links and their targets remain untouched. A failed backup stops installation with the original launcher still in place.

## Verification

`bash test/shell.d/mise-install-preservation-test.sh` covers custom contents and permissions, repeated installs, symlinks, dangling links and backup failure. Existing mise install, quiet-wrapper migration and Hermes CLI tests pass. All installations use temporary homes and stubbed tools.

`git diff --check` passes. Changed shell files pass `bash -n`, and the command style checks pass.
