### PR TITLE
Add keyboard movement for floating windows

### DIFF
--- a/default/hypr/bindings/tiling.lua
+++ b/default/hypr/bindings/tiling.lua
@@ -44,6 +44,11 @@ o.bind("SUPER + SHIFT + RIGHT", "Swap window to the right", hl.dsp.window.swap({
 o.bind("SUPER + SHIFT + UP", "Swap window up", hl.dsp.window.swap({ direction = "u" }))
 o.bind("SUPER + SHIFT + DOWN", "Swap window down", hl.dsp.window.swap({ direction = "d" }))
 
+o.bind("SUPER + CTRL + SHIFT + LEFT", "Move floating window left", hl.dsp.window.move({ x = -25, y = 0, relative = true }), { repeating = true })
+o.bind("SUPER + CTRL + SHIFT + RIGHT", "Move floating window right", hl.dsp.window.move({ x = 25, y = 0, relative = true }), { repeating = true })
+o.bind("SUPER + CTRL + SHIFT + UP", "Move floating window up", hl.dsp.window.move({ x = 0, y = -25, relative = true }), { repeating = true })
+o.bind("SUPER + CTRL + SHIFT + DOWN", "Move floating window down", hl.dsp.window.move({ x = 0, y = 25, relative = true }), { repeating = true })
+
 o.bind("ALT + TAB", "Focus on next window", hl.dsp.window.cycle_next())
 o.bind("ALT + SHIFT + TAB", "Focus on previous window", hl.dsp.window.cycle_next({ next = false }))
 o.bind("ALT + TAB", "Reveal active window on top", hl.dsp.window.bring_to_top())

--- a/manual/04-navigation.md
+++ b/manual/04-navigation.md
@@ -22,6 +22,8 @@ If you hit `Super + Shift + 2`, you'll move the current focused application onto
 
 If you hold down `Super` and use the mouse to click on a window, you'll be able to rearrange where it sits. If you hold `Super` and use the right button on the mouse, you can freely resize the window.
 
+To position a floating window with the keyboard, focus it with `Super + Arrow`, then use `Super + Ctrl + Shift + Arrow` to move it in 25-pixel steps. Hold the shortcut to keep moving. If the window is tiled, press `Super + T` first to make it floating; press `Super + T` again when you want it back in the tiled layout. `Super + Shift + Arrow` continues to swap tiled windows.
+
 You close a window on `Super + W` or `Super + Q` (and close all windows on `Ctrl + Alt + Delete`).
 
 You can also go full screen with `Super + F` or even just full-width (keeping the top bar) with `Super + Alt + F` or full-screen within a window with `Super + Ctrl + F` (good for YouTube!).


### PR DESCRIPTION
## Why

Floating a window with Super + T is keyboard-accessible, but positioning it currently requires Super + mouse drag. This leaves a gap for people who want to manage their desktop entirely from the keyboard.

## Change

Add **Super + Ctrl + Shift + Arrow** to move the focused floating window in 25-pixel steps, with key repeat when held. Document the complete float → position → tile workflow in the navigation manual.

The four bindings use Hyprland's native `hl.dsp.window.move({ x, y, relative = true })` dispatcher. No helper process or new dependency is needed. Existing focus, tiled swapping, grouping and monitor shortcuts retain their bindings. The default binding conflict check confirms the proposed chords are available.

Hyprland's coordinate-move path only moves floating layout targets; it does not turn tiled windows into floating windows. Fullscreen windows use Hyprland's existing movement restriction.

## Validation

- Passed: `bash test/shell.d/hyprland-binding-conflicts-test.sh`.
- Passed: `bash test/shell.d/hyprland-default-config-test.sh` (exit 0; its fixture setup emitted a missing-`lspci` symlink diagnostic in this container).
- Passed: `luac -p default/hypr/bindings/tiling.lua` with Lua 5.4.6.
- Passed: `git diff --check` and mechanical PR preflight.
- Checked the dispatcher arguments against the [Hyprland documentation](https://wiki.hypr.land/Configuring/Basics/Dispatchers/) and its coordinate-move implementation.

Tom Ballard confirmed that he has validated the change and requested that this PR be marked ready for review. The automated checks above were run by Codex; live validation was reported by Tom.

Prepared with Codex. No linked issue; this is a focused proposal prompted by a request for mouse-free floating-window positioning.