### PR TITLE
Require session token for notification exec argv

### DIFF
--- a/bin/omarchy-notification-send
+++ b/bin/omarchy-notification-send
@@ -176,6 +176,17 @@ if ((exec_present)); then
   # NUL-delimit into jq so every byte survives as data: jq's own --args would eat
   # a bare "--", and a newline in an arg must not split the vector.
   exec_argv_json=$(printf '%s\0' "${exec_args[@]}" | jq -Rsc 'split("\u0000")[:-1]')
+  token_file="${XDG_RUNTIME_DIR:-}/omarchy/notification-exec-token"
+  if [[ -z ${XDG_RUNTIME_DIR:-} || ! -r $token_file ]]; then
+    echo "omarchy-notification-send: --exec needs a live session token at \$XDG_RUNTIME_DIR/omarchy/notification-exec-token" >&2
+    exit 1
+  fi
+  exec_token=$(tr -d '\n' <"$token_file")
+  if [[ -z $exec_token ]]; then
+    echo "omarchy-notification-send: notification exec token is empty" >&2
+    exit 1
+  fi
+  hints+=(omarchy-exec-token s "$exec_token")
   hints+=(omarchy-exec-argv s "$exec_argv_json")
 fi
 

--- a/shell/plugins/notifications/NotificationLogic.js
+++ b/shell/plugins/notifications/NotificationLogic.js
@@ -146,17 +146,21 @@ function glyphFromHints(hints) {
 // clickable (a libnotify action can't — its sender is gone). Run via
 // Util.execArgv as bash positional parameters, never a shell string, so
 // attacker-controlled values (a title, a filename) can't become commands.
-function execArgvFromHints(hints) {
-  return stringHint(hints, "omarchy-exec-argv")
+function execArgvFromHints(hints, sessionToken) {
+  var argv = stringHint(hints, "omarchy-exec-argv")
+  if (!argv) return ""
+  var token = stringHint(hints, "omarchy-exec-token")
+  if (!sessionToken || !token || token !== String(sessionToken)) return ""
+  return argv
 }
 
 // Validate a persisted omarchy-exec-argv into a runnable argv, or null. This is
 // a STRUCTURAL check only: it fails closed on a malformed hint (non-array, a
 // non-string or empty program, or a leading-dash program that argv would read as
 // an option). It does not judge intent — a well-formed ["bash","-c",…] is
-// accepted. WHICH senders may set this hint is a separate boundary: any
-// session-bus process can, by the freedesktop protocol's design (see
-// docs/notifications.md), which is equivalent to same-uid code execution.
+// accepted. WHICH senders may set a runnable click argv is gated by a per-session
+// token (omarchy-exec-token) that only host processes can read from
+// $XDG_RUNTIME_DIR (see docs/notifications.md / issue #8433).
 function parseExecArgv(value) {
   var text = String(value || "")
   if (!text) return null
@@ -180,7 +184,7 @@ function shouldRenderCompactGlyph(glyph, iconSource, singleLineToast) {
   return String(glyph || "").length > 0 && String(iconSource || "").length === 0 && !!singleLineToast
 }
 
-function snapshotOf(notification, timestamp) {
+function snapshotOf(notification, timestamp, sessionToken) {
   var n = notification || {}
   var id = n.id || 0
   var expireTimeout = Number(n.expireTimeout || 0)
@@ -194,7 +198,7 @@ function snapshotOf(notification, timestamp) {
     body: n.body || "",
     image: n.image || "",
     glyph: glyphFromHints(n.hints),
-    execArgv: execArgvFromHints(n.hints),
+    execArgv: execArgvFromHints(n.hints, sessionToken),
     urgency: n.urgency,
     expireTimeout: expireTimeout,
     timestamp: timestamp === undefined ? Date.now() : timestamp

--- a/shell/plugins/notifications/Service.qml
+++ b/shell/plugins/notifications/Service.qml
@@ -16,6 +16,7 @@ Item {
 
   // Injected by omarchy-shell (the first-party service loader).
   property var shell: null
+  property string execSessionToken: ""
 
   property string omarchyPath: Quickshell.env("OMARCHY_PATH")
   readonly property string home: Quickshell.env("HOME")
@@ -132,7 +133,7 @@ Item {
   }
 
   function snapshotOf(notification) {
-    return NotificationLogic.snapshotOf(notification, Date.now())
+    return NotificationLogic.snapshotOf(notification, Date.now(), service.execSessionToken)
   }
 
   // A notification nobody looks back at:
@@ -408,6 +409,29 @@ Item {
   }
 
   Process { id: focusAppProc; running: false }
+
+  
+  Process {
+    id: writeExecTokenProc
+    running: false
+    command: ["bash", "-c",
+      'runtime="${XDG_RUNTIME_DIR:-}"; ' +
+      '[[ -n $runtime ]] || exit 1; ' +
+      'mkdir -m 700 -p "$runtime/omarchy"; ' +
+      'token=$(openssl rand -hex 32); ' +
+      'umask 077; printf "%s\n" "$token" >"$runtime/omarchy/notification-exec-token"; ' +
+      'chmod 600 "$runtime/omarchy/notification-exec-token"; ' +
+      'printf "%s" "$token"'
+    ]
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: {
+        var tok = text.trim()
+        if (tok.length > 0)
+          service.execSessionToken = tok
+      }
+    }
+  }
 
   Process {
     id: ensureDirsProc
@@ -834,6 +858,7 @@ Item {
 
   Component.onCompleted: {
     ensureDirsProc.running = true
+    writeExecTokenProc.running = true
     // Once mkdir has had a tick, load the existing settings file. FileView
     // surfaces an empty string when the file doesn't exist; loadSettings
     // handles that path.

--- a/test/shell.d/notification-send-test.sh
+++ b/test/shell.d/notification-send-test.sh
@@ -6,6 +6,11 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
 tmpdir=$(mktemp -d)
 trap 'rm -rf "$tmpdir"' EXIT
+runtime_dir="$tmpdir/runtime"
+mkdir -m 700 -p "$runtime_dir/omarchy"
+printf 'test-session-token\n' >"$runtime_dir/omarchy/notification-exec-token"
+chmod 600 "$runtime_dir/omarchy/notification-exec-token"
+export XDG_RUNTIME_DIR="$runtime_dir"
 
 args_file="$tmpdir/args"
 
@@ -197,3 +202,17 @@ send "Timed" -t 3000 >/dev/null
 load
 [[ ${args[12]} == "" && ${args[-1]} == "3000" ]] || fail "notification wrapper still parses a flag after the headline" "body=${args[12]} timeout=${args[-1]}"
 pass "notification wrapper still treats a known flag after the headline as an option"
+
+: >"$args_file"
+send "With exec" --exec true >/dev/null
+load
+[[ $(hint_value omarchy-exec-token) == "test-session-token" ]] || fail "send attaches session exec token" "$(hint_value omarchy-exec-token)"
+pass "send attaches omarchy-exec-token for --exec"
+
+chmod 000 "$runtime_dir/omarchy/notification-exec-token" || true
+if send "No token" --exec true >/dev/null 2>"$tmpdir/no-token.err"; then
+  fail "send must fail --exec when token unreadable"
+fi
+grep -qi token "$tmpdir/no-token.err" || fail "send error should mention token"
+chmod 600 "$runtime_dir/omarchy/notification-exec-token"
+pass "send fails closed when exec token is unreadable"

--- a/test/shell.d/notifications-test.sh
+++ b/test/shell.d/notifications-test.sh
@@ -218,13 +218,47 @@ const execSnapshot = notifications.snapshotOf({
   id: 3,
   appName: 'omarchy-action',
   summary: 'Download complete',
-  hints: { 'omarchy-exec-argv': '["mpv","--","/tmp/clip.mp4"]' }
-}, 1)
+  hints: {
+    'omarchy-exec-argv': '["mpv","--","/tmp/clip.mp4"]',
+    'omarchy-exec-token': 'sess'
+  }
+}, 1, 'sess')
 assertEqual(
   execSnapshot.execArgv,
   '["mpv","--","/tmp/clip.mp4"]',
-  'notifications carry the exec argv hint onto the snapshot'
+  'notifications carry the exec argv hint onto the snapshot when the session token matches'
 )
+
+assertEqual(
+  notifications.execArgvFromHints({ 'omarchy-exec-argv': '["true"]' }, 'sess'),
+  '',
+  'notifications drop exec argv without a session token hint'
+)
+assertEqual(
+  notifications.execArgvFromHints({
+    'omarchy-exec-argv': '["true"]',
+    'omarchy-exec-token': 'nope'
+  }, 'sess'),
+  '',
+  'notifications drop exec argv when the session token mismatches'
+)
+assertEqual(
+  notifications.execArgvFromHints({
+    'omarchy-exec-argv': '["true"]',
+    'omarchy-exec-token': 'sess'
+  }, 'sess'),
+  '["true"]',
+  'notifications keep exec argv when the session token matches'
+)
+assertEqual(
+  notifications.snapshotOf({
+    id: 9,
+    hints: { 'omarchy-exec-argv': '["true"]', 'omarchy-exec-token': 'x' }
+  }, 1, 'sess').execArgv,
+  '',
+  'notifications snapshot clears exec argv without a matching session token'
+)
+
 
 assertDeepEqual(
   notifications.popupPlacement('top', 32, 6),


### PR DESCRIPTION
Notifications service writes a per-session token under $XDG_RUNTIME_DIR/omarchy/. --exec attaches omarchy-exec-token; missing or mismatched tokens drop exec argv so sandboxed bus clients cannot get click-to-exec.

Fixes #8433