### PR TITLE
fix(monitor): use eval and reload for display toggle instead of keyword (#11450)

### DIFF
--- a/shell/plugins/panels/monitor/Panel.qml
+++ b/shell/plugins/panels/monitor/Panel.qml
@@ -300,7 +300,13 @@ Panel {
     if (!name) return
     if (enabled && root.enabledDisplayCount <= 1) return
 
-    actionProc.command = ["hyprctl", "keyword", "monitor", name + (enabled ? ",disable" : ",preferred,auto,auto")]
+    if (enabled) {
+      actionProc.command = ["hyprctl", "eval", "hl.monitor({ output = \"" + name + "\", disabled = true })"]
+    } else {
+      // Re-enable by reloading config so the user's monitors.lua geometry
+      // (scale/position) is restored instead of guessing preferred,auto,auto
+      actionProc.command = ["hyprctl", "reload"]
+    }
     if (!actionProc.running) actionProc.running = true
   }
 


### PR DESCRIPTION
Fixes #11450

`toggleDisplay()` used `hyprctl keyword monitor NAME,disable` which Hyprland rejects under Omarchy's Lua parser ("keyword can't work with non-legacy parsers. Use eval.") and exits 0, so clicks silently did nothing. The re-enable arm also discarded user's configured geometry (`preferred,auto,auto` vs `scale=1.25 pos=0x0") and missed `disabled=false".

- `shell/plugins/panels/monitor/Panel.qml:303` — disable: `hyprctl eval 'hl.monitor({ output = "NAME", disabled = true })'`
- Re-enable: `hyprctl reload` to re-apply user's `monitors.lua` geometry (matches `omarchy-hyprland-monitor-internal` pattern)

Only `hyprctl keyword` left under `shell/` — now 0.

Test: external monitor row now toggles correctly, `hyprctl monitors all -j` shows `disabled` flip and scale/position restored after reload.