### PR TITLE
fix(nightlight): detach hyprsunset stdio to prevent wrapper hang (#11457)

### DIFF
--- a/bin/omarchy-toggle-nightlight
+++ b/bin/omarchy-toggle-nightlight
@@ -36,7 +36,7 @@ fi
 
 # Ensure hyprsunset is running
 if ! pgrep -x hyprsunset >/dev/null; then
-  setsid uwsm-app -- hyprsunset &
+  setsid uwsm-app -- hyprsunset >/dev/null 2>&1 &
 fi
 
 # Query the current temperature


### PR DESCRIPTION
Fixes #11457

Starting `hyprsunset` via `setsid uwsm-app -- hyprsunset &` leaves it holding the invoker's stdout/stderr. Any wrapper that captures output (e.g. OmaSettings via `head -c 4MB`) blocks forever on the pipe because the long-lived daemon keeps the fd open — stalling subsequent settings changes (theme picks swallowed).

- `bin/omarchy-toggle-nightlight:39` — redirect `>/dev/null 2>&1` before `&`

Test: `bash -n` ok, `omarchy-toggle-nightlight | head -c 4194304` now returns, `hyprsunset` fd 2 no longer shares pipe inode.