### PR TITLE
fix: use the accent for menu and tooltip borders

### DIFF
--- a/default/themed/shell.toml.tpl
+++ b/default/themed/shell.toml.tpl
@@ -137,7 +137,7 @@ border-alpha     = 1.0
 background       = "{{ background }}"
 background-alpha = 0.97
 text             = "{{ foreground }}"
-border           = "hyprland.active-border-foreground"
+border           = "hyprland.active-border"
 border-alpha     = 1.0
 
 [notifications]
@@ -176,7 +176,7 @@ selected-border-alpha     = 0.25
 background                = "{{ background }}"
 background-alpha          = 1.0
 text                      = "{{ foreground }}"
-border                    = "hyprland.active-border-foreground"
+border                    = "hyprland.active-border"
 border-alpha              = 1.0
 scrim                     = "{{ background }}"
 scrim-alpha               = 0.5

--- a/shell/Commons/Color.qml
+++ b/shell/Commons/Color.qml
@@ -83,7 +83,7 @@ QtObject {
   readonly property QtObject tooltip: QtObject {
     property color background: root.composed("tooltip.background", "tooltip.background-alpha", root.background, 1.0)
     property color text: root.pick("tooltip.text", root.foreground)
-    property color border: root.composed("tooltip.border", "tooltip.border-alpha", root.foreground, 1.0)
+    property color border: root.composed("tooltip.border", "tooltip.border-alpha", root.accent, 1.0)
   }
   readonly property QtObject notifications: QtObject {
     property color background: root.composed("notifications.background", "notifications.background-alpha", root.background, 1.0)
@@ -94,7 +94,7 @@ QtObject {
   readonly property QtObject menu: QtObject {
     property color background: root.composed("menu.background", "menu.background-alpha", root.background, 1.0)
     property color text: root.pick("menu.text", root.foreground)
-    property color border: root.composed("menu.border", "menu.border-alpha", root.foreground, 1.0)
+    property color border: root.composed("menu.border", "menu.border-alpha", root.accent, 1.0)
     property color scrim: root.composed("menu.scrim", "menu.scrim-alpha", root.background, 0.5)
     property color selectedBackground: root.composed("menu.selected-background", "menu.selected-background-alpha", root.foreground, 0.08)
     property color selectedText: root.pick("menu.selected-text", root.accent)


### PR DESCRIPTION
Menu-style cards and tooltips took their outline from active-border-foreground, so they showed the theme foreground instead of the accent that popups, notifications, polkit and plugin panels already use. Point both surfaces at active-border and align the Color.qml fallbacks.

<img width="1817" height="1237" alt="example" src="https://github.com/user-attachments/assets/ce55e82b-dcd2-45ae-b707-554499c0451c" />



