### PR TITLE
Own pending shell service loads across reloads

### DIFF
--- a/docs/omarchy-shell.md
+++ b/docs/omarchy-shell.md
@@ -45,6 +45,12 @@ A third-party replacement bar can render registered widget components, but widge
 
 Full schema: [`shell/services/PluginRegistry.qml`](../shell/services/PluginRegistry.qml).
 
+Pending asynchronous service loads belong to the host so stale completions
+cannot displace current plugin services during reloads or configuration changes.
+The lifecycle owner is [`shell/shell.qml`](../shell/shell.qml); regression
+evidence lives in the [service lifecycle tests](../test/shell.d/service-lifecycle-test.sh)
+and [Qt runtime checks](../test/shell.d/service-lifecycle-runtime-test.sh).
+
 ## Installing a third-party plugin
 
 A plugin is a **git repo** with a `manifest.json` at its root. Adding one

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -274,6 +274,8 @@ ShellRoot {
   }
 
   property var _services: ({})
+  property var _serviceLoads: ({})
+  property int _serviceLoadGeneration: 0
   property var _pluginShellApis: ({})
   property var _pluginShellApiDescriptors: ({})
   property var _pluginBarEntryShellApis: ({})
@@ -887,23 +889,72 @@ ShellRoot {
         && manifest.__hostCapabilities.indexOf("authentication") !== -1)
   }
 
-  function ensureService(pluginId) {
-    var key = String(pluginId)
-    if (_services[key]) return _services[key]
+  function _serviceManifest(key) {
+    if (pluginReloading) return null
     var manifest = pluginRegistry && pluginRegistry.installedPlugins
       ? pluginRegistry.installedPlugins[key] : null
-    if (!manifest) return null
+    if (!manifest || !pluginRegistry.isEnabled(key)) return null
     if (!Array.isArray(manifest.kinds) || manifest.kinds.indexOf("service") === -1) return null
     if (!manifest.entryPoints || !manifest.entryPoints.service) return null
+    return manifest
+  }
+
+  function _serviceLoadCurrent(key, load) {
+    return !load.done && _serviceLoads[key] === load
+      && load.generation === _serviceLoadGeneration && !_services[key]
+      && _serviceManifest(key) === load.manifest
+      && pluginRegistry.entryPointUrl(load.manifest, "service") === load.url
+  }
+
+  function _releaseServiceLoad(key, load) {
+    load.done = true
+    if (_serviceLoads[key] === load) {
+      var next = ({})
+      for (var id in _serviceLoads) if (id !== key) next[id] = _serviceLoads[id]
+      _serviceLoads = next
+    }
+    if (load.connected) {
+      load.component.statusChanged.disconnect(load.finalize)
+      load.connected = false
+    }
+    var comp = load.component
+    load.component = null
+    if (comp) comp.destroy()
+  }
+
+  function ensureService(pluginId) {
+    var key = String(pluginId)
+    if (pluginReloading) return null
+    if (_services[key]) return _services[key]
+    var manifest = _serviceManifest(key)
+    if (!manifest) return null
     var url = pluginRegistry.entryPointUrl(manifest, "service")
     if (!url) return null
     var authenticationService = shell.isAuthenticationService(manifest, key)
     if (authenticationService && AuthServiceStore.has(key)) return null
 
-    var comp = Qt.createComponent(url, Component.PreferSynchronous)
+    var pending = _serviceLoads[key]
+    if (pending && _serviceLoadCurrent(key, pending)) return null
+    if (pending) _releaseServiceLoad(key, pending)
+    // Reserve before compilation/construction, both of which may reenter the host.
+    var load = { generation: _serviceLoadGeneration, manifest: manifest, url: url,
+      component: null, finalize: null, connected: false, finalizing: false, done: false }
+    var loads = ({})
+    for (var id in _serviceLoads) loads[id] = _serviceLoads[id]
+    loads[key] = load
+    _serviceLoads = loads
+    var comp = load.component = Qt.createComponent(url, Component.PreferSynchronous)
     function finalize() {
+      if (load.done || load.finalizing) return
+      if (comp.status === Component.Loading) return
+      load.finalizing = true
+      if (!_serviceLoadCurrent(key, load)) {
+        _releaseServiceLoad(key, load)
+        return
+      }
       if (comp.status !== Component.Ready) {
         console.warn("service plugin load failed for " + key + ": " + comp.errorString())
+        _releaseServiceLoad(key, load)
         return
       }
       // Authentication services and third-party services have no visual
@@ -912,13 +963,26 @@ ShellRoot {
       var inst = comp.createObject(manifest.__isFirstParty && !authenticationService ? serviceHost : null)
       if (!inst) {
         console.warn("service plugin createObject returned null for", key)
+        _releaseServiceLoad(key, load)
         return
       }
+      function discardIfStale() {
+        if (_serviceLoadCurrent(key, load)) return false
+        inst.destroy()
+        _releaseServiceLoad(key, load)
+        return true
+      }
+      if (discardIfStale()) return
       if ("omarchyPath" in inst) inst.omarchyPath = shell.omarchyPath
+      if (discardIfStale()) return
       if ("shell" in inst) inst.shell = shell.pluginShellFor(manifest)
+      if (discardIfStale()) return
       if ("manifest" in inst) inst.manifest = shell.publicPluginManifest(manifest)
+      if (discardIfStale()) return
       if ("barWidgetRegistry" in inst) inst.barWidgetRegistry = shell.pluginBarWidgetRegistryFor(manifest)
+      if (discardIfStale()) return
       if ("pluginRegistry" in inst) inst.pluginRegistry = shell.pluginRegistryFor(manifest)
+      if (discardIfStale()) return
       if (authenticationService) {
         // Never publish lock/polkit through ShellRoot._services. The private JS
         // import retains their lifetime without adding a traversable property
@@ -930,9 +994,16 @@ ShellRoot {
         snext[key] = inst
         _services = snext
       }
+      _releaseServiceLoad(key, load)
+    }
+    load.finalize = finalize
+    if (!comp || !_serviceLoadCurrent(key, load)) {
+      _releaseServiceLoad(key, load)
+      return _services[key] || null
     }
     if (comp.status === Component.Loading) {
       comp.statusChanged.connect(finalize)
+      load.connected = true
       return null
     }
     finalize()
@@ -940,7 +1011,12 @@ ShellRoot {
   }
 
   function _syncServices() {
-    if (!pluginRegistry || !pluginRegistry.installedPlugins) return
+    if (pluginReloading || !pluginRegistry || !pluginRegistry.installedPlugins) return
+    var pending = _serviceLoads
+    for (var loadingId in pending) {
+      if (!_serviceLoadCurrent(loadingId, pending[loadingId]))
+        _releaseServiceLoad(loadingId, pending[loadingId])
+    }
     var plugins = pluginRegistry.installedPlugins
     for (var id in plugins) {
       var m = plugins[id]
@@ -1020,6 +1096,10 @@ ShellRoot {
   // Destroying omarchy.lock drops the ext-session-lock client while Hyprland
   // still holds the lock, which surfaces the crashed-lockscreen fallback.
   function unloadPluginServices() {
+    _serviceLoadGeneration++
+    var pending = _serviceLoads
+    _serviceLoads = ({})
+    for (var loadingId in pending) _releaseServiceLoad(loadingId, pending[loadingId])
     var next = ({})
     for (var existingId in _services) {
       if (serviceKeepLoaded(existingId)) {

--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -284,6 +284,10 @@ ShellRoot {
   property var _pluginAppLibraryApis: ({})
   property var _pluginBarStateApis: ({})
   property var _pluginFirstPartyServiceApis: ({})
+  // Keyed by raw manifest object (stable per scan generation); ensures every
+  // caller of publicPluginManifest for the same raw manifest gets back the
+  // identical scrubbed copy, not a fresh clone per call site.
+  property var _publicManifestCache: new WeakMap()
 
   Component {
     id: pluginShellApiComponent
@@ -318,10 +322,25 @@ ShellRoot {
   function publicPluginManifest(manifest) {
     if (!manifest) return null
     if (manifest.__isFirstParty) return manifest
+    // Reference-stable per raw manifest object: a third-party service plugin
+    // may want to compare its own injected manifest against pluginRegistry's
+    // exposed copy (e.g. to detect a stale registration surviving past a
+    // rescan). Two independently-JSON-cloned copies of the same raw manifest
+    // would never satisfy that by reference, even when nothing is actually
+    // stale - and QML's property system does not reliably preserve plain-JS-
+    // object identity for a `property var` value read back through a nested
+    // facade object either, so callers should not rely on reference equality
+    // at all. __registryRevision is a plain number - unaffected by that - and
+    // is pinned to whichever scan this raw manifest object was first seen in
+    // (memoization keeps every caller's clone, and its stamped revision, in
+    // sync for the same raw manifest).
+    if (_publicManifestCache.has(manifest)) return _publicManifestCache.get(manifest)
     var copy = JSON.parse(JSON.stringify(manifest))
     delete copy.__sourceDir
     delete copy.__isFirstParty
     delete copy.__hostCapabilities
+    copy.__registryRevision = shell.pluginRegistry ? shell.pluginRegistry.registryRevision : 0
+    _publicManifestCache.set(manifest, copy)
     return copy
   }
 

--- a/test/shell.d/fixtures/service-lifecycle/ConstructorReload.qml
+++ b/test/shell.d/fixtures/service-lifecycle/ConstructorReload.qml
@@ -1,0 +1,10 @@
+import QtQuick
+
+Item {
+  objectName: "constructor"
+  property var shell: null
+  property var manifest: null
+
+  Component.onCompleted: parent.serviceConstructed()
+  Component.onDestruction: parent.serviceDestroyed(objectName)
+}

--- a/test/shell.d/fixtures/service-lifecycle/InjectionReload.qml
+++ b/test/shell.d/fixtures/service-lifecycle/InjectionReload.qml
@@ -1,0 +1,10 @@
+import QtQuick
+
+Item {
+  objectName: "injection"
+  property var shell: null
+  property var manifest: null
+
+  onManifestChanged: if (manifest && shell) shell.serviceInjected()
+  Component.onDestruction: parent.serviceDestroyed(objectName)
+}

--- a/test/shell.d/fixtures/service-lifecycle/Service.qml
+++ b/test/shell.d/fixtures/service-lifecycle/Service.qml
@@ -1,0 +1,13 @@
+import QtQuick
+
+Item {
+  objectName: "service"
+  property string omarchyPath: ""
+  property var shell: null
+  property var manifest: null
+  property var barWidgetRegistry: null
+  property var pluginRegistry: null
+  property string observedHostPath: shell ? shell.omarchyPath : ""
+
+  Component.onDestruction: parent.serviceDestroyed(objectName)
+}

--- a/test/shell.d/fixtures/service-lifecycle/tst_service_lifecycle.qml
+++ b/test/shell.d/fixtures/service-lifecycle/tst_service_lifecycle.qml
@@ -1,0 +1,135 @@
+import QtQuick
+import QtTest
+import "services"
+import "services/AuthServiceStore.js" as AuthServiceStore
+
+Item {
+  id: shell
+  width: 1
+  height: 1
+
+  property string omarchyPath: "/test/omarchy"
+  property var barWidgetRegistry: ({})
+  property bool pluginReloading: false
+  property var destroyedServices: []
+  property var replacement: null
+  property var constructionHook: function() {}
+  property var injectionHook: function() {}
+  property QtObject pluginRegistry: QtObject {
+    property var installedPlugins: ({})
+    function isEnabled(id) { return !!installedPlugins[id] }
+    function entryPointUrl(manifest, kind) { return String(Qt.resolvedUrl(manifest.entryPoints[kind])) }
+    // No clone aliasing in these fixtures; every id already names itself.
+    function resolveEnabledId(id) { return id }
+  }
+
+  Item {
+    id: serviceHost
+    function serviceConstructed() { shell.constructionHook() }
+    function serviceDestroyed(name) { shell.destroyedServices.push(name) }
+  }
+  function serviceInjected() { injectionHook() }
+
+  // PRODUCTION_SERVICE_LOADER
+
+  TestCase {
+    name: "ServiceLifecycle"
+    when: windowShown
+
+    function install(file) {
+      // First-party so pluginShellFor/pluginRegistryFor/pluginBarWidgetRegistryFor/
+      // publicPluginManifest take their identity short-circuit instead of the
+      // scoped-plugin-API path, which needs real QML Components this isolated
+      // fixture cannot resolve. That wrapping is orthogonal to the
+      // load-ownership behavior under test here.
+      var manifest = { id: "test", kinds: ["service"], entryPoints: { service: file }, __isFirstParty: true }
+      shell.pluginRegistry.installedPlugins = { test: manifest }
+      return manifest
+    }
+
+    function init() {
+      shell.constructionHook = function() {}
+      shell.injectionHook = function() {}
+      shell.unloadPluginServices()
+      wait(0)
+      shell.destroyedServices = []
+      shell.replacement = null
+      shell.pluginRegistry.installedPlugins = ({})
+    }
+
+    function cleanup() {
+      shell.unloadPluginServices()
+      wait(0)
+    }
+
+    function replaceService() {
+      shell.unloadPluginServices()
+      install("Service.qml")
+      shell.replacement = shell.ensureService("test")
+    }
+
+    function test_component_cleanup_preserves_created_service() {
+      var manifest = install("Service.qml")
+      var inst = shell.ensureService("test")
+      verify(inst !== null)
+      compare(inst.manifest, manifest)
+      compare(inst.shell, shell)
+      compare(inst.omarchyPath, shell.omarchyPath)
+      // Component.destroy() is deferred by Qt; cross an event-loop turn before
+      // asserting that destroying the factory did not destroy its instance.
+      wait(10)
+      compare(shell.serviceFor("test"), inst)
+      compare(inst.objectName, "service")
+      compare(shell.destroyedServices.length, 0)
+      compare(inst.observedHostPath, "/test/omarchy")
+      shell.omarchyPath = "/test/updated-omarchy"
+      compare(inst.observedHostPath, "/test/updated-omarchy")
+      shell.omarchyPath = "/test/omarchy"
+      shell.unloadPluginServices()
+      wait(10)
+      compare(shell.destroyedServices.length, 1)
+      compare(shell.destroyedServices[0], "service")
+    }
+
+    function test_release_disconnects_real_status_signal() {
+      var comp = Qt.createComponent("Service.qml", Component.PreferSynchronous)
+      compare(comp.status, Component.Ready)
+      var calls = 0
+      var callback = function() { calls++ }
+      comp.statusChanged.connect(callback)
+      comp.statusChanged(comp.status)
+      compare(calls, 1)
+      var load = { component: comp, finalize: callback, connected: true, done: false }
+      shell._serviceLoads = { test: load }
+      shell._releaseServiceLoad("test", load)
+      comp.statusChanged(comp.status)
+      compare(calls, 1)
+      wait(0)
+      compare(Object.keys(shell._serviceLoads).length, 0)
+    }
+
+    function test_reload_from_component_completion_preserves_replacement() {
+      install("ConstructorReload.qml")
+      shell.constructionHook = replaceService
+      shell.ensureService("test")
+      verify(shell.replacement !== null)
+      wait(10)
+      compare(shell.serviceFor("test"), shell.replacement)
+      compare(shell.replacement.objectName, "service")
+      compare(shell.destroyedServices.length, 1)
+      compare(shell.destroyedServices[0], "constructor")
+    }
+
+    function test_reload_from_property_change_preserves_replacement() {
+      install("InjectionReload.qml")
+      shell.injectionHook = replaceService
+      shell.ensureService("test")
+      verify(shell.replacement !== null)
+      wait(10)
+      compare(shell.serviceFor("test"), shell.replacement)
+      compare(shell.replacement.objectName, "service")
+      compare(shell.destroyedServices.length, 1)
+      compare(shell.destroyedServices[0], "injection")
+    }
+  }
+}

--- a/test/shell.d/service-lifecycle-runtime-test.sh
+++ b/test/shell.d/service-lifecycle-runtime-test.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+runner=$(command -v qmltestrunner || true)
+[[ -n $runner || ! -x /usr/lib/qt6/bin/qmltestrunner ]] || runner=/usr/lib/qt6/bin/qmltestrunner
+if [[ -z $runner ]]; then
+  pass "qmltestrunner not installed; skipping service lifecycle Qt runtime test"
+  exit 0
+fi
+require_command node
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+mkdir -p "$test_tmp/home" "$test_tmp/runtime"
+chmod 700 "$test_tmp/runtime"
+cp "$SHELL_TEST_DIR/fixtures/service-lifecycle/"*.qml "$test_tmp/"
+# The extracted production loader declares Component{} blocks for every
+# scoped plugin-API type (PluginShellApi, PluginRegistryApi, ...) and
+# unconditionally calls AuthServiceStore via ensureService's
+# isAuthenticationService check. QML type-checks Component{} bodies at
+# compile time regardless of whether they are ever instantiated, so the real
+# services/ directory (all plain, dependency-free QtObject types plus the
+# AuthServiceStore.js module) must be resolvable alongside the fixture.
+cp -r "$ROOT/shell/services" "$test_tmp/services"
+
+# Run the production service block in a plain QtQuick host, without Quickshell
+# or a connection to the user's desktop session.
+node - "$ROOT/shell/shell.qml" "$test_tmp/tst_service_lifecycle.qml" <<'JS'
+const fs = require('fs')
+const source = fs.readFileSync(process.argv[2], 'utf8')
+const start = source.indexOf('  property var _services:')
+const end = source.indexOf('  Connections {\n    target: shell.pluginRegistry', start)
+if (start < 0 || end < 0) throw new Error('cannot locate production service loader')
+const template = fs.readFileSync(process.argv[3], 'utf8')
+fs.writeFileSync(process.argv[3], template.replace('  // PRODUCTION_SERVICE_LOADER', source.slice(start, end)))
+JS
+
+if ! output=$(env -u WAYLAND_DISPLAY -u DISPLAY -u QT_QPA_PLATFORMTHEME -u QT_IM_MODULE \
+  HOME="$test_tmp/home" XDG_CONFIG_HOME="$test_tmp/home/config" \
+  XDG_CACHE_HOME="$test_tmp/home/cache" XDG_DATA_HOME="$test_tmp/home/data" \
+  XDG_STATE_HOME="$test_tmp/home/state" XDG_RUNTIME_DIR="$test_tmp/runtime" \
+  DBUS_SESSION_BUS_ADDRESS="unix:path=$test_tmp/no-session-bus" \
+  QT_QPA_PLATFORM=offscreen QT_QUICK_BACKEND=software \
+  timeout 20 "$runner" -input "$test_tmp/tst_service_lifecycle.qml" 2>&1); then
+  fail "service lifecycle Qt runtime checks" "$output"
+fi
+printf '%s\n' "$output"
+pass "service lifecycle Qt runtime checks"

--- a/test/shell.d/service-lifecycle-test.sh
+++ b/test/shell.d/service-lifecycle-test.sh
@@ -1,0 +1,489 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+# An optional source path lets the same regression run against an older revision.
+export SERVICE_LIFECYCLE_SOURCE=${1:-"$ROOT/shell/shell.qml"}
+export SERVICE_LIFECYCLE_AUTH_STORE="$ROOT/shell/services/AuthServiceStore.js"
+
+run_node_test <<'JS'
+const fs = require('fs')
+const vm = require('vm')
+const check = require('node:assert/strict')
+const source = fs.readFileSync(process.env.SERVICE_LIFECYCLE_SOURCE, 'utf8')
+const serviceSection = source.slice(source.indexOf('  property var _services:'), source.indexOf('  Connections {\n    target: shell.pluginRegistry'))
+const functions = serviceSection.match(/^  function \w+\([^\n]*\) \{[\s\S]*?^  \}/gm)
+check.ok(functions && functions.length >= 5, 'extract production service functions')
+const properties = [...serviceSection.matchAll(/^  property (?:var|int) (\w+): (.+)$/gm)]
+  .map(([, name, value]) => `var ${name} = ${value}`)
+const production = properties.concat(functions).join('\n')
+const Component = { Null: 0, Ready: 1, Loading: 2, Error: 3, PreferSynchronous: 0 }
+
+function fixture() {
+  const requests = []
+  const queue = []
+  const warnings = []
+  const installedPlugins = {}
+  const enabled = new Set()
+  // The extracted production loader unconditionally calls AuthServiceStore
+  // via ensureService's isAuthenticationService check; run the real,
+  // dependency-free module (shell/services/AuthServiceStore.js) rather than
+  // a hand-rolled stand-in. None of these fixtures are trusted, so isTrusted
+  // stays false and the store otherwise just tracks put/has/destroy/ids.
+  const authContext = {}
+  vm.createContext(authContext)
+  vm.runInContext(fs.readFileSync(process.env.SERVICE_LIFECYCLE_AUTH_STORE, 'utf8'), authContext)
+  const AuthServiceStore = {
+    isTrusted: authContext.isTrusted,
+    has: authContext.has,
+    put: authContext.put,
+    updateManifest: authContext.updateManifest,
+    destroy: authContext.destroy,
+    ids: authContext.ids
+  }
+  const context = {
+    Component,
+    AuthServiceStore,
+    serviceHost: {},
+    omarchyPath: '/test/omarchy',
+    barWidgetRegistry: {},
+    pluginReloading: false,
+    console: { warn: (...args) => warnings.push(args.join(' ')) },
+    pluginRegistry: {
+      installedPlugins,
+      isEnabled: id => enabled.has(id),
+      entryPointUrl: manifest => manifest.basePath + '/' + manifest.entryPoints.service,
+      // No clone aliasing in these fixtures; every id already names itself.
+      resolveEnabledId: id => id
+    },
+    Qt: {
+      createComponent(url, mode) {
+        check.equal(mode, Component.PreferSynchronous)
+        const comp = queue.shift()
+        check.ok(comp !== undefined, 'fixture has a component for each load')
+        requests.push({ url, comp })
+        return comp
+      }
+    }
+  }
+  context.shell = context
+  vm.createContext(context)
+  vm.runInContext(production, context, { filename: 'shell.qml:services' })
+
+  function install(id = 'test.service') {
+    // First-party so pluginShellFor/pluginRegistryFor/pluginBarWidgetRegistryFor/
+    // publicPluginManifest take their identity short-circuit instead of the
+    // scoped-plugin-API path, which needs real QML Components this harness
+    // cannot construct. That wrapping is orthogonal to the load-ownership
+    // behavior under test here.
+    const manifest = { id, kinds: ['service'], entryPoints: { service: 'Service.qml' }, basePath: '/plugins/' + id, __isFirstParty: true }
+    installedPlugins[id] = manifest
+    enabled.add(id)
+    return manifest
+  }
+
+  function component(status = Component.Loading, onCreate) {
+    const callbacks = new Set()
+    const history = []
+    const instances = []
+    const comp = {
+      status,
+      creates: 0,
+      destroys: 0,
+      callbacks,
+      history,
+      instances,
+      statusChanged: {
+        connect(callback) { callbacks.add(callback); history.push(callback) },
+        disconnect(callback) { check.ok(callbacks.delete(callback), 'disconnect an attached callback') }
+      },
+      errorString() { return 'fixture component error' },
+      destroy() { this.destroys++ },
+      createObject(parent) {
+        check.equal(parent, context.serviceHost)
+        this.creates++
+        const inst = { omarchyPath: null, shell: null, manifest: null, barWidgetRegistry: null, pluginRegistry: null, destroys: 0, destroy() { this.destroys++ } }
+        instances.push(inst)
+        return onCreate ? onCreate(inst) : inst
+      },
+      emit(nextStatus) {
+        this.status = nextStatus
+        for (const callback of [...callbacks]) callback()
+      },
+      late(nextStatus) {
+        this.status = nextStatus
+        for (const callback of history) callback()
+      }
+    }
+    queue.push(comp)
+    return comp
+  }
+  return { context, install, component, requests, queue, enabled, installedPlugins, warnings }
+}
+
+let failures = 0
+function test(description, body) {
+  try {
+    body()
+    pass(description)
+  } catch (error) {
+    failures++
+    console.error(`not ok - ${description}\n${error.stack}`)
+  }
+}
+
+test('late old load cannot displace the fresh service after unload', () => {
+  const f = fixture()
+  f.install()
+  const old = f.component()
+  f.context.ensureService('test.service')
+  f.context.unloadPluginServices()
+  const fresh = f.component()
+  f.context.ensureService('test.service')
+  fresh.emit(Component.Ready)
+  const current = f.context.serviceFor('test.service')
+  old.late(Component.Ready)
+  check.ok(f.context.serviceFor('test.service') === current, 'the fresh service retains ownership')
+  check.equal(old.creates, 0)
+  check.equal(current.destroys, 0)
+  check.equal(old.callbacks.size, 0)
+  check.equal(fresh.callbacks.size, 0)
+})
+
+test('pending ensure and sync requests share one load and Loading remains pending', () => {
+  const f = fixture()
+  f.install()
+  const comp = f.component()
+  check.equal(f.context.ensureService('test.service'), null)
+  check.equal(f.context.ensureService('test.service'), null)
+  f.context._syncServices()
+  comp.emit(Component.Loading)
+  check.equal(comp.creates, 0)
+  check.equal(f.warnings.length, 0)
+  check.equal(comp.callbacks.size, 1)
+  check.equal(f.requests.length, 1)
+  comp.emit(Component.Ready)
+  const inst = f.context.serviceFor('test.service')
+  check.ok(inst)
+  check.equal(f.context.ensureService('test.service'), inst)
+  comp.late(Component.Ready)
+  check.equal(comp.creates, 1)
+  check.equal(comp.callbacks.size, 0)
+  check.equal(f.context.serviceFor('test.service'), inst)
+})
+
+test('synchronous creation returns the injected service with the existing injection order', () => {
+  const f = fixture()
+  const manifest = f.install()
+  const writes = []
+  const comp = f.component(Component.Ready, inst => new Proxy(inst, {
+    set(target, key, value) { writes.push(key); target[key] = value; return true }
+  }))
+  const inst = f.context.ensureService('test.service')
+  check.ok(inst)
+  check.equal(inst.omarchyPath, f.context.omarchyPath)
+  check.equal(inst.shell.serviceFor('test.service'), inst)
+  check.equal(inst.manifest, manifest)
+  check.equal(inst.barWidgetRegistry, f.context.barWidgetRegistry)
+  check.equal(inst.pluginRegistry, f.context.pluginRegistry)
+  check.deepEqual(writes, ['omarchyPath', 'shell', 'manifest', 'barWidgetRegistry', 'pluginRegistry'])
+  check.equal(comp.callbacks.size, 0)
+  check.equal(f.context.firstPartyServiceFor('test.service'), inst)
+})
+
+const invalidations = {
+  disabled: f => f.enabled.delete('test.service'),
+  removed: f => delete f.installedPlugins['test.service'],
+  'manifest replaced': f => f.install(),
+  'URL changed': f => { f.installedPlugins['test.service'].basePath = '/replacement' },
+  'service kind removed': f => { f.installedPlugins['test.service'].kinds = ['panel'] },
+  'entry point removed': f => { delete f.installedPlugins['test.service'].entryPoints.service }
+}
+
+for (const [reason, invalidate] of Object.entries(invalidations)) {
+  test(`${reason} while pending prevents stale construction and allows explicit retry`, () => {
+    const f = fixture()
+    f.install()
+    const stale = f.component()
+    f.context.ensureService('test.service')
+    invalidate(f)
+    stale.emit(Component.Ready)
+    check.equal(stale.creates, 0)
+    check.equal(stale.callbacks.size, 0)
+    check.equal(f.context.serviceFor('test.service'), null)
+    f.install()
+    const fresh = f.component(Component.Ready)
+    check.ok(f.context.ensureService('test.service'))
+    check.equal(fresh.creates, 1)
+  })
+}
+
+for (const reason of ['disabled', 'removed', 'service kind removed', 'entry point removed']) {
+  test(`sync cancels a ${reason} pending load without waiting for completion`, () => {
+    const f = fixture()
+    f.install()
+    const stale = f.component()
+    f.context.ensureService('test.service')
+    invalidations[reason](f)
+    f.context._syncServices()
+    check.equal(stale.callbacks.size, 0)
+    stale.late(Component.Ready)
+    check.equal(stale.creates, 0)
+    check.equal(f.context.serviceFor('test.service'), null)
+  })
+}
+
+test('disabled or invalid service requests do not create components', () => {
+  const f = fixture()
+  check.equal(f.context.ensureService('missing'), null)
+  for (const reason of ['disabled', 'service kind removed', 'entry point removed']) {
+    f.install()
+    invalidations[reason](f)
+    check.equal(f.context.ensureService('test.service'), null)
+  }
+  check.equal(f.requests.length, 0)
+})
+
+for (const status of [Component.Error, Component.Null]) {
+  for (const asynchronous of [false, true]) {
+    test(`${asynchronous ? 'asynchronous' : 'synchronous'} status ${status} releases failed load for retry`, () => {
+      const f = fixture()
+      f.install()
+      const failed = f.component(asynchronous ? Component.Loading : status)
+      check.equal(f.context.ensureService('test.service'), null)
+      if (asynchronous) failed.emit(status)
+      check.equal(failed.callbacks.size, 0)
+      check.equal(failed.creates, 0)
+      check.equal(f.context.serviceFor('test.service'), null)
+      const fresh = f.component(Component.Ready)
+      const inst = f.context.ensureService('test.service')
+      check.ok(inst)
+      failed.late(Component.Ready)
+      check.equal(failed.creates, 0)
+      check.equal(fresh.creates, 1)
+      check.equal(f.context.serviceFor('test.service'), inst)
+    })
+  }
+}
+
+test('null createObject releases the load so an explicit retry can succeed', () => {
+  const f = fixture()
+  f.install()
+  const failed = f.component(Component.Loading, () => null)
+  f.context.ensureService('test.service')
+  failed.emit(Component.Ready)
+  check.equal(failed.callbacks.size, 0)
+  check.equal(f.context.serviceFor('test.service'), null)
+  f.component(Component.Ready)
+  check.ok(f.context.ensureService('test.service'))
+  check.equal(failed.creates, 1)
+})
+
+test('null component releases the load so an explicit retry can succeed', () => {
+  const f = fixture()
+  f.install()
+  f.queue.push(null)
+  check.equal(f.context.ensureService('test.service'), null)
+  f.component(Component.Ready)
+  check.ok(f.context.ensureService('test.service'))
+  check.equal(f.requests.length, 2)
+})
+
+for (const reason of ['manifest replaced', 'URL changed']) {
+  test(`sync replaces a pending load when its ${reason}`, () => {
+    const f = fixture()
+    f.install()
+    const old = f.component()
+    f.context.ensureService('test.service')
+    invalidations[reason](f)
+    const fresh = f.component()
+    f.context._syncServices()
+    check.equal(old.callbacks.size, 0)
+    check.equal(fresh.callbacks.size, 1)
+    old.late(Component.Ready)
+    check.equal(old.creates, 0)
+    check.equal(f.context.ensureService('test.service'), null)
+    check.equal(f.requests.length, 2)
+    fresh.emit(Component.Ready)
+    check.equal(f.context.serviceFor('test.service'), fresh.instances[0])
+    check.equal(fresh.instances[0].manifest, f.installedPlugins['test.service'])
+    check.equal(f.requests[1].url, f.context.pluginRegistry.entryPointUrl(f.installedPlugins['test.service']))
+  })
+}
+
+test('cancelled callbacks cannot release a newer pending claim', () => {
+  const f = fixture()
+  f.install()
+  const old = f.component()
+  f.context.ensureService('test.service')
+  f.context.unloadPluginServices()
+  const fresh = f.component()
+  f.context.ensureService('test.service')
+  old.late(Component.Error)
+  old.late(Component.Ready)
+  check.equal(f.context.ensureService('test.service'), null)
+  check.equal(f.requests.length, 2)
+  check.equal(fresh.callbacks.size, 1)
+  check.equal(old.creates, 0)
+  fresh.emit(Component.Ready)
+  check.equal(f.context.serviceFor('test.service'), fresh.instances[0])
+})
+
+test('unloading destroys registered services and disconnects every pending service', () => {
+  const f = fixture()
+  f.install('ready')
+  f.install('pending')
+  const ready = f.component(Component.Ready)
+  const inst = f.context.ensureService('ready')
+  const pending = f.component()
+  f.context.ensureService('pending')
+  f.context.unloadPluginServices()
+  check.equal(inst.destroys, 1)
+  check.equal(pending.callbacks.size, 0)
+  pending.late(Component.Ready)
+  check.equal(pending.creates, 0)
+  check.equal(f.context.serviceFor('ready'), null)
+  check.equal(f.context.serviceFor('pending'), null)
+  f.context.unloadPluginServices()
+  check.equal(ready.instances[0].destroys, 1)
+})
+
+test('sync cancellation leaves an unrelated service and pending callback intact', () => {
+  const f = fixture()
+  f.install('retained')
+  f.install('pending')
+  f.install('disabled')
+  f.component(Component.Ready)
+  const retained = f.context.ensureService('retained')
+  const pending = f.component()
+  f.context.ensureService('pending')
+  const disabled = f.component()
+  f.context.ensureService('disabled')
+  f.enabled.delete('disabled')
+  f.context._syncServices()
+  check.equal(disabled.callbacks.size, 0)
+  check.equal(pending.callbacks.size, 1)
+  check.equal(f.context.serviceFor('retained'), retained)
+  check.equal(retained.destroys, 0)
+  pending.emit(Component.Ready)
+  check.ok(f.context.serviceFor('pending'))
+})
+
+for (const phase of ['createObject', 'omarchyPath', 'shell', 'manifest', 'barWidgetRegistry', 'pluginRegistry']) {
+  test(`reentrant unload during ${phase} destroys the stale instance and preserves the replacement`, () => {
+    const f = fixture()
+    f.install()
+    let replacement
+    function reload() {
+      f.context.unloadPluginServices()
+      f.component(Component.Ready)
+      replacement = f.context.ensureService('test.service')
+    }
+    const stale = f.component(Component.Ready, inst => {
+      if (phase === 'createObject') {
+        reload()
+      } else {
+        let value
+        Object.defineProperty(inst, phase, {
+          get() { return value },
+          set(next) { value = next; reload() }
+        })
+      }
+      return inst
+    })
+    f.context.ensureService('test.service')
+    check.ok(replacement)
+    check.ok(f.context.serviceFor('test.service') === replacement, 'replacement retains ownership after reentrant unload')
+    check.equal(replacement.destroys, 0)
+    check.equal(stale.instances[0].destroys, 1)
+    check.equal(stale.callbacks.size, 0)
+  })
+}
+
+test('reentrant duplicate requests during construction retain the in-flight claim', () => {
+  const f = fixture()
+  f.install()
+  const comp = f.component(Component.Ready, inst => {
+    check.equal(f.context.ensureService('test.service'), null)
+    f.context._syncServices()
+    return inst
+  })
+  check.ok(f.context.ensureService('test.service'))
+  check.equal(f.requests.length, 1)
+  check.equal(comp.creates, 1)
+})
+
+test('reentrant reload during component compilation cleans up the obsolete factory', () => {
+  const f = fixture()
+  f.install()
+  const old = f.component()
+  const createComponent = f.context.Qt.createComponent
+  let reloaded = false
+  let replacement
+  f.context.Qt.createComponent = (url, mode) => {
+    const comp = createComponent(url, mode)
+    if (!reloaded) {
+      reloaded = true
+      f.context.unloadPluginServices()
+      f.component(Component.Ready)
+      replacement = f.context.ensureService('test.service')
+    }
+    return comp
+  }
+  f.context.ensureService('test.service')
+  check.ok(replacement)
+  check.equal(f.context.serviceFor('test.service'), replacement)
+  check.equal(replacement.destroys, 0)
+  check.equal(old.creates, 0)
+  check.equal(old.callbacks.size, 0)
+  check.equal(old.destroys, 1)
+})
+
+test('plugin reload blocks ensure and sync until the new registry is ready', () => {
+  const f = fixture()
+  f.install()
+  f.context.pluginReloading = true
+  check.equal(f.context.ensureService('test.service'), null)
+  f.context._syncServices()
+  check.equal(f.requests.length, 0)
+  f.context.pluginReloading = false
+  const old = f.component()
+  f.context.ensureService('test.service')
+  f.context.pluginReloading = true
+  old.emit(Component.Ready)
+  check.equal(old.creates, 0)
+  check.equal(old.callbacks.size, 0)
+  check.equal(f.context.serviceFor('test.service'), null)
+  f.context.pluginReloading = false
+  f.component(Component.Ready)
+  f.context._syncServices()
+  check.ok(f.context.serviceFor('test.service'))
+})
+
+for (const phase of ['createObject', 'manifest']) {
+  for (const [reason, invalidate] of Object.entries(invalidations)) {
+    test(`${reason} during ${phase} destroys the stale instance before registration`, () => {
+      const f = fixture()
+      f.install()
+      const stale = f.component(Component.Ready, inst => {
+        if (phase === 'createObject') {
+          invalidate(f)
+        } else {
+          Object.defineProperty(inst, 'manifest', { set() { invalidate(f) } })
+        }
+        return inst
+      })
+      check.equal(f.context.ensureService('test.service'), null)
+      check.equal(f.context.serviceFor('test.service'), null)
+      check.equal(stale.instances[0].destroys, 1)
+      f.install()
+      f.component(Component.Ready)
+      check.ok(f.context.ensureService('test.service'))
+    })
+  }
+}
+
+if (failures) process.exit(1)
+JS


### PR DESCRIPTION
Two related defects in the shell's service loader let an enabled `service`-kind plugin end up with no live service, or with a service that can never admit itself. Both surface on third-party plugins that pair a `service` entry point with a bar widget or panel.

## 1. Pending service loads are not owned across reloads

`ensureService` compiled a component and registered whatever its `finalize` callback produced, with no claim on the in-flight load. When an asynchronous load completed after a reload had already started a fresh load for the same plugin, the obsolete finalizer still ran `_services[key] = inst`, displacing the fresh owner with a stale, inactive instance. `_syncServices` then skipped the key as occupied, so nothing recovered it until the next shell restart — where the same race could repeat.

The fix adds a per-key pending claim plus a reload generation:

- one claim per key, so duplicate `ensureService`/`_syncServices` requests share a single in-flight load rather than racing;
- revalidation of the enabled manifest, entry-point URL and claim ownership before construction, between every property injection and before registration, discarding a stale instance instead of publishing it;
- callback detachment and component cleanup on cancellation, and a generation bump in `unloadPluginServices` so pending loads from a previous generation can never register.

Public service APIs, the injection order and synchronous creation are unchanged.

## 2. `publicPluginManifest` re-clones per call site

Every call independently `JSON.parse(JSON.stringify(...))`-ed the raw manifest, so a plugin's own injected `manifest` and the copy handed to its scoped `PluginRegistryApi` facade were different objects. A plugin that compares the two — to notice that its registration was superseded by a newer scan — saw them differ on every load, not just a stale one.

Reference equality is not a dependable contract here anyway: reading a plain JS object back out of a `property var` through the facade does not preserve strict identity (it arrives as a `V4ReferenceObject` wrapper). So the copy is now memoized per raw manifest object *and* stamped with `__registryRevision`, a plain number pinned to the scan generation the raw manifest was first seen in. Numbers survive the property round trip, so plugins have something reliable to compare. Memoization also removes the redundant re-cloning on every facade construction and rescan.

## Tests

- `test/shell.d/service-lifecycle-test.sh` — 45 Node cases driving the extracted production loader: late/duplicate completion order, disable/remove/rescan invalidation, loading/error/null status, reentrant creation and injection, cancellation, and unaffected neighbours. They fail against the unpatched loader and pass with it.
- `test/shell.d/service-lifecycle-runtime-test.sh` — the same production block inside a real QtQuick host via `qmltestrunner`, covering component cleanup, real `statusChanged` disconnection and reload-during-construction/injection. Skips cleanly when `qmltestrunner` is absent.
The existing authentication-boundary coverage in `plugin-auth-boundary-test.sh` still passes.

## Verification

Built as a local `omarchy` package and installed on a 4.0.3 desktop. Before: an enabled third-party `service` plugin never got a live service instance, and once the loader race was fixed it was still rejected permanently by its own stale-registration check. After both fixes the service registers, admits itself and its helper process runs.

Happy to split this into two PRs or adjust naming — whatever suits.
