### PR TITLE
Tell agents to reboot through omarchy system reboot

### DIFF
--- a/default/agents/skills/omarchy/SKILL.md
+++ b/default/agents/skills/omarchy/SKILL.md
@@ -7,8 +7,9 @@ description: >
   Triggers: Hyprland, window rules, animations, keybindings, monitors, gaps, borders,
   blur, opacity, omarchy-shell, bar, terminal config, themes, background,
   night light, idle, lock screen, screenshots, reminders, layer rules, workspace
-  settings, display config, and user-facing omarchy commands. Excludes Omarchy
-  source development through `omarchy dev link` workflows.
+  settings, display config, user-facing omarchy commands, reboot, shutdown, power off,
+  halt, and systemctl reboot. Excludes Omarchy source development through
+  `omarchy dev link` workflows.
 ---
 
 # Omarchy Skill
@@ -31,6 +32,7 @@ It is not for contributing to Omarchy source code.
 - Themes, backgrounds, fonts, appearance changes
 - User-facing `omarchy` commands (`omarchy theme ...`, `omarchy refresh ...`, `omarchy restart ...`, etc.)
 - Screenshots, screen recording, reminders, night light, idle behavior, lock screen
+- Reboot, shutdown, or power-off (`reboot!`, `systemctl reboot`, `shutdown now`, etc.)
 
 **If you're about to edit a config file in ~/.config/ on this system, STOP and use this skill first.**
 
@@ -225,6 +227,10 @@ omarchy system shutdown         # Shutdown
 omarchy system reboot           # Reboot
 ```
 
+`omarchy system reboot` and `omarchy system shutdown` schedule the action in the user systemd, show an on-screen notice, then close application windows. Use those. Do not run `systemctl reboot`, `reboot`, `shutdown`, or `poweroff` from an agent — they kill Hyprland on the still-drawn frame, so the machine looks frozen while systemd continues. Do not wait for the session to die after scheduling the reboot.
+
+Do not `modprobe -r` in-use audio, GPU, or Wi-Fi drivers as a way to avoid a reboot. A module stuck in uninterruptible sleep (D-state) can stall shutdown the same way.
+
 **IMPORTANT:** Always run `omarchy debug` with `--no-sudo --print` flags to avoid interactive sudo prompts that will hang the terminal.
 
 ## Troubleshooting
@@ -292,3 +298,4 @@ This skill intentionally does not cover Omarchy source development. Do not use t
 - "Reset shell/bar to defaults" -> `omarchy refresh shell`
 - "Record my screen" -> `omarchy screenrecord --fullscreen`, then `omarchy screenrecord --stop-recording` (see `capture.md`)
 - "Report this bug to Omarchy" -> Gather diagnostics and a capture of the problem, then file it (see `contributing.md`)
+- "Reboot!" / "Restart the computer" -> `omarchy system reboot` (never `systemctl reboot`)

--- a/manual/45-troubleshooting.md
+++ b/manual/45-troubleshooting.md
@@ -26,6 +26,12 @@ hl.config({
 
 Before you reboot, try restarting the offending subsystem on its own. _Update > Hardware_ in the Omarchy menu has Wi-Fi, Bluetooth, Audio, and Trackpad, and reloading one of those clears up the majority of "it worked five minutes ago" situations — a Bluetooth headset that won't reconnect, a trackpad that went dead after a suspend, sound that vanished when you unplugged a monitor.
 
+### The screen froze when I rebooted
+
+A raw `systemctl reboot` (or `reboot`) from a terminal or coding agent kills Hyprland immediately, so the last frame stays on screen while systemd shuts down. Use `omarchy system reboot` instead — it shows an on-screen notice and closes windows first.
+
+If the machine still hangs on reboot, a kernel driver is probably stuck in uninterruptible sleep. Unloading an in-use audio, GPU, or Wi-Fi module with `modprobe -r` is a common way to get there. Wait it out, or hold the power button; don't try to unload the driver again.
+
 ### Why are my external speakers not playing?
 
 Probably because they're not set as the primary output. Click on the speaker icon on the right side of the bar, and it'll open the volume popup where you can pick the output device (and mix per-app volumes too).


### PR DESCRIPTION
## Why

`omarchy system reboot` already exists to schedule a reboot, show an OSD, and close windows before systemd takes the session down. Coding agents on Omarchy still skip it.

On 2026-09-12 an agent ran `systemctl reboot` after a stuck `modprobe -r` of `snd_sof_pci_intel_ptl`. systemd accepted the reboot, Hyprland/SDDM died on the still-drawn frame, and the laptop sat frozen for about two minutes while shutdown waited on that D-state driver. Journal:

```
Sep 12 10:23:24 systemd-logind: reboot requested from client PID … ('systemctl')
Sep 12 10:23:24 sddm-helper … crashed (exit code 1)
Sep 12 10:23:30 journal ends while unmounting /home
Sep 12 10:25:30 next boot
```

This is not a compositor bug. A raw reboot from inside the graphical session looks like a freeze, and unloading an in-use kernel module can stall the rest.

## What

- Agent skill now matches reboot/shutdown prompts, requires `omarchy system reboot` / `omarchy system shutdown`, and forbids `systemctl reboot` plus live `modprobe -r` of in-use drivers.
- Troubleshooting: "The screen froze when I rebooted."

No GitHub issue: Omarchy already has the right command. The gap is that agents (and anyone following `systemctl reboot`) do not use it.

## Tests

`bash test/shell.d/system-power-test.sh` passes. `./test/all` was run on this worktree; the five failures (`bar-icon-geometry`, `launch-about`, `config-test` PKGBUILD drop-in, `locate-test` decode, `snapper-test` missing `omarchy-iso`) are unrelated to these docs.

Filed by grok-4.6 via Grok Build.