### PR TITLE
fix(capture): single-flight screen recording stop and skip empty (#11508)

### DIFF
--- a/bin/omarchy-capture-screenrecording
+++ b/bin/omarchy-capture-screenrecording
@@ -202,6 +202,14 @@ start_screenrecording() {
 }
 
 stop_screenrecording() {
+  exec 9>/tmp/omarchy-screenrecord.lock
+  if ! flock -n 9; then
+    exec 9>&-
+    return 0
+  fi
+  # Ensure lock is released on any exit path
+  trap 'exec 9>&-' RETURN
+
   pkill -SIGINT -f "^gpu-screen-recorder" # SIGINT required to save video properly
 
   # Wait a maximum of 5 seconds to finish before hard killing
@@ -218,8 +226,15 @@ stop_screenrecording() {
     pkill -9 -f "^gpu-screen-recorder"
     omarchy-notification-send -u critical -t 5000 "Screen recording error" "Recording process had to be force-killed. Video may be corrupted."
   else
-    finalize_recording
     local filename=$(cat "$RECORDING_FILE" 2>/dev/null)
+    # If another stop already consumed the recording file, don't post a duplicate toast
+    if [[ -z $filename ]]; then
+      rm -f "$RECORDING_FILE"
+      exec 9>&-
+      trap - RETURN
+      return 0
+    fi
+    finalize_recording
     echo "$filename"
     local preview="${filename%.mp4}-preview.png"
 
@@ -240,6 +255,8 @@ stop_screenrecording() {
   fi
 
   rm -f "$RECORDING_FILE"
+  exec 9>&-
+  trap - RETURN
 }
 
 toggle_screenrecording_indicator() {


### PR DESCRIPTION
Fixes #11508

Two concurrent `stop_screenrecording` calls (slow encoder drain 2-3s at 4K) both read `/tmp/omarchy-screenrecord-filename` before either removes it, posting duplicate "Screen recording saved" toasts and racing over `-preview.png" (broken thumbnail). If second starts after first removed file, it reads empty name and posts `-preview.png".

- `bin/omarchy-capture-screenrecording:204` — add `flock -n /tmp/omarchy-screenrecord.lock` at top of `stop_screenrecording` to make it single-flight (suggested `exec 9>...; flock -n 9 || return 0`)
- Check for empty filename after reading `RECORDING_FILE` and skip duplicate finalize/notification
- Ensure lock fd is closed on all exit paths

Repro: `omarchy-capture-screenrecording --fullscreen --resolution=3840x2160; sleep 5; stop & sleep 0.4; stop` no longer posts two toasts.