### PR TITLE
Ignore USB Touch Bar DRM when detecting external displays

### DIFF
--- a/bin/omarchy-hw-external-monitors
+++ b/bin/omarchy-hw-external-monitors
@@ -6,7 +6,8 @@ drm_path="${OMARCHY_DRM_PATH:-/sys/class/drm}"
 
 for status in "$drm_path"/card*-*/status; do
   [[ -e $status ]] || continue
-  [[ $status =~ -(eDP|LVDS|DSI)-[^/]+/status$ ]] && continue
+  # Internal laptop panels. USB is the T1/iBridge Touch Bar DRM connector, not a desktop head.
+  [[ $status =~ -(eDP|LVDS|DSI|USB)-[^/]+/status$ ]] && continue
   [[ $(< $status) == "connected" ]] && exit 0
 done
 exit 1

--- a/test/shell.d/hw-external-monitors-test.sh
+++ b/test/shell.d/hw-external-monitors-test.sh
@@ -59,3 +59,34 @@ pass "physical monitor detection ignores disconnected external displays"
 write_connectors DP-1 connected
 has_external_monitor || fail "external-only systems still report a connected display"
 pass "physical monitor detection still supports external-only systems"
+
+write_connectors USB-1 connected
+if has_external_monitor; then
+  fail "a Touch Bar USB DRM connector is not an external display"
+fi
+pass "physical monitor detection ignores a USB Touch Bar connector"
+
+write_named_connectors() {
+  rm -rf "$drm_path"
+  mkdir -p "$drm_path"
+
+  while (( $# )); do
+    mkdir -p "$drm_path/$1"
+    printf '%s\n' "$2" >"$drm_path/$1/status"
+    shift 2
+  done
+}
+
+write_named_connectors card1-eDP-1 connected card0-USB-1 connected
+if has_external_monitor; then
+  fail "a Touch Bar on a second DRM card is not an external display"
+fi
+pass "physical monitor detection ignores a USB Touch Bar alongside an internal panel"
+
+write_named_connectors card1-eDP-1 connected card0-USB-1 connected card1-DP-1 connected
+has_external_monitor || fail "a real DP display still counts when a Touch Bar is present"
+pass "physical monitor detection still finds DP when a Touch Bar is present"
+
+write_named_connectors card1-eDP-1 connected card0-USB-1 disconnected card1-HDMI-A-1 connected
+has_external_monitor || fail "HDMI still counts when the Touch Bar is disconnected"
+pass "physical monitor detection still finds HDMI when a Touch Bar is disconnected"


### PR DESCRIPTION
## Summary

`omarchy-hw-external-monitors` walks `/sys/class/drm/card*-*/status` and treats every connected connector that is not `eDP`/`LVDS`/`DSI` as a desktop display.

On a T1 MacBook the Touch Bar is a real DRM device (`card0-USB-1`, always `connected`, `ID_SEAT=seat-touchbar`). Hyprland does not list it as a monitor. The helper still returned true with **no HDMI/DP attached**, so:

- `omarchy-system-lid-close` skipped the lock (`lid closed && ! external`)
- `omarchy-hw-clamshell` was true whenever the lid was shut
- logind never took the undocked suspend path (`HandleLidSwitchDocked=ignore`)

Reproduced on MacBookPro14,2 (Omarchy 4.0.3, T1Bridge Touch Bar). With a local override of this helper, undocked lid-close locks immediately. A real DP/HDMI dock still counts.

This does **not** change lid-open bindings or suspend/resume backlight. A long lid-close that actually reaches S3 can still take a while to light the panel; that is separate.

## Test plan

- [x] `bash test/shell.d/hw-external-monitors-test.sh` (existing cases plus USB-1 alone, split-card eDP+USB, DP still found with Touch Bar, HDMI still found)
- [x] `bash test/shell.d/lid-close-test.sh`
- [x] Live undocked lid-close on MacBookPro14,2: lock starts as soon as the lid shuts
- [ ] Reviewer: USB-C DP-alt / DisplayLink still show up as `DP-*` / `HDMI-*` / `DVI-*`, not `USB-*`
