### PR TITLE
Keep terminal font size on this machine, not in the shared config

### DIFF
--- a/bin/omarchy-display-text-size
+++ b/bin/omarchy-display-text-size
@@ -129,68 +129,36 @@ term_pt_for() {
     'BEGIN { printf "%d", int(s * p / b + 0.5) }'
 }
 
-# Set the font point size in terminal configs, creating Kitty overrides when
-# it inherits its size from the system config. Family is left
-# untouched — that is omarchy-font-set's job. Live-reload signals mirror
-# omarchy-font-set; foot has no reload signal, so running instances are nudged.
+# Write point size to per-machine overlays (not the shared terminal configs).
+# Family is left untouched — that is omarchy-font-set's job. omarchy-font-size
+# reloads Kitty/Ghostty; Foot has no reload signal, so running instances are nudged.
 set_terminal_size() {
   local pt="$1"
 
-  if [[ -f ~/.config/alacritty/alacritty.toml ]]; then
-    sed -i -E "s/^size[[:space:]]*=.*/size = $pt/" ~/.config/alacritty/alacritty.toml
-  fi
+  omarchy-font-size --quiet "$pt"
 
-  if [[ -f ~/.config/kitty/kitty.conf ]] || omarchy-cmd-present kitty; then
-    mkdir -p ~/.config/kitty
-    if grep -qE '^[[:space:]]*font_size[[:space:]]+' ~/.config/kitty/kitty.conf 2>/dev/null; then
-      sed --follow-symlinks -i -E "s/^[[:space:]]*font_size[[:space:]]+.*/font_size $pt.0/" ~/.config/kitty/kitty.conf
-    else
-      printf '\nfont_size %s.0\n' "$pt" >>~/.config/kitty/kitty.conf
-    fi
-    pkill -USR1 kitty 2>/dev/null || true
-  fi
-
-  if [[ -f ~/.config/ghostty/config ]]; then
-    sed -i -E "s/^font-size = .*/font-size = $pt/" ~/.config/ghostty/config
-    pkill -SIGUSR2 ghostty 2>/dev/null || true
-  fi
-
-  if [[ -f ~/.config/foot/foot.ini ]]; then
-    sed -i -E "s/(:size=)[0-9.]+/\1$pt/" ~/.config/foot/foot.ini
-    # Foot has no config-reload signal, so a running instance keeps its startup
-    # size until relaunched (new windows pick up the change). Nudge the user —
-    # but reuse the same notification id (freedesktop replaces_id) so dragging
-    # through several sizes refreshes one toast instead of stacking a pile.
-    if pgrep -x foot >/dev/null 2>&1; then
-      local id_file="${XDG_RUNTIME_DIR:-/tmp}/omarchy-display-text-size.foot-notif-id"
-      local prev_id=""
-      [[ -f $id_file ]] && read -r prev_id <"$id_file" 2>/dev/null
-      local replace=()
-      [[ $prev_id =~ ^[0-9]+$ ]] && replace=(-r "$prev_id")
-      local new_id
-      new_id="$(omarchy-notification-send \
-        "Restart Foot to apply the new terminal font size" \
-        "${replace[@]}" -p 2>/dev/null)" || true
-      [[ $new_id =~ ^[0-9]+$ ]] && printf '%s\n' "$new_id" >"$id_file"
-    fi
+  # Foot has no config-reload signal, so a running instance keeps its startup
+  # size until relaunched (new windows pick up the change). Nudge the user —
+  # but reuse the same notification id (freedesktop replaces_id) so dragging
+  # through several sizes refreshes one toast instead of stacking a pile.
+  if pgrep -x foot >/dev/null 2>&1; then
+    local id_file="${XDG_RUNTIME_DIR:-/tmp}/omarchy-display-text-size.foot-notif-id"
+    local prev_id=""
+    [[ -f $id_file ]] && read -r prev_id <"$id_file" 2>/dev/null
+    local replace=()
+    [[ $prev_id =~ ^[0-9]+$ ]] && replace=(-r "$prev_id")
+    local new_id
+    new_id="$(omarchy-notification-send \
+      "Restart Foot to apply the new terminal font size" \
+      "${replace[@]}" -p 2>/dev/null)" || true
+    [[ $new_id =~ ^[0-9]+$ ]] && printf '%s\n' "$new_id" >"$id_file"
   fi
 }
 
-# Report the current terminal point size from whichever config we find first.
+# Report the current terminal point size from the machine-local overlay,
+# falling back to shared configs (pre-migration) and the 9pt default.
 term_current_pt() {
-  if [[ -f ~/.config/ghostty/config ]]; then
-    grep -oP '^font-size = \K[0-9.]+' ~/.config/ghostty/config | head -1
-  elif [[ -f ~/.config/alacritty/alacritty.toml ]]; then
-    grep -oP '^size[[:space:]]*=[[:space:]]*\K[0-9.]+' ~/.config/alacritty/alacritty.toml | head -1
-  elif [[ -f ~/.config/kitty/kitty.conf ]]; then
-    local pt
-    pt=$(grep -oP '^[[:space:]]*font_size[[:space:]]+\K[0-9.]+' ~/.config/kitty/kitty.conf | tail -1)
-    echo "${pt:-$TERM_DEFAULT_PT}"
-  elif [[ -f ~/.config/foot/foot.ini ]]; then
-    grep -oP ':size=\K[0-9.]+' ~/.config/foot/foot.ini | head -1
-  elif omarchy-cmd-present kitty; then
-    echo "$TERM_DEFAULT_PT"
-  fi
+  omarchy-font-size
 }
 
 case "${1:-}" in

--- a/bin/omarchy-font-set
+++ b/bin/omarchy-font-set
@@ -47,7 +47,18 @@ if [[ -f ~/.config/ghostty/config ]]; then
 fi
 
 if [[ -f ~/.config/foot/foot.ini ]]; then
-  sed -i "s/^font=.*/font=$font_name:size=9/g" ~/.config/foot/foot.ini
+  sed -i -E "s/^font=[^:]+/font=$font_name/" ~/.config/foot/foot.ini
+fi
+
+# Size lives in the machine-local overlay. Keep family in sync there too.
+foot_local="${XDG_CONFIG_HOME:-$HOME/.config}/foot/local.ini"
+if [[ -f $foot_local ]]; then
+  size=$(sed -n 's/.*:size=\([0-9.]*\).*/\1/p' "$foot_local" | head -1)
+  size=${size:-9}
+  cat >"$foot_local" <<EOF
+# Machine-local Foot overrides. Not part of the shared desktop config.
+font=$font_name:size=$size
+EOF
 fi
 
 # fontconfig is the canonical source of truth — the omarchy shell, Qt apps,

--- a/bin/omarchy-font-size
+++ b/bin/omarchy-font-size
@@ -1,0 +1,178 @@
+#!/bin/bash
+
+# omarchy:summary=Show or set terminal font size on this machine
+# omarchy:args=[size]
+# omarchy:examples=omarchy font size | omarchy font size 11
+
+set -euo pipefail
+
+usage() {
+  echo "Usage: omarchy-font-size [size]"
+}
+
+ghostty_local="${XDG_CONFIG_HOME:-$HOME/.config}/ghostty/local"
+kitty_local="${XDG_CONFIG_HOME:-$HOME/.config}/kitty/local.conf"
+foot_local="${XDG_CONFIG_HOME:-$HOME/.config}/foot/local.ini"
+alacritty_local="${XDG_CONFIG_HOME:-$HOME/.config}/alacritty/local.toml"
+ghostty_shared="${XDG_CONFIG_HOME:-$HOME/.config}/ghostty/config"
+kitty_shared="${XDG_CONFIG_HOME:-$HOME/.config}/kitty/kitty.conf"
+foot_shared="${XDG_CONFIG_HOME:-$HOME/.config}/foot/foot.ini"
+alacritty_shared="${XDG_CONFIG_HOME:-$HOME/.config}/alacritty/alacritty.toml"
+
+read_size() {
+  local size=""
+  if [[ -f $ghostty_local ]]; then
+    size=$(sed -n 's/^font-size[[:space:]]*=[[:space:]]*//p' "$ghostty_local" | head -1)
+  fi
+  if [[ -z $size && -f $kitty_local ]]; then
+    size=$(sed -n 's/^font_size[[:space:]]*//p' "$kitty_local" | head -1)
+  fi
+  if [[ -z $size && -f $foot_local ]]; then
+    size=$(sed -n 's/.*:size=\([0-9.]*\).*/\1/p' "$foot_local" | head -1)
+  fi
+  if [[ -z $size && -f $alacritty_local ]]; then
+    size=$(sed -n 's/^size[[:space:]]*=[[:space:]]*//p' "$alacritty_local" | head -1)
+  fi
+  if [[ -z $size && -f $ghostty_shared ]]; then
+    size=$(sed -n 's/^font-size[[:space:]]*=[[:space:]]*//p' "$ghostty_shared" | head -1)
+  fi
+  if [[ -z $size && -f $alacritty_shared ]]; then
+    size=$(sed -n 's/^size[[:space:]]*=[[:space:]]*//p' "$alacritty_shared" | head -1)
+  fi
+  if [[ -z $size && -f $kitty_shared ]]; then
+    size=$(sed -n 's/^[[:space:]]*font_size[[:space:]]*//p' "$kitty_shared" | head -1)
+  fi
+  if [[ -z $size && -f $foot_shared ]]; then
+    size=$(sed -n 's/.*:size=\([0-9.]*\).*/\1/p' "$foot_shared" | head -1)
+  fi
+  size=${size:-9}
+  size=${size%.0}
+  printf '%s\n' "$size"
+}
+
+font_family() {
+  omarchy-font-current 2>/dev/null || printf '%s\n' "JetBrainsMono Nerd Font"
+}
+
+ensure_line() {
+  local file="$1"
+  local line="$2"
+  [[ -f $file ]] || return 0
+  grep -Fqx "$line" "$file" && return 0
+  printf '\n%s\n' "$line" >>"$file"
+}
+
+ensure_includes() {
+  ensure_line "$ghostty_shared" 'config-file = ?"~/.config/ghostty/local"'
+
+  mkdir -p "$(dirname "$kitty_shared")"
+  if [[ ! -f $kitty_shared ]]; then
+    printf 'globinclude ~/.config/kitty/local.conf\n' >"$kitty_shared"
+  elif ! grep -qE '^[[:space:]]*globinclude[[:space:]]+.*kitty/local\.conf' "$kitty_shared" &&
+    ! grep -qE '^[[:space:]]*include[[:space:]]+.*kitty/local\.conf' "$kitty_shared"; then
+    printf '\nglobinclude ~/.config/kitty/local.conf\n' >>"$kitty_shared"
+  fi
+
+  if [[ -f $foot_shared ]] && ! grep -Fq 'foot/local.ini' "$foot_shared"; then
+    printf '\ninclude=%s\n' "${XDG_CONFIG_HOME:-$HOME/.config}/foot/local.ini" >>"$foot_shared"
+  fi
+
+  if [[ -f $alacritty_shared ]] && ! grep -Fq 'alacritty/local.toml' "$alacritty_shared"; then
+    if grep -q 'general.import' "$alacritty_shared"; then
+      python3 - "$alacritty_shared" <<'PY' || true
+import pathlib, re, sys
+path = pathlib.Path(sys.argv[1])
+text = path.read_text()
+needle = '"~/.config/alacritty/local.toml"'
+if needle in text:
+    raise SystemExit(0)
+text, n = re.subn(
+    r'(general\.import\s*=\s*\[)([^\]]*)(\])',
+    lambda m: m.group(1) + m.group(2).rstrip() + (", " if m.group(2).strip() else "") + needle + m.group(3),
+    text,
+    count=1,
+)
+if n:
+    path.write_text(text)
+PY
+    fi
+  fi
+}
+
+write_size() {
+  local size="$1"
+  local family kitty_size
+  family=$(font_family)
+  kitty_size=$size
+  [[ $kitty_size == *.* ]] || kitty_size="${kitty_size}.0"
+
+  mkdir -p "$(dirname "$ghostty_local")" "$(dirname "$kitty_local")" "$(dirname "$foot_local")" "$(dirname "$alacritty_local")"
+
+  cat >"$ghostty_local" <<EOF
+# Machine-local Ghostty overrides. Not part of the shared desktop config.
+font-size = $size
+EOF
+
+  cat >"$kitty_local" <<EOF
+# Machine-local Kitty overrides. Not part of the shared desktop config.
+font_size $kitty_size
+EOF
+
+  cat >"$foot_local" <<EOF
+# Machine-local Foot overrides. Not part of the shared desktop config.
+font=$family:size=$size
+EOF
+
+  cat >"$alacritty_local" <<EOF
+# Machine-local Alacritty overrides. Not part of the shared desktop config.
+[font]
+size = $size
+EOF
+
+  ensure_includes
+}
+
+quiet=0
+size=""
+
+while (($#)); do
+  case $1 in
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  --quiet)
+    quiet=1
+    shift
+    ;;
+  *)
+    size=$1
+    shift
+    ;;
+  esac
+done
+
+if [[ -z $size ]]; then
+  read_size
+  exit 0
+fi
+
+if [[ ! $size =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+  echo "Font size must be a number, got: $size" >&2
+  exit 1
+fi
+
+write_size "$size"
+
+if pgrep -x kitty >/dev/null 2>&1; then
+  pkill -USR1 kitty 2>/dev/null || true
+fi
+if pgrep -x ghostty >/dev/null 2>&1; then
+  pkill -SIGUSR2 ghostty 2>/dev/null || true
+  if (( ! quiet )); then
+    omarchy-notification-send -g "Restart Ghostty to see the font size" || true
+  fi
+fi
+if (( ! quiet )) && pgrep -x foot >/dev/null 2>&1; then
+  omarchy-notification-send -g "Restart Foot to see the font size" || true
+fi

--- a/config/alacritty/alacritty.toml
+++ b/config/alacritty/alacritty.toml
@@ -1,4 +1,7 @@
-general.import = [ "~/.local/state/omarchy/current/theme/alacritty.toml" ]
+general.import = [
+  "~/.local/state/omarchy/current/theme/alacritty.toml",
+  "~/.config/alacritty/local.toml",
+]
 
 [env]
 TERM = "xterm-256color"
@@ -10,7 +13,6 @@ osc52 = "CopyPaste"
 normal = { family = "JetBrainsMono Nerd Font", style = "Regular" }
 bold = { family = "JetBrainsMono Nerd Font", style = "Bold" }
 italic = { family = "JetBrainsMono Nerd Font", style = "Italic" }
-size = 9
 
 [window]
 padding.x = 14

--- a/config/alacritty/local.toml
+++ b/config/alacritty/local.toml
@@ -1,0 +1,3 @@
+# Machine-local Alacritty overrides. Not part of the shared desktop config.
+[font]
+size = 9

--- a/config/foot/foot.ini
+++ b/config/foot/foot.ini
@@ -1,7 +1,8 @@
 [main]
 include=~/.local/state/omarchy/current/theme/foot.ini
 term=xterm-256color
-font=JetBrainsMono Nerd Font:size=9
+font=JetBrainsMono Nerd Font
+include=~/.config/foot/local.ini
 pad=14x14
 initial-window-mode=windowed
 workers=0

--- a/config/foot/local.ini
+++ b/config/foot/local.ini
@@ -1,0 +1,2 @@
+# Machine-local Foot overrides. Not part of the shared desktop config.
+font=JetBrainsMono Nerd Font:size=9

--- a/config/ghostty/config
+++ b/config/ghostty/config
@@ -1,10 +1,10 @@
 # Dynamic theme colors
 config-file = ?"~/.local/state/omarchy/current/theme/ghostty.conf"
 
-# Font
+# Font family is shared. Size lives in ~/.config/ghostty/local so two machines
+# can keep the same config and different sizes. `omarchy font size` writes it.
 font-family = "JetBrainsMono Nerd Font"
 font-style = Regular
-font-size = 9
 
 # Window
 window-theme = ghostty
@@ -39,3 +39,6 @@ mouse-scroll-multiplier = 0.95
 
 # Fix general slowness on hyprland (https://github.com/ghostty-org/ghostty/discussions/3224)
 async-backend = epoll
+
+# Optional per-machine overrides (font-size). Missing file is ignored.
+config-file = ?"~/.config/ghostty/local"

--- a/config/ghostty/local
+++ b/config/ghostty/local
@@ -1,0 +1,3 @@
+# Machine-local Ghostty overrides. Not part of the shared desktop config.
+# `omarchy font size` rewrites this file.
+font-size = 9

--- a/config/hypr/hyprland.lua
+++ b/config/hypr/hyprland.lua
@@ -22,6 +22,16 @@ require("hypr.bindings")
 require("hypr.looknfeel")
 require("hypr.autostart")
 
+-- Optional per-machine input (touchpad, extra gestures). Missing file is skipped.
+do
+  local path = (os.getenv("XDG_CONFIG_HOME") or (os.getenv("HOME") .. "/.config")) .. "/hypr/input.local.lua"
+  local file = io.open(path, "r")
+  if file then
+    file:close()
+    dofile(path)
+  end
+end
+
 -- Toggle config flags dynamically.
 require("default.hypr.toggles")
 

--- a/config/kitty/kitty.conf
+++ b/config/kitty/kitty.conf
@@ -4,7 +4,8 @@ include ~/.local/state/omarchy/current/theme/kitty.conf
 # Settings below override Omarchy's defaults in /etc/xdg/kitty/kitty.conf.
 # Learn more: https://sw.kovidgoyal.net/kitty/conf/
 
-# Font
+# Font family can be set here. Size is per-machine: `omarchy font size` and
+# `omarchy display text size` write ~/.config/kitty/local.conf and globinclude it.
 # font_family JetBrainsMono Nerd Font
 # font_size 12
 

--- a/config/kitty/local.conf
+++ b/config/kitty/local.conf
@@ -1,0 +1,3 @@
+# Machine-local Kitty overrides. Not part of the shared desktop config.
+# `omarchy font size` rewrites this file.
+font_size 9.0

--- a/default/agents/skills/omarchy/theming.md
+++ b/default/agents/skills/omarchy/theming.md
@@ -75,5 +75,10 @@ omarchy theme set catppuccin-custom
 ```bash
 omarchy font list               # Available fonts
 omarchy font current            # Current font
-omarchy font set <name>         # Change font
+omarchy font set <name>         # Change font family (all machines)
+omarchy font size               # Show this machine's terminal font size
+omarchy font size 11            # Set this machine's terminal font size
+omarchy display text size 14    # Shell + GTK + terminal, still per-machine for the terminal
 ```
+
+Family is shared. Terminal size is per-machine: `~/.config/ghostty/local`, `kitty/local.conf`, `foot/local.ini`, `alacritty/local.toml`.

--- a/manual/33-monitors.md
+++ b/manual/33-monitors.md
@@ -28,7 +28,7 @@ Monitor scaling changes the size of everything. If all you want is bigger or sma
 omarchy display text size 14
 ```
 
-That takes a pixel size between 9 and 20, and moves the Omarchy shell, GTK applications, and your terminal together, so the whole desktop stays in proportion. Run it without an argument to see where you're at, and `omarchy display text size reset` to go back to the default. Foot is the one straggler: it has no way to reload its config, so running terminals keep their old size until you open a new one.
+That takes a pixel size between 9 and 20, and moves the Omarchy shell, GTK applications, and your terminal together, so the whole desktop stays in proportion. Terminal size is stored in per-machine overlay files, so it does not ride along when you sync the rest of the config between computers. Run it without an argument to see where you're at, and `omarchy display text size reset` to go back to the default. Foot is the one straggler: it has no way to reload its config, so running terminals keep their old size until you open a new one.
 
 ### Extending and mirroring laptop displays
 

--- a/manual/38-fonts.md
+++ b/manual/38-fonts.md
@@ -4,6 +4,8 @@ Omarchy uses JetBrainsMono Nerd Font as both the terminal and system font by def
 
  ![fonts-jetbrainsmono](images/fonts-jetbrainsmono.webp)
 
-You can change this through the _Style > Font_ menu in the Omarchy menu (`Super + Space`). That sets the monospace font everywhere: the terminal, the bar, and anything else that asks for it.
+You can change this through the _Style > Font_ menu in the Omarchy menu (`Super + Space`). That sets the monospace **family** everywhere: the terminal, the bar, and anything else that asks for it.
+
+Terminal **size** is per machine, so a laptop and a desktop can share the rest of the config. `omarchy display text size` (and `omarchy font size` for the terminal only) writes overlay files on this computer (`~/.config/ghostty/local`, plus the same idea for Kitty, Foot, and Alacritty). The bar's type scale is `[font] base-size` in `~/.config/omarchy/shell.toml`.
 
 You can install other popular programming fonts via _Install > Style > Font_ in the Omarchy menu: Cascadia Mono, Meslo LG Mono, Fira Code, Victor Code, Bitstream Vera Mono, and Iosevka are all one click away, in their Nerd Font versions so the glyphs in the bar and terminal keep working. After installing one, pick it under _Style > Font_.

--- a/migrations/1789224260.sh
+++ b/migrations/1789224260.sh
@@ -1,0 +1,53 @@
+echo "Move terminal font size into per-machine overlay files"
+
+size=""
+ghostty="$HOME/.config/ghostty/config"
+kitty="$HOME/.config/kitty/kitty.conf"
+foot="$HOME/.config/foot/foot.ini"
+alacritty="$HOME/.config/alacritty/alacritty.toml"
+ghostty_local="${XDG_CONFIG_HOME:-$HOME/.config}/ghostty/local"
+kitty_local="${XDG_CONFIG_HOME:-$HOME/.config}/kitty/local.conf"
+foot_local="${XDG_CONFIG_HOME:-$HOME/.config}/foot/local.ini"
+alacritty_local="${XDG_CONFIG_HOME:-$HOME/.config}/alacritty/local.toml"
+
+if [[ -f $ghostty_local ]]; then
+  size=$(sed -n 's/^font-size[[:space:]]*=[[:space:]]*//p' "$ghostty_local" | head -1)
+fi
+if [[ -z $size && -f $kitty_local ]]; then
+  size=$(sed -n 's/^font_size[[:space:]]*//p' "$kitty_local" | head -1)
+fi
+if [[ -z $size && -f $foot_local ]]; then
+  size=$(sed -n 's/.*:size=\([0-9.]*\).*/\1/p' "$foot_local" | head -1)
+fi
+if [[ -z $size && -f $alacritty_local ]]; then
+  size=$(sed -n 's/^size[[:space:]]*=[[:space:]]*//p' "$alacritty_local" | head -1)
+fi
+if [[ -z $size && -f $ghostty ]]; then
+  size=$(sed -n 's/^font-size[[:space:]]*=[[:space:]]*//p' "$ghostty" | head -1)
+fi
+if [[ -z $size && -f $kitty ]]; then
+  size=$(sed -n 's/^[[:space:]]*font_size[[:space:]]*//p' "$kitty" | head -1)
+fi
+if [[ -z $size && -f $foot ]]; then
+  size=$(sed -n 's/.*:size=\([0-9.]*\).*/\1/p' "$foot" | head -1)
+fi
+if [[ -z $size && -f $alacritty ]]; then
+  size=$(sed -n 's/^size[[:space:]]*=[[:space:]]*//p' "$alacritty" | head -1)
+fi
+size=${size:-9}
+size=${size%.0}
+
+omarchy-font-size --quiet "$size"
+
+if [[ -f $ghostty ]]; then
+  sed -i '/^font-size[[:space:]]*=/d' "$ghostty"
+fi
+if [[ -f $kitty ]]; then
+  sed --follow-symlinks -i '/^[[:space:]]*font_size[[:space:]]/d' "$kitty"
+fi
+if [[ -f $foot ]]; then
+  sed -i 's/^\(font=[^:]*\):size=[0-9.]*/\1/' "$foot"
+fi
+if [[ -f $alacritty ]]; then
+  sed -i '/^size[[:space:]]*=/d' "$alacritty"
+fi

--- a/test/shell.d/font-size-test.sh
+++ b/test/shell.d/font-size-test.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+home="$tmpdir/home"
+mkdir -p "$home/.config/ghostty" "$home/.config/kitty" "$home/.config/foot" "$home/.config/alacritty"
+
+cp "$ROOT/config/ghostty/config" "$home/.config/ghostty/config"
+cp "$ROOT/config/kitty/kitty.conf" "$home/.config/kitty/kitty.conf"
+cp "$ROOT/config/foot/foot.ini" "$home/.config/foot/foot.ini"
+cp "$ROOT/config/alacritty/alacritty.toml" "$home/.config/alacritty/alacritty.toml"
+
+# Default stock configs must not pin a size in the shared file.
+if grep -q '^font-size' "$home/.config/ghostty/config"; then
+  fail "ghostty default config has no font-size"
+fi
+if grep -qE '^[[:space:]]*font_size[[:space:]]' "$home/.config/kitty/kitty.conf"; then
+  fail "kitty default config has no font_size"
+fi
+if grep -q ':size=' "$home/.config/foot/foot.ini"; then
+  fail "foot default config has no :size= on the shared font line"
+fi
+if grep -q '^size' "$home/.config/alacritty/alacritty.toml"; then
+  fail "alacritty default config has no size in the shared file"
+fi
+pass "stock terminal configs leave size to the local overlay"
+
+mkdir -p "$tmpdir/bin"
+printf '#!/bin/bash\nexit 1\n' >"$tmpdir/bin/pgrep"
+chmod +x "$tmpdir/bin/pgrep"
+export HOME="$home" XDG_CONFIG_HOME="$home/.config" PATH="$tmpdir/bin:$ROOT/bin:$PATH"
+
+output=$(omarchy-font-size)
+[[ $output == 9 ]] || fail "font size defaults to 9 when no overlay exists" "$output"
+pass "font size defaults to 9 when no overlay exists"
+
+omarchy-font-size 11 >/dev/null
+
+[[ $(omarchy-font-size) == 11 ]] || fail "font size reports the value that was set"
+grep -qx 'font-size = 11' "$home/.config/ghostty/local" || fail "ghostty local overlay has size 11"
+grep -q 'font_size 11.0' "$home/.config/kitty/local.conf" || fail "kitty local overlay has size 11"
+grep -q ':size=11' "$home/.config/foot/local.ini" || fail "foot local overlay has size 11"
+grep -qx 'size = 11' "$home/.config/alacritty/local.toml" || fail "alacritty local overlay has size 11"
+pass "omarchy font size 11 writes every terminal overlay"
+
+grep -Fq 'config-file = ?"~/.config/ghostty/local"' "$home/.config/ghostty/config" ||
+  fail "ghostty config includes the local overlay"
+grep -Fq 'globinclude ~/.config/kitty/local.conf' "$home/.config/kitty/kitty.conf" ||
+  fail "kitty config globincludes the local overlay"
+grep -Fq 'foot/local.ini' "$home/.config/foot/foot.ini" ||
+  fail "foot config includes the local overlay"
+pass "omarchy font size ensures shared configs include the overlays"
+
+# Packaged font-set used to force Foot size=9. Family changes must keep size.
+cat >"$home/.config/foot/foot.ini" <<'INI'
+[main]
+font=OldFont
+INI
+cat >"$home/.config/foot/local.ini" <<'INI'
+font=OldFont:size=11
+INI
+
+mkdir -p "$tmpdir/bin"
+cat >"$tmpdir/bin/fc-list" <<'SH'
+#!/bin/bash
+echo "JetBrainsMono Nerd Font"
+SH
+printf '#!/bin/bash\nexit 0\n' >"$tmpdir/bin/omarchy-restart-shell"
+printf '#!/bin/bash\nexit 0\n' >"$tmpdir/bin/omarchy-hook"
+printf '#!/bin/bash\nexit 0\n' >"$tmpdir/bin/omarchy-notification-send"
+printf '#!/bin/bash\necho JetBrainsMono Nerd Font\n' >"$tmpdir/bin/omarchy-font-current"
+chmod +x "$tmpdir/bin/fc-list" "$tmpdir/bin/omarchy-restart-shell" "$tmpdir/bin/omarchy-hook" \
+  "$tmpdir/bin/omarchy-notification-send" "$tmpdir/bin/omarchy-font-current"
+
+PATH="$tmpdir/bin:$ROOT/bin:$PATH" HOME="$home" XDG_CONFIG_HOME="$home/.config" \
+  omarchy-font-set "JetBrainsMono Nerd Font" >/dev/null
+
+grep -qx 'font=JetBrainsMono Nerd Font' "$home/.config/foot/foot.ini" ||
+  fail "font set writes Foot family without a size" "$(cat "$home/.config/foot/foot.ini")"
+grep -q 'font=JetBrainsMono Nerd Font:size=11' "$home/.config/foot/local.ini" ||
+  fail "font set keeps Foot overlay size" "$(cat "$home/.config/foot/local.ini")"
+pass "omarchy font set does not clobber this machine's Foot size"
+
+# Migration extracts an in-file size onto the overlay and strips the shared file.
+rm -f "$home/.config/ghostty/local" "$home/.config/kitty/local.conf" \
+  "$home/.config/foot/local.ini" "$home/.config/alacritty/local.toml"
+cat >"$home/.config/ghostty/config" <<'CONF'
+font-family = "JetBrainsMono Nerd Font"
+font-size = 14
+CONF
+HOME="$home" XDG_CONFIG_HOME="$home/.config" PATH="$tmpdir/bin:$ROOT/bin:$PATH" \
+  bash -euo pipefail "$ROOT/migrations/1789224260.sh" >/dev/null
+if grep -q '^font-size' "$home/.config/ghostty/config"; then
+  fail "migration strips font-size from the shared Ghostty config"
+fi
+[[ $(HOME="$home" XDG_CONFIG_HOME="$home/.config" omarchy-font-size) == 14 ]] ||
+  fail "migration preserves the previous Ghostty size on the overlay"
+pass "migration moves in-file font size onto the overlay"

--- a/test/shell.d/kitty-config-test.sh
+++ b/test/shell.d/kitty-config-test.sh
@@ -114,9 +114,11 @@ SH
 chmod +x "$test_dir/bin/"*
 
 run_command() {
-  env HOME="$test_home" OMARCHY_PATH="$ROOT" PATH="$test_dir/bin:$ROOT/bin:$PATH" "$ROOT/bin/$@"
+  env HOME="$test_home" XDG_CONFIG_HOME="$test_home/.config" OMARCHY_PATH="$ROOT" \
+    PATH="$test_dir/bin:$ROOT/bin:$PATH" "$ROOT/bin/$@"
 }
 
+kitty_local="$test_home/.config/kitty/local.conf"
 cp "$ROOT/config/kitty/kitty.conf" "$kitty_config"
 output=$(run_command omarchy-display-text-size)
 [[ $output == *"terminal font: 9 pt"* ]] || fail "size report accounts for inherited Kitty default"
@@ -126,25 +128,28 @@ grep -qx 'font_family Test Font' "$kitty_config" || fail "font command creates f
 run_command omarchy-font-set Font
 grep -qx 'font_family Font' "$kitty_config" || fail "font command updates family override"
 [[ $(grep -c '^font_family ' "$kitty_config") == "1" ]] || fail "font update avoids duplicate overrides"
-grep -qx 'font_size 12.0' "$kitty_config" || fail "size command creates size override"
+grep -qx 'font_size 12.0' "$kitty_local" || fail "size command creates size overlay" "$(cat "$kitty_local" 2>/dev/null)"
+! grep -qE '^[[:space:]]*font_size[[:space:]]' "$kitty_config" || fail "size command leaves shared Kitty config without font_size"
 grep -qx '# font_size 12' "$kitty_config" || fail "font commands keep commented instructions"
 run_command omarchy-display-text-size 18
-[[ $(grep -c '^font_size ' "$kitty_config") == "1" ]] || fail "size update avoids duplicate overrides"
+[[ $(grep -c '^font_size ' "$kitty_local") == "1" ]] || fail "size update avoids duplicate overlays"
 run_command omarchy-display-text-size reset
-grep -qx 'font_size 9.0' "$kitty_config" || fail "size reset restores default"
+grep -qx 'font_size 9.0' "$kitty_local" || fail "size reset restores default overlay"
 pass "font controls add and update overrides in the minimal template"
 
-rm "$kitty_config"
+rm -f "$kitty_config" "$kitty_local"
 output=$(run_command omarchy-display-text-size)
 [[ $output == *"terminal font: 9 pt"* ]] || fail "size report handles absent Kitty config"
 run_command omarchy-font-set 'Test Font'
 run_command omarchy-display-text-size 16
 grep -qx 'font_family Test Font' "$kitty_config" || fail "font command handles absent config"
-grep -qx 'font_size 12.0' "$kitty_config" || fail "size command handles absent setting"
+grep -qx 'font_size 12.0' "$kitty_local" || fail "size command handles absent setting"
 ! grep -q '^include ' "$kitty_config" || fail "font controls must not opt users back into theming"
-rm "$kitty_config"
+rm -f "$kitty_config" "$kitty_local"
 run_command omarchy-display-text-size 16
-grep -qx 'font_size 12.0' "$kitty_config" || fail "size command handles absent config"
+grep -qx 'font_size 12.0' "$kitty_local" || fail "size command handles absent config"
+grep -Fq 'globinclude ~/.config/kitty/local.conf' "$kitty_config" || fail "size command globincludes the overlay"
+! grep -q '^include ' "$kitty_config" || fail "size command must not restore the theme include"
 pass "font controls create missing Kitty overrides without restoring the theme include"
 
 if "$ROOT/bin/omarchy-cmd-present" kitty; then


### PR DESCRIPTION
Grok (xAI), writing with Sean.

Two machines sharing a desktop config fight over terminal font size. Changing size on a laptop rewrites Ghostty, Kitty, Foot, and Alacritty files that then show up as Incoming on the desktop. `omarchy font set` also forces Foot back to size 9, so a laptop that wants 11 cannot keep it.

## How

Family stays in the shared terminal configs. Size moves to per-machine overlay files that `omarchy font size` and `omarchy display text size` write. Kitty's user template stays a single active theme include; size goes in `local.conf` and is globincluded at runtime so it does not fight the system default in `/etc/xdg/kitty/kitty.conf`. `omarchy font set` updates Foot's family without clobbering this machine's overlay size.

A migration copies any in-file size onto the overlays and strips it from the shared files. Optional `hypr/input.local.lua` is loaded when present so touchpad (and similar) overrides can stay off the shared `input.lua` the same way.

## Where

- `bin/omarchy-font-size`, `bin/omarchy-font-set`, `bin/omarchy-display-text-size`
- `config/{ghostty,kitty,foot,alacritty}/` and `config/hypr/hyprland.lua`
- `migrations/1789224260.sh`
- `test/shell.d/font-size-test.sh`, `test/shell.d/kitty-config-test.sh`

## Test plan

- `bash test/shell.d/font-size-test.sh`
- `bash test/shell.d/kitty-config-test.sh`
- `omarchy font size 11` on one machine does not change the shared Ghostty/Kitty/Foot/Alacritty files beyond the include line
- `omarchy display text size 16` still scales shell + GTK, and writes terminal size to the overlays
- `omarchy font set "JetBrainsMono Nerd Font"` leaves an existing Foot overlay size alone