### PR TITLE
fix(capture): add icon to screenshot notification (#11506)

### DIFF
--- a/bin/omarchy-capture-screenshot
+++ b/bin/omarchy-capture-screenshot
@@ -68,7 +68,7 @@ case "$PROCESSING" in
 
     # Best-effort: the screenshot is already saved and on the clipboard, so a
     # notification outage must not report the capture itself as failed.
-    omarchy-notification-send "Screenshot saved to clipboard and file" "Edit with Super + Alt + , (or click this)" \
+    omarchy-notification-send -i camera-photo "Screenshot saved to clipboard and file" "Edit with Super + Alt + , (or click this)" \
       --image "$FILEPATH" \
       --exec "$SCREENSHOT_EDITOR" "$FILEPATH" || true
     ;;


### PR DESCRIPTION
Fixes #11506

Screenshot notification used no `-i/--icon` so the daemon showed the generic missing-icon glyph (four purple/black squares). Pass `-i camera-photo` (freedesktop standard) so the toast shows a meaningful camera icon.

- `bin/omarchy-capture-screenshot:71` — add `-i camera-photo` before headline
- `--image` already carries the preview, `app_icon` is separate

Test: `bash -n bin/omarchy-capture-screenshot` ok, screenshot still saves/copies, notification shows icon.