### PR TITLE
Make /boot not world-accessible

### DIFF
--- a/install/post-install/all.sh
+++ b/install/post-install/all.sh
@@ -1,3 +1,5 @@
 run_logged "$OMARCHY_INSTALL/post-install/pacman.sh"
 run_logged "$OMARCHY_INSTALL/post-install/udev.sh"
 run_logged "$OMARCHY_INSTALL/post-install/localdb.sh"
+
+run_logged "$OMARCHY_INSTALL/post-install/boot-permissions.sh"

--- a/install/post-install/boot-permissions.sh
+++ b/install/post-install/boot-permissions.sh
@@ -1,0 +1,3 @@
+# Restrict /boot for bootctl (world-accessible mount / random-seed warnings).
+[[ -d /boot ]] && chmod 0700 /boot || true
+[[ -e /boot/loader/random-seed ]] && chmod 0600 /boot/loader/random-seed || true

--- a/migrations/1789231611.sh
+++ b/migrations/1789231611.sh
@@ -1,0 +1,26 @@
+echo "Restrict /boot so it is not world-accessible"
+
+if [[ -d /boot ]]; then
+  sudo chmod 0700 /boot || true
+fi
+
+if [[ -e /boot/loader/random-seed ]]; then
+  sudo chmod 0600 /boot/loader/random-seed || true
+fi
+
+if [[ -f /etc/fstab ]] && grep -Eq '[[:space:]]/boot[[:space:]]+vfat[[:space:]]' /etc/fstab; then
+  if ! grep -Eq '[[:space:]]/boot[[:space:]]+vfat[[:space:]][^[:space:]]*(fmask|dmask)' /etc/fstab; then
+    tmp=$(mktemp)
+    sudo cp /etc/fstab /etc/fstab.omarchy-boot-perms.bak
+    awk '
+      $2 == "/boot" && $3 == "vfat" && $4 !~ /fmask=/ {
+        if ($4 == "defaults") $4 = "defaults,fmask=0077,dmask=0077"
+        else $4 = $4 ",fmask=0077,dmask=0077"
+      }
+      { print }
+    ' /etc/fstab >"$tmp"
+    sudo install -Dm644 "$tmp" /etc/fstab
+    rm -f "$tmp"
+    echo "Updated /boot vfat fstab options (backup: /etc/fstab.omarchy-boot-perms.bak)"
+  fi
+fi


### PR DESCRIPTION
Migration (+ install post-step) sets /boot to 0700, loader/random-seed to 0600, and tightens vfat fmask/dmask in fstab when needed so bootctl stops warning about a world-accessible ESP.

Fixes #5377