### PR TITLE
Size the weather bar icon like the other bar icons

### DIFF
--- a/shell/plugins/panels/weather/BarWidget.qml
+++ b/shell/plugins/panels/weather/BarWidget.qml
@@ -69,7 +69,6 @@ BarWidget {
     anchors.fill: parent
     bar: root.bar
     text: panelLoader.item ? panelLoader.item.label : ""
-    slotSize: Style.bar.statusSlot
     // Tooltip suppressed because the panel is the detail view.
     tooltipText: ""
 

--- a/test/shell.d/fixtures/bar-widget-contract/shell.qml
+++ b/test/shell.d/fixtures/bar-widget-contract/shell.qml
@@ -169,8 +169,10 @@ ShellRoot {
             var verticalId = root.createdIds[k]
             if (verticalId === "omarchy.clock")
               root.assertEqual(verticalItem.implicitHeight, Style.bar.iconSlot * 3, verticalId + " uses one slot per line")
-            else if (verticalId === "omarchy.weather" || verticalId === "omarchy.system-update")
+            else if (verticalId === "omarchy.system-update")
               root.assertEqual(verticalItem.implicitHeight, Style.bar.statusSlot, verticalId + " uses one compact status slot")
+            else if (verticalId === "omarchy.weather")
+              root.assertEqual(verticalItem.implicitHeight, Style.bar.iconSlot, verticalId + " uses the standard icon slot")
             if (verticalItem && typeof verticalItem.destroy === "function") verticalItem.destroy()
           }
           root.assertTrue(root.createdIds.length === entries.length, "all bar widgets instantiate")


### PR DESCRIPTION
## Summary

- `omarchy.weather` forced `BarIconButton.slotSize` to `Style.bar.statusSlot` (default 21). Neighbors use `iconSlot` (default 27), so the weather glyph reads smaller than keyboard/update/media on a 15.6" 1080p bar.
- Drop the override. `BarIconButton` already defaults to `iconSlot` / `iconCanvas` / `iconFont`.
- `omarchy.system-update` stays on the compact status slot. The bar-widget contract now asserts weather `iconSlot` and update `statusSlot` separately.

Lived on Omarchy 4.0.3-1, `eDP-1` 1920×1080 scale 1, bar reserved 30px. Same change has been running locally via `omarchy plugin clone omarchy.weather`.

## Test plan

- [x] `bash test/shell.d/bar-widget-contract-test.sh` — weather expects `iconSlot`, update still `statusSlot`
- [x] `bash test/shell.d/weather-test.sh`
- [ ] `./test/all` — `test/cli` green; `test/shell` had 6 remaining failures on this laptop that are checkout/environment (`omarchy-pkgs` missing, locate utf-8, launch-about animation, snapper/unowned PKGBUILD). None of those files touch weather.
- [ ] Visual: weather glyph same size as keyboard-layout / media; system-update badge still compact. Before/after fullscreen captures on this 1080p box: `Pictures/Screenshots/screenshot-2026-09-12_18-45-31.png` (stock `statusSlot`) vs `...18-45-32.png` (clone `iconSlot`). `gh` cannot attach images; I can drop them on the PR in the browser.


Made with [Cursor](https://cursor.com)