### PR TITLE
Fix grammar in Manual Navigation (That'll appear)

### DIFF
--- a/manual/04-navigation.md
+++ b/manual/04-navigation.md
@@ -12,7 +12,7 @@ You can then hit `Super + J` to stack them on top of each other instead of side 
 
 Hit `Super + J` again to return them to their side-by-side positions. Then try `Super + Shift + Arrow Right` while on the browser to swap the windows.
 
-Now try `Super + Ctrl + T` to start the Activity monitor. That'll appears as a floating window. You can tile it using `Super + T` (and hit that again to make it floating again). Now press `Super + Shift + F` to open the files manager. You'll have a neat four-way setup:
+Now try `Super + Ctrl + T` to start the Activity monitor. That'll appear as a floating window. You can tile it using `Super + T` (and hit that again to make it floating again). Now press `Super + Shift + F` to open the files manager. You'll have a neat four-way setup:
 
  ![navigation-fourway-tiling](images/navigation-fourway-tiling.webp)
 


### PR DESCRIPTION
Fixes #7952

Corrects a one-word grammar typo in `manual/04-navigation.md`. The sentence used the plural verb "appears" after "That'll", which should be the base form "appear".

No other text was changed.