### PR TITLE
Enable paccache.timer to prune the pacman cache weekly

### DIFF
--- a/install/config/enable-services.sh
+++ b/install/config/enable-services.sh
@@ -16,3 +16,6 @@ systemctl enable sddm.service
 # whole session down. [Install] pulls in systemd-oomd.socket via Also=, which
 # is what the user manager reports app.slice candidacy over.
 systemctl enable systemd-oomd.service
+# Prune the pacman package cache weekly to prevent unbounded disk growth.
+# Provided by pacman-contrib, keeping the 3 most recent package versions.
+systemctl enable paccache.timer

--- a/migrations/1789156273.sh
+++ b/migrations/1789156273.sh
@@ -1,0 +1,18 @@
+echo "Prune the pacman package cache weekly to prevent unbounded disk growth"
+
+# New installs get this from install/config/enable-services.sh. Existing ones
+# retain every package version downloaded since installation in /var/cache/pacman/pkg.
+
+as_root() {
+  if (( EUID == 0 )); then
+    "$@"
+  else
+    sudo "$@"
+  fi
+}
+
+# Machine-wide, so a second user on the same box finds it already done.
+if ! systemctl is-enabled --quiet paccache.timer 2>/dev/null; then
+  as_root systemctl enable --now paccache.timer >/dev/null 2>&1 ||
+    echo "Could not enable paccache.timer; package cache will continue to grow unbounded."
+fi

--- a/test/shell.d/systemd-test.sh
+++ b/test/shell.d/systemd-test.sh
@@ -104,3 +104,7 @@ pass "systemd-oomd acts on sustained memory stall"
 grep -Fx 'systemctl enable systemd-oomd.service' "$ROOT/install/config/enable-services.sh" >/dev/null ||
   fail "new installs ship the oomd drop-ins with the daemon that reads them disabled"
 pass "new installs enable systemd-oomd"
+
+grep -Fx 'systemctl enable paccache.timer' "$ROOT/install/config/enable-services.sh" >/dev/null ||
+  fail "new installs do not enable paccache.timer"
+pass "new installs enable paccache.timer"


### PR DESCRIPTION
## Summary

Enables `paccache.timer` on new and existing Omarchy installations to clean up `/var/cache/pacman/pkg` weekly.

## Why

Arch Linux ships `paccache.timer` (provided by `pacman-contrib`, which is already in Omarchy's base package set) with `preset: disabled`.

Because `pacman` never purges cached tarballs on its own, every package update leaves previous versions in `/var/cache/pacman/pkg`. Over months of regular updates, this cache can accumulate substantial disk usage.

`paccache.timer` runs weekly in the background to discard old versions while retaining the 3 most recent package versions for rollback support.

Reference: https://man.archlinux.org/man/paccache.8

## Change

- `install/config/enable-services.sh`: Add `systemctl enable paccache.timer` for new installs.
- `migrations/1789156273.sh`: Idempotent migration to enable `paccache.timer` on existing installs.
- `test/shell.d/systemd-test.sh`: Assert that new installs enable `paccache.timer`.

## Verification

- `bash test/shell.d/systemd-test.sh` passes.
- `./test/cli` passes.
- `bash -n migrations/1789156273.sh` clean.
