### PR TITLE
Skip omarchy-fcitx5.service when fcitx5 is not installed

### DIFF
--- a/default/systemd/user/omarchy-fcitx5.service
+++ b/default/systemd/user/omarchy-fcitx5.service
@@ -17,6 +17,12 @@ PartOf=graphical-session.target
 # working one -- Wants= does not restart what is already running. Skip the start
 # instead; the unit stays enabled and starts for real at graphical login.
 ConditionEnvironment=WAYLAND_DISPLAY
+# fcitx5 comes from its own package, and nothing here depends on it hard. Without
+# the binary every start fails 203/EXEC, and Restart=always brings it back two
+# seconds later, forever: RestartSec=2 fits exactly five starts into the default
+# StartLimitBurst=5 per 10s window, so the rate limiter never trips. Skip the
+# start instead; once fcitx5 is installed the next start request works normally.
+ConditionPathExists=/usr/bin/fcitx5
 
 [Service]
 Type=simple

--- a/test/shell.d/systemd-test.sh
+++ b/test/shell.d/systemd-test.sh
@@ -70,6 +70,8 @@ grep -Fx 'WantedBy=graphical-session.target' "$fcitx_service" >/dev/null ||
   fail "fcitx5 is never pulled in at login without a WantedBy"
 grep -Fx 'ConditionEnvironment=WAYLAND_DISPLAY' "$fcitx_service" >/dev/null ||
   fail "an update over SSH has a live user manager and no display; starting fcitx5 there wedges the unit active-but-blind, and Wants= will not replace it at graphical login"
+grep -Fx 'ConditionPathExists=/usr/bin/fcitx5' "$fcitx_service" >/dev/null ||
+  fail "without fcitx5 installed the unit 203/EXEC-loops every 2s; RestartSec=2 fits exactly StartLimitBurst=5 per 10s, so systemd never rate-limits it"
 
 grep -F 'pkill -x fcitx5' "$ROOT/bin/omarchy-restart-xcompose" >/dev/null ||
   fail "restart-xcompose cannot reload a fcitx5 running outside the unit, so it silently keeps serving the old table"


### PR DESCRIPTION
## Summary

`omarchy-fcitx5.service` runs `ExecStart=/usr/bin/fcitx5 --disable notificationitem` with `Restart=always` / `RestartSec=2`, guarded only by `ConditionEnvironment=WAYLAND_DISPLAY`. When the `fcitx5` package is not installed, every start fails `203/EXEC` and systemd restarts it forever. This adds `ConditionPathExists=/usr/bin/fcitx5` so the enabled unit stays inert until the package is present — the same idiom `omarchy-tailscale-receive.service` already uses (`ConditionPathExists=/usr/bin/tailscale`) — and pins it in `test/shell.d/systemd-test.sh`.

`install/user/first-run/enable-user-units.sh` enables the unit unconditionally and states the invariant this unit was missing:

> ConditionPath* in the unit files keep the enabled units inert on hardware they don't apply to.

Of the six units that script enables, this is the only one that pairs `Restart=always` with an `ExecStart` from a separately installed package and no path guard.

## Why the loop is unbounded

systemd's default start limiter (`StartLimitBurst=5` per `StartLimitIntervalSec=10s`) never engages, because `RestartSec=2` sits exactly on the boundary — a point @vantuan5644 measured on #7461 (2026-08-25, `RestartUSec=2s`, ~4.7 starts per 10 s window) and @jkubo restated there (2026-09-04). On the affected guest below: median restart spacing 2.250 s, and the most starts in any 10 s window is exactly 5. The limiter trips only when a window *exceeds* the burst, so it never fires.

Confirmed with two probe units run side by side for 30 s (`ExecStart` pointing at a nonexistent path, no `Condition*` lines, default limits, only `RestartSec` differing): `RestartSec=1` → `failed` (`start-limit-hit`) at `NRestarts=5`; `RestartSec=2` → 13 restarts, still `activating`.

## Observed impact

Try Omarchy guest (`try-omarchy-runtime 4.0.2-1`, Omarchy 4.0.0.alpha, aarch64/QEMU), where the trimmed package set omits `fcitx5` but the first-run script still enables the unit:

- **333,398 restarts** over one continuous boot (Sep 2 → masked Sep 11), ~37,000/day
- **2,002,172 journal lines from this one unit — 54 % of all 3,686,125 lines on the machine**; journal at **2.1 GB** (read 2026-09-11 ~17:25, before a vacuum)
- six lines every ~2.25 s:

```
systemd[459]: omarchy-fcitx5.service: Scheduled restart job, restart counter is at 333398.
systemd[459]: Started Fcitx5 input method (XCompose sequences).
(fcitx5)[2067479]: omarchy-fcitx5.service: Unable to locate executable '/usr/bin/fcitx5': No such file or directory
(fcitx5)[2067479]: omarchy-fcitx5.service: Failed at step EXEC spawning /usr/bin/fcitx5: No such file or directory
systemd[459]: omarchy-fcitx5.service: Main process exited, code=exited, status=203/EXEC
systemd[459]: omarchy-fcitx5.service: Failed with result 'exit-code'.
```

CPU cost is negligible (a probe accumulated 4.4 ms across 13 restarts); the cost is journal volume and a journal that is useless for diagnosing anything else.

The sibling units enabled by the same script, on the same machine:

| Unit | Guard | `Restart=` | `NRestarts` |
|---|---|---|---|
| `bt-agent` | `ConditionPathIsDirectory=/sys/class/bluetooth` + `ExecCondition=` on `bluetooth.service` (no guard on the binary itself — see #6992) | `on-failure` | 0 |
| `omarchy-recover-internal-monitor` | `ConditionPathExists=%h/...` | (none) | 0 |
| `omarchy-sleep-lock` | `ConditionEnvironment` ×2 | `always` | 0 *(ExecStart ships with omarchy)* |
| `omarchy-migrate-notify` | `ConditionPathIsDirectory=/usr/share/omarchy/migrations` | (none) | 0 |
| `omarchy-crash-watch` | `ConditionEnvironment` + `ConditionPathExists=!` | `always` | 0 *(ExecStart ships with omarchy)* |
| **`omarchy-fcitx5`** | **`ConditionEnvironment` only** | **`always`** | **333,398** |

`fcitx5` is a plain entry in `install/omarchy-base.packages`; nothing in this tree pins it, so a normal install that removes it lands here too. Reproduction on any install:

```bash
sudo mv /usr/bin/fcitx5 /usr/bin/fcitx5.bak     # or: pacman -Rc fcitx5
systemctl --user restart omarchy-fcitx5.service
sleep 30; systemctl --user show -p NRestarts --value omarchy-fcitx5.service   # climbs ~1 per 2.25 s
```

## What the guard does and does not do

- Binary absent at start → `ConditionResult=no`, `ActiveState=inactive`, `Result=success`, `NRestarts=0`. Clean skip; the unit stays enabled.
- Binary installed later → the next start request activates it normally; conditions are re-evaluated per start request.
- **Gap, stated plainly:** `Condition*` is not re-evaluated on `Restart=` auto-restarts (verified: removing the binary from under a running instance still loops). The guard prevents a loop from starting; it does not abort one already in flight — an explicit `stop` / `reset-failed` / next start request does, `daemon-reload` alone does not. Real installs have `fcitx5`, so nothing is mid-loop there; no migration is needed. The change reaches existing installs through `omarchy-settings` and takes effect at the next login.

## Verification

- `bash test/shell.d/systemd-test.sh` — all `ok`, including the new assertion.
- `test/all` before and after on the same guest — no new failures (counts below).
- **On the affected guest** (stock unit, no drop-in, binary absent), a script that unmasks the unit, reproduces the loop, then loads the patched file as a whole-file user override and re-checks:

```
ok - preconditions: binary absent, patched unit present, unit masked
Removed '/home/dant/.config/systemd/user/omarchy-fcitx5.service'.
# stock after 30s: NRestarts=13 ActiveState=activating
# journal lines for the unit after C1: 83
ok - stock unit restart-loops on 203/EXEC (NRestarts=13 in 30s)
# patched after 30s: ConditionResult=no ActiveState=inactive Result=success NRestarts=0 DropInPaths='' FragmentPath=/home/dant/.config/systemd/user/omarchy-fcitx5.service
# journal lines for the unit after C2 (condition-skip notice expected): 1
#   Fcitx5 input method (XCompose sequences) skipped, unmet condition check ConditionPathExists=/usr/bin/fcitx5
ok - patched unit skips cleanly with no drop-in (ConditionResult=no, inactive, success, NRestarts=0)
# final: UnitFileState=masked NRestarts=0
ok - unit left masked with NRestarts=0
```

`test/all` before/after:

```
baseline (quattro 31bd80da, untouched):  7 of 236 test files failed
patched:                                  6 of 236 test files failed
new failures introduced by this change:   0

Pre-existing failures on this guest (both runs): config-test, locate-test,
runtime-smoke-test, screenshot-sanity-test, snapper-test,
unowned-system-paths-test -- missing omarchy-pkgs checkout, no updatedb, and
runtime/screenshot smoke tests that need a compositor the guest lacks.
bar-widget-contract-test failed once, in the baseline only (flaky).
systemd-test.sh: ok in both runs, including the new assertion.
Run on a local copy of the tree; the working tree lives on a 9p share
where test/cli is too slow to finish.
```

## Related

- #7461 / #7474 — same unit, same symptom, **different cause**: a second fcitx5 (user autostart entry or D-Bus activation) owns the bus name, fcitx5 exits 0, `Restart=always` loops. #7474 hides stray autostart entries and does not touch the unit. The `Restart=on-failure` suggested there would not cover `203/EXEC` (a failure still restarts), and the existing test forbids it for the bus-name case. Complementary, not overlapping.
- #6992 — same class, different unit: `bt-agent.service` enabled while `bluez-tools` was removed → `203/EXEC` loop on a real Quattro upgrade. `bt-agent` still has no guard on `/usr/bin/bt-agent`.
- omacom/try-omarchy#91 → omacom/try-omarchy#106 — the downstream drop-in for this exact unit (`ConditionPathExists=/usr/bin/fcitx5`), merged 2026-09-04. This PR moves the guard into the unit that needs it.

## Environment

```
Omarchy        4.0.0.alpha on the guest; unit byte-identical to quattro 31bd80da and to v4.0.3
Guest          Try Omarchy v0.3.0 (try-omarchy-runtime 4.0.2-1), QEMU/aarch64 on a Mac host, Arch Linux ARM
systemd        261 (261.2-1-arch)
fcitx5         not installed
```

*Investigated and drafted by Claude via Claude Code.*
