### PR TITLE
Bind sshd to localhost; skip opening ufw 22 by default

### DIFF
--- a/bin/omarchy-setup-security-sshd
+++ b/bin/omarchy-setup-security-sshd
@@ -37,7 +37,7 @@ while (( $# > 0 )); do
   -h | --help)
     echo "Usage: omarchy-setup-security-sshd [--key=<public-key>] [--gh-keys <github-username>]"
     echo
-    echo "Sets up the OpenSSH server, opens the SSH port in the UFW firewall,"
+    echo "Sets up the OpenSSH server, binds sshd to localhost by default (not world-reachable),"
     echo "and authorizes an SSH key (from GitHub, pasted, or passed via --key)."
     echo
     echo "Passing --key or --gh-keys skips the prompts, so the command can run"
@@ -57,6 +57,30 @@ if [[ -n $KEY && -n $GITHUB_USER ]]; then
   exit 2
 fi
 
+
+bind_localhost() {
+  local config=/etc/ssh/sshd_config.d/20-omarchy-localhost.conf
+
+  echo "Binding sshd to localhost only..."
+  sudo install -Dm644 /dev/stdin "$config" <<'CONF'
+# Written by omarchy-setup-security-sshd. Loopback only by default.
+# To expose SSH remotely:
+#   1. remove this file (or comment the ListenAddress lines)
+#   2. sudo ufw limit 22/tcp comment "omarchy-sshd" && sudo ufw reload
+#   3. sudo systemctl reload sshd
+ListenAddress 127.0.0.1
+ListenAddress ::1
+CONF
+
+  if ! sudo sshd -t; then
+    echo -e "\e[31msshd rejected the localhost bind config; removing it.\e[0m" >&2
+    sudo rm -f "$config"
+    return 0
+  fi
+
+  sudo systemctl reload sshd.service || true
+}
+
 setup_sshd() {
   echo "Installing and starting the OpenSSH server..."
   omarchy-pkg-add openssh
@@ -64,14 +88,12 @@ setup_sshd() {
 }
 
 open_firewall() {
+  # Default is localhost-only (bind_localhost). Do not open port 22 publicly.
   if omarchy-cmd-missing ufw; then
-    echo "UFW is not installed; skipping firewall rule."
     return
   fi
-
-  echo "Opening the SSH port in the firewall (rate limited against brute force)..."
-  sudo ufw limit 22/tcp comment "omarchy-sshd" >/dev/null
-  sudo ufw reload >/dev/null
+  echo "SSH firewall port left closed (localhost bind only)."
+  echo "Remote: clear ListenAddress drop-in, then: sudo ufw limit 22/tcp comment \"omarchy-sshd\""
 }
 
 valid_key() {
@@ -190,6 +212,7 @@ CONF
 echo -e "\e[32mSetting up SSH server access with key-based authentication.\n\e[0m"
 
 setup_sshd
+bind_localhost
 open_firewall
 
 echo

--- a/test/shell.d/setup-security-sshd-test.sh
+++ b/test/shell.d/setup-security-sshd-test.sh
@@ -115,3 +115,12 @@ fi
 ! grep -q "Password logins are off" "$test_dir/invalid.output" ||
   fail "SSH setup must not claim rejected hardening succeeded"
 pass "SSH setup fails safely when sshd rejects the config"
+
+localhost_cfg="$test_dir/success/root/etc/ssh/sshd_config.d/20-omarchy-localhost.conf"
+[[ -f $localhost_cfg ]] || fail "SSH setup should write localhost ListenAddress drop-in"
+grep -qxF "ListenAddress 127.0.0.1" "$localhost_cfg" || fail "missing ListenAddress 127.0.0.1"
+grep -qxF "ListenAddress ::1" "$localhost_cfg" || fail "missing ListenAddress ::1"
+! grep -E '^[[:space:]]*sudo ufw limit 22' "$ROOT/bin/omarchy-setup-security-sshd" ||
+  fail "sshd setup must not open ufw 22 by default"
+pass "sshd setup binds localhost and leaves ufw 22 closed"
+


### PR DESCRIPTION
setup-security-sshd writes ListenAddress 127.0.0.1/::1 and no longer opens ufw 22 unless the admin opts in. Documents how to expose SSH remotely. Does not duplicate authorize-before-start work in #8365.

Fixes #8248