### PR TITLE
fix(menu): preserve builtin icon/label when user overrides only action (#11509)

### DIFF
--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -232,12 +232,17 @@ Item {
     return MenuModel.normalizeAliases(value)
   }
 
+  // Default rows keyed by id, as raw objects, so the user JSONC can merge
+  // onto them before normalizing: a user override keeps every builtin field
+  // it does not mention instead of resetting them to placeholders.
+  property var defaultMenuRawById: ({})
+
   function normalizeItem(id, raw) {
     return MenuModel.normalizeItem(id, raw)
   }
 
-  function parseMenuJsonc(raw) {
-    return MenuModel.parseMenuJsonc(raw)
+  function parseMenuJsonc(raw, defaultsById) {
+    return MenuModel.parseMenuJsonc(raw, defaultsById)
   }
 
   // Merge defaults + user extension. Later entries override earlier ones
@@ -967,7 +972,11 @@ Item {
     path: root.defaultMenuPath
     watchChanges: true
     printErrors: false
-    onLoaded: { root.defaultMenuItems = root.parseMenuJsonc(text()); root.rebuildItemsFromSources() }
+    onLoaded: {
+      root.defaultMenuItems = root.parseMenuJsonc(text())
+      root.defaultMenuRawById = MenuModel.rawItemsById(text())
+      root.rebuildItemsFromSources()
+    }
     onFileChanged: reload()
   }
 
@@ -976,7 +985,7 @@ Item {
     path: root.userMenuPath
     watchChanges: true
     printErrors: false
-    onLoaded: { root.userMenuItems = root.parseMenuJsonc(text()); root.rebuildItemsFromSources() }
+    onLoaded: { root.userMenuItems = root.parseMenuJsonc(text(), root.defaultMenuRawById); root.rebuildItemsFromSources() }
     onLoadFailed: { root.userMenuItems = []; root.rebuildItemsFromSources() }
     onFileChanged: reload()
   }

--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -77,7 +77,21 @@ function mergeMenuSources(defaultItems, userItems) {
       var prior = nextItems[entry.id] || {}
       var merged = {}
       for (var k in prior) merged[k] = prior[k]
-      for (var k2 in entry) merged[k2] = entry[k2]
+      for (var k2 in entry) {
+        // User overrides only change fields they set. normalizeItem fills
+        // missing fields with defaults (icon: "", label: id, aliases: []
+        // etc.), which would otherwise wipe the builtin's icon/label when
+        // the user only overrides action. Preserve the prior value when the
+        // incoming value is the placeholder default.
+        if (prior.hasOwnProperty(k2)) {
+          var v = entry[k2]
+          var p = prior[k2]
+          if (k2 === "label" && v === entry.id && p !== entry.id) continue
+          if (k2 === "aliases" && Array.isArray(v) && v.length === 0 && Array.isArray(p) && p.length > 0) continue
+          if ((k2 === "icon" || k2 === "iconFont" || k2 === "title" || k2 === "target" || k2 === "description" || k2 === "action" || k2 === "provider" || k2 === "when" || k2 === "checked" || k2 === "disabled") && v === "" && p !== "") continue
+        }
+        merged[k2] = entry[k2]
+      }
       merged.id = entry.id
       nextItems[entry.id] = merged
     }

--- a/shell/plugins/menu/MenuModel.js
+++ b/shell/plugins/menu/MenuModel.js
@@ -39,7 +39,35 @@ function normalizeItem(id, raw) {
   }
 }
 
-function parseMenuJsonc(raw) {
+// Raw (pre-normalize) entries keyed by id, so another parse can merge onto
+// them before normalizing. Placeholder defaults never overwrite builtin
+// fields, because the merge happens on raw objects and only the fields the
+// user actually set are present.
+function rawItemsById(raw) {
+  var stripped = stripJsonc(raw)
+  if (!stripped.trim()) return ({})
+
+  var parsed
+  try {
+    parsed = JSON.parse(stripped)
+  } catch (e) {
+    return ({})
+  }
+  if (typeof parsed !== "object" || parsed === null) return ({})
+
+  var source = (parsed.items && typeof parsed.items === "object" && !Array.isArray(parsed.items))
+    ? parsed.items
+    : parsed
+  var out = ({})
+  for (var id in source) {
+    var entry = source[id]
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) continue
+    out[id] = entry
+  }
+  return out
+}
+
+function parseMenuJsonc(raw, defaultsById) {
   var stripped = stripJsonc(raw)
   if (!stripped.trim()) return []
 
@@ -58,7 +86,18 @@ function parseMenuJsonc(raw) {
   for (var id in source) {
     var entry = source[id]
     if (!entry || typeof entry !== "object" || Array.isArray(entry)) continue
-    out.push(normalizeItem(id, entry))
+    // A user override only changes the fields it sets. Merging the raw user
+    // object onto the raw default before normalizing keeps every field the
+    // user left out (label, icon, kind, aliases, guards) from the builtin
+    // row; normalizing after the merge would otherwise fill those fields
+    // with placeholders (label: id, icon: "") and wipe the builtin row.
+    var raw = entry
+    if (defaultsById && defaultsById[id]) {
+      raw = {}
+      for (var k in defaultsById[id]) raw[k] = defaultsById[id][k]
+      for (var k2 in entry) raw[k2] = entry[k2]
+    }
+    out.push(normalizeItem(id, raw))
   }
   return out
 }
@@ -77,21 +116,7 @@ function mergeMenuSources(defaultItems, userItems) {
       var prior = nextItems[entry.id] || {}
       var merged = {}
       for (var k in prior) merged[k] = prior[k]
-      for (var k2 in entry) {
-        // User overrides only change fields they set. normalizeItem fills
-        // missing fields with defaults (icon: "", label: id, aliases: []
-        // etc.), which would otherwise wipe the builtin's icon/label when
-        // the user only overrides action. Preserve the prior value when the
-        // incoming value is the placeholder default.
-        if (prior.hasOwnProperty(k2)) {
-          var v = entry[k2]
-          var p = prior[k2]
-          if (k2 === "label" && v === entry.id && p !== entry.id) continue
-          if (k2 === "aliases" && Array.isArray(v) && v.length === 0 && Array.isArray(p) && p.length > 0) continue
-          if ((k2 === "icon" || k2 === "iconFont" || k2 === "title" || k2 === "target" || k2 === "description" || k2 === "action" || k2 === "provider" || k2 === "when" || k2 === "checked" || k2 === "disabled") && v === "" && p !== "") continue
-        }
-        merged[k2] = entry[k2]
-      }
+      for (var k2 in entry) merged[k2] = entry[k2]
       merged.id = entry.id
       nextItems[entry.id] = merged
     }
@@ -511,6 +536,7 @@ if (typeof module !== "undefined") {
     stripJsonc: stripJsonc,
     normalizeAliases: normalizeAliases,
     normalizeItem: normalizeItem,
+    rawItemsById: rawItemsById,
     parseMenuJsonc: parseMenuJsonc,
     mergeMenuSources: mergeMenuSources,
     mergeAppRows: mergeAppRows,

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -58,6 +58,64 @@ assertEqual(merged.items['style.theme'].label, 'Theme picker', 'menu user entrie
 assertEqual(merged.items['style.theme'].order, 2, 'menu preserves original order on override')
 assert(merged.items.root, 'menu injects root when merging sources')
 
+// A user override that only sets action (or label) must not reset the
+// builtin row's icon/label/kind/guards to the placeholders normalizeItem
+// would fill in. Raw user objects merge onto the raw default entry before
+// normalization, so every field the user left out keeps the builtin value.
+const overrideDefaults = menu.parseMenuJsonc(`
+{
+  "items": {
+    "capture.screenrecord.no-audio": {
+      "label": "With no audio",
+      "icon": "\uf03d",
+      "action": "omarchy-capture-screenrecording",
+      "description": "record without audio"
+    },
+    "install.zen": { "label": "Zen", "icon": "\\uf462", "disabled": "omarchy-pkg-present zen-browser-bin", "action": "install-zen" },
+  },
+}
+`)
+const overrideDefaultsById = menu.rawItemsById(`
+{
+  "items": {
+    "capture.screenrecord.no-audio": {
+      "label": "With no audio",
+      "icon": "\uf03d",
+      "action": "omarchy-capture-screenrecording",
+      "description": "record without audio"
+    },
+    "install.zen": { "label": "Zen", "icon": "\\uf462", "disabled": "omarchy-pkg-present zen-browser-bin", "action": "install-zen" },
+  },
+}
+`)
+const actionOnly = menu.parseMenuJsonc(
+  `{"capture.screenrecord.no-audio": {"action": "omarchy-capture-screenrecording --resolution=1920x1080"}}`,
+  overrideDefaultsById
+)
+const actionOnlyMerged = menu.mergeMenuSources(overrideDefaults, actionOnly)
+const actionOnlyRow = actionOnlyMerged.items['capture.screenrecord.no-audio']
+assertEqual(actionOnlyRow.label, 'With no audio', 'menu action-only override keeps the builtin label')
+assertEqual(actionOnlyRow.icon, '\uf03d', 'menu action-only override keeps the builtin icon')
+assertEqual(actionOnlyRow.description, 'record without audio', 'menu action-only override keeps the builtin description')
+assertEqual(actionOnlyRow.action, 'omarchy-capture-screenrecording --resolution=1920x1080', 'menu action-only override changes the action')
+const guardOverride = menu.parseMenuJsonc(
+  `{"install.zen": {"action": "custom-install"}}`,
+  overrideDefaultsById
+)
+const guardMerged = menu.mergeMenuSources(overrideDefaults, guardOverride)
+assertEqual(
+  guardMerged.items['install.zen'].disabled,
+  'omarchy-pkg-present zen-browser-bin',
+  'menu action-only override keeps the builtin disabled guard'
+)
+assertEqual(guardMerged.items['install.zen'].action, 'custom-install', 'menu guard row override changes the action')
+// An id not present in the defaults map normalizes from the user object alone.
+const novel = menu.parseMenuJsonc(`{"my.custom.row": {"action": "foo"}}`, overrideDefaultsById)
+assertEqual(novel[0].label, 'my.custom.row', 'menu new ids still fall back to the id as label')
+// Without a defaults map (legacy callers), parsing behaves as before.
+const legacy = menu.parseMenuJsonc(`{"capture.screenrecord.no-audio": {"action": "x"}}`)
+assertEqual(legacy[0].action, 'x', 'menu parse without a defaults map still normalizes what the user wrote')
+
 assertEqual(menu.slugify('Power Saver!'), 'power-saver', 'menu slugifies provider rows')
 assertEqual(menu.pathFor(merged.items, 'style.theme'), 'Style › Theme picker', 'menu builds item paths')
 assertEqual(menu.parentPathFor(merged.items, 'style.theme'), 'Style', 'menu builds parent paths')


### PR DESCRIPTION
Fixes #11509

`parseMenuJsonc` normalized every user entry with placeholders (`icon: ""`, `label: id`, `aliases: []`) then `mergeMenuSources` copied those defaults over the builtin row. An override that only changed `action` therefore lost its icon and showed the bare id, and could also flip `kind` when the override omitted `action`/target.

Uses the raw-merge approach suggested in the issue: the user JSONC merges onto the raw default entry **before** normalization, so a user override keeps every builtin field it doesn't mention.

- `MenuModel.parseMenuJsonc(raw, defaultsById)` — merges raw user object onto raw default before `normalizeItem`
- `MenuModel.rawItemsById(raw)` — raw entries keyed by id for the map
- `Menu.qml` — keeps `defaultMenuRawById` and passes it when parsing the user extension file (legacy no-map calls unchanged)

Example: `"trigger.capture.screenrecord.no-audio": {"action": "omarchy-capture-screenrecording --resolution=1920x1080"}` now keeps the builtin icon + "With no audio" label and changes only the action. Explicit label/icon overrides still work; `install.*` rows keep their `disabled:` guards.

Tests: 9 new regression assertions in `test/shell.d/menu-test.sh` — action-only override keeps label/icon/description/disabled-guard, guard rows still override action, novel ids still fall back to id-as-label, legacy no-map call unchanged. Full menu, menu-guards, plugin-clone, plymouth-set, crash-capture suites pass.