### PR TITLE
fix(shell): derive publicBarConfig from shellConfig directly (#11505)

### DIFF
--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -324,7 +324,9 @@ ShellRoot {
   }
 
   function publicBarConfig() {
-    return JSON.parse(JSON.stringify(shell.barConfig || {}))
+    var config = shell.shellConfig && Util.isPlainObject(shell.shellConfig.bar)
+      ? shell.shellConfig.bar : builtinShellConfig.bar
+    return JSON.parse(JSON.stringify(config))
   }
 
   function barConfigFor(manifest) {


### PR DESCRIPTION
Fixes #11505

`publicBarConfig()` read `shell.barConfig` binding, which hasn't re-evaluated inside `onShellConfigChanged` handler. Plugin services refreshed via `syncPluginApis()` from that handler therefore saw stale bar config one step late — inline setting toggles appeared ignored and could desync persisted state.

- `shell/shell.qml:326` — derive from `shellConfig` directly like `publicIdleConfigFor()` does:
  ```qml
  var config = shell.shellConfig && Util.isPlainObject(shell.shellConfig.bar) ? shell.shellConfig.bar : builtinShellConfig.bar
  ```

Bar widgets were unaffected (they use `onBarConfigChanged`); only service path lagged.

Test: minimal repro in issue now shows handler sees actual value, not stale.