### PR TITLE
Strip CAP_DAC_READ_SEARCH from btop

### DIFF
--- a/bin/omarchy-strip-btop-caps
+++ b/bin/omarchy-strip-btop-caps
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# omarchy:summary=Strip file capabilities from btop
+# omarchy:hidden=true
+
+set -euo pipefail
+
+if [[ -x /usr/bin/btop ]] && command -v setcap >/dev/null 2>&1; then
+  setcap -r /usr/bin/btop || true
+fi

--- a/default/libalpm/hooks/90-omarchy-strip-btop-caps.hook
+++ b/default/libalpm/hooks/90-omarchy-strip-btop-caps.hook
@@ -1,0 +1,11 @@
+[Trigger]
+Operation = Install
+Operation = Upgrade
+Type = Package
+Target = btop
+
+[Action]
+Description = Stripping file capabilities from btop...
+When = PostTransaction
+Depends = omarchy
+Exec = /usr/bin/omarchy-strip-btop-caps

--- a/migrations/1789231548.sh
+++ b/migrations/1789231548.sh
@@ -1,0 +1,24 @@
+echo "Strip file capabilities from btop"
+
+if [[ -x /usr/bin/btop ]] && command -v setcap >/dev/null 2>&1; then
+  if getcap /usr/bin/btop 2>/dev/null | grep -q .; then
+    sudo setcap -r /usr/bin/btop
+  fi
+fi
+
+hook=/etc/pacman.d/hooks/90-omarchy-strip-btop-caps.hook
+if [[ ! -f $hook ]]; then
+  sudo mkdir -p /etc/pacman.d/hooks
+  sudo install -Dm644 /dev/stdin "$hook" <<'HOOK'
+[Trigger]
+Operation = Install
+Operation = Upgrade
+Type = Package
+Target = btop
+
+[Action]
+Description = Stripping file capabilities from btop...
+When = PostTransaction
+Exec = /usr/bin/omarchy-strip-btop-caps
+HOOK
+fi

--- a/test/shell.d/config-test.sh
+++ b/test/shell.d/config-test.sh
@@ -428,3 +428,9 @@ if grep -RIl 'upgrade-to-quattro\|Omarchy 4\.0 is upgraded' "$ROOT/migrations" >
   fail "4.0 upgrade is not modeled as a migration"
 fi
 pass "4.0 upgrade is handled outside the migration runner"
+
+[[ -f $ROOT/default/libalpm/hooks/90-omarchy-strip-btop-caps.hook ]] || fail "missing btop cap-strip pacman hook"
+[[ -x $ROOT/bin/omarchy-strip-btop-caps ]] || fail "missing omarchy-strip-btop-caps"
+grep -Fq 'Exec = /usr/bin/omarchy-strip-btop-caps' "$ROOT/default/libalpm/hooks/90-omarchy-strip-btop-caps.hook" ||
+  fail "btop cap-strip hook must call omarchy-strip-btop-caps"
+pass "btop capability strip hook and command are present"


### PR DESCRIPTION
Adds omarchy-strip-btop-caps, an in-tree pacman hook, and a migration that strips btop now and installs an /etc/pacman.d/hooks drop-in so upgrades stay stripped. omarchy-pkgs still needs the one-line hook install to package the hook.

Fixes #8249