### PR TITLE
Skip lid suspend for working agents and on demand

### DIFF
--- a/bin/omarchy-system-lid-guard
+++ b/bin/omarchy-system-lid-guard
@@ -1,0 +1,176 @@
+#!/bin/bash
+
+# omarchy:summary=Block lid-close suspend while agents are working
+# omarchy:group=system
+# omarchy:hidden=true
+
+# The guard owns the lid-suspend inhibitor and reconciles it from two inputs:
+# a manual one-shot skip flag (see omarchy-toggle-lid-suspend) and live agent
+# activity from herdr. A handle-lid-switch block inhibitor only suppresses
+# logind's suspend action; the Hyprland lid-switch binds still fire, so
+# omarchy-system-lid-close keeps locking and reconciling displays.
+#
+# Fail-open everywhere: herdr missing or unreadable means no working agents,
+# so lid close suspends exactly as it would without this service.
+
+set -euo pipefail
+
+FLAG="$HOME/.local/state/omarchy/toggles/lid-suspend-skip-once"
+RUNTIME_DIR="${XDG_RUNTIME_DIR:-/tmp/omarchy-$UID}/omarchy-lid-guard"
+PIDFILE="$RUNTIME_DIR/inhibit.pid"
+PREV_LID="$RUNTIME_DIR/prev-lid"
+INTERVAL=5
+SKIP_TTL=1800
+
+process_start_time() {
+  local process_pid="$1"
+  local process_stat=""
+  local stat_fields=()
+
+  [[ -r /proc/$process_pid/stat ]] || return 1
+  process_stat=$(</proc/"$process_pid"/stat)
+  process_stat="${process_stat##*) }"
+  read -r -a stat_fields <<<"$process_stat"
+  (( ${#stat_fields[@]} > 19 )) || return 1
+  printf '%s\n' "${stat_fields[19]}"
+}
+
+lid_state() {
+  local state_file=""
+  local lid_glob="${OMARCHY_LID_STATE_GLOB:-/proc/acpi/button/lid/*/state}"
+
+  # Unquoted so the glob expands; override with OMARCHY_LID_STATE_GLOB to
+  # point at a canned state file in tests.
+  for state_file in $lid_glob; do
+    [[ -f $state_file ]] || return 1
+    awk '{print $2}' "$state_file"
+    return 0
+  done
+  return 1
+}
+
+flag_set() {
+  [[ -f $FLAG ]] || return 1
+  if (( $(date +%s) - $(stat -c %Y "$FLAG") > SKIP_TTL )); then
+    rm -f "$FLAG"
+    return 1
+  fi
+}
+
+# Print space-separated names of working agents, or fail when there are none.
+# herdr is optional: missing or unreadable means fail-open, suspend as usual.
+working_agent_names() {
+  local agents_json=""
+  local names=""
+
+  omarchy-cmd-missing herdr && return 1
+  agents_json=$(timeout 10 herdr agent list 2>/dev/null) || return 1
+  names=$(echo "$agents_json" | jq -r '[.result.agents[]? | select(.agent_status == "working") | .agent] | join(" ")' 2>/dev/null) || return 1
+  [[ -n $names ]] || return 1
+  printf '%s\n' "$names"
+}
+
+recorded_inhibitor() {
+  [[ -s $PIDFILE ]] || return 1
+  cat "$PIDFILE"
+}
+
+inhibitor_alive() {
+  local recorded_pid=""
+  local recorded_start=""
+  local current_start=""
+
+  recorded_pid=$(head -n 1 "$PIDFILE" 2>/dev/null | cut -d' ' -f1) || return 1
+  recorded_start=$(head -n 1 "$PIDFILE" 2>/dev/null | cut -d' ' -f2) || return 1
+  [[ -n $recorded_pid && -n $recorded_start ]] || return 1
+  current_start=$(process_start_time "$recorded_pid") || return 1
+  [[ $current_start == "$recorded_start" ]]
+}
+
+recorded_reason() {
+  sed -n 2p "$PIDFILE" 2>/dev/null
+}
+
+start_inhibitor() {
+  local reason="$1"
+  local inhibit_pid=""
+
+  mkdir -p "$RUNTIME_DIR"
+  systemd-inhibit --what=handle-lid-switch --who="omarchy-lid-guard" \
+    --why="$reason" --mode=block sleep infinity &
+  inhibit_pid=$!
+  printf '%s %s\n%s\n' "$inhibit_pid" "$(process_start_time "$inhibit_pid")" "$reason" >"$PIDFILE"
+}
+
+stop_inhibitor() {
+  local recorded_pid=""
+
+  if inhibitor_alive; then
+    recorded_pid=$(head -n 1 "$PIDFILE" | cut -d' ' -f1)
+    kill "$recorded_pid" 2>/dev/null || true
+  fi
+  rm -f "$PIDFILE"
+}
+
+reconcile() {
+  local previous=""
+  local current=""
+  local names=""
+  local reason=""
+
+  mkdir -p "$RUNTIME_DIR"
+  previous=$(cat "$PREV_LID" 2>/dev/null || lid_state || echo unknown)
+  current=$(lid_state || echo unknown)
+  printf '%s\n' "$current" >"$PREV_LID"
+
+  # The skip covers one close: once the lid re-opens, it is consumed.
+  if [[ -f $FLAG && $previous == "closed" && $current == "open" ]]; then
+    rm -f "$FLAG"
+  fi
+
+  if flag_set; then
+    reason="manual skip of next lid suspend"
+  elif names=$(working_agent_names); then
+    reason="agents working: $names"
+  fi
+
+  if [[ -n $reason ]]; then
+    # A blocked lid close never reaches logind's suspend path, so lock here
+    # the way omarchy-system-lid-close would have around a real suspend.
+    if [[ $previous == "open" && $current == "closed" ]]; then
+      omarchy-system-lock >/dev/null 2>&1 || true
+    fi
+    if inhibitor_alive; then
+      if [[ $(recorded_reason) != "$reason" ]]; then
+        stop_inhibitor
+        start_inhibitor "$reason"
+      fi
+    else
+      start_inhibitor "$reason"
+    fi
+  else
+    stop_inhibitor
+  fi
+}
+
+cmd_daemon() {
+  trap reconcile USR1
+  trap stop_inhibitor TERM INT EXIT
+  while true; do
+    reconcile
+    sleep "$INTERVAL" || true
+  done
+}
+
+case "${1:-daemon}" in
+  daemon)
+    cmd_daemon
+    ;;
+  reconcile)
+    reconcile
+    ;;
+  *)
+    echo "Usage: omarchy-system-lid-guard [daemon|reconcile]" >&2
+    exit 1
+    ;;
+esac

--- a/bin/omarchy-system-lid-guard
+++ b/bin/omarchy-system-lid-guard
@@ -12,6 +12,9 @@
 #
 # Fail-open everywhere: herdr missing or unreadable means no working agents,
 # so lid close suspends exactly as it would without this service.
+#
+# The automatic agent guard only engages on AC power; the manual skip works
+# anywhere.
 
 set -euo pipefail
 
@@ -130,8 +133,8 @@ reconcile() {
 
   if flag_set; then
     reason="manual skip of next lid suspend"
-  elif names=$(working_agent_names); then
-    reason="agents working: $names"
+  elif names=$(working_agent_names) && omarchy-power-present >/dev/null 2>&1; then
+    reason="agents working on AC: $names"
   fi
 
   if [[ -n $reason ]]; then

--- a/bin/omarchy-toggle-lid-suspend
+++ b/bin/omarchy-toggle-lid-suspend
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# omarchy:summary=Skip suspend on the next lid close
+# omarchy:args=[skip-once|toggle|allow|status]
+# omarchy:examples=omarchy toggle lid-suspend skip-once | omarchy toggle lid-suspend status
+
+set -euo pipefail
+
+FLAG="$HOME/.local/state/omarchy/toggles/lid-suspend-skip-once"
+SERVICE="omarchy-lid-guard.service"
+SKIP_TTL=1800
+
+flag_set() {
+  [[ -f $FLAG ]] || return 1
+  (( $(date +%s) - $(stat -c %Y "$FLAG") <= SKIP_TTL ))
+}
+
+poke_guard() {
+  # The guard daemon owns the inhibitor; wake it so the flag takes effect
+  # immediately instead of on its next poll. If it is not running, start it.
+  systemctl --user kill -s USR1 "$SERVICE" 2>/dev/null ||
+    systemctl --user start "$SERVICE" 2>/dev/null ||
+    echo "lid-guard service is not available; the skip is recorded but nothing is watching" >&2
+}
+
+cmd_skip_once() {
+  mkdir -p "$(dirname "$FLAG")"
+  date -u +%s >"$FLAG"
+  poke_guard
+  omarchy-notification-send -g 󰒲 "Lid suspend skipped" "Next lid close locks without suspending"
+}
+
+cmd_allow() {
+  rm -f "$FLAG"
+  poke_guard
+  omarchy-notification-send -g 󰒲 "Lid suspend restored" "Next lid close suspends again"
+}
+
+cmd_status() {
+  if flag_set; then
+    echo "skip armed: next lid close locks without suspending"
+  else
+    rm -f "$FLAG"
+    echo "no skip armed: lid close suspends normally"
+  fi
+  if systemctl --user is-active --quiet "$SERVICE" 2>/dev/null; then
+    echo "guard service: active"
+  else
+    echo "guard service: inactive"
+  fi
+  systemd-inhibit --list 2>/dev/null | grep "lid-guard" || echo "no lid-guard inhibitor held"
+}
+
+case "${1:-toggle}" in
+  skip-once|skip|once)
+    cmd_skip_once
+    ;;
+  allow|off)
+    cmd_allow
+    ;;
+  toggle|"")
+    if flag_set; then
+      cmd_allow
+    else
+      cmd_skip_once
+    fi
+    ;;
+  status)
+    cmd_status
+    ;;
+  *)
+    echo "Usage: omarchy-toggle-lid-suspend [skip-once|toggle|allow|status]" >&2
+    exit 1
+    ;;
+esac

--- a/bin/omarchy-toggle-lid-suspend
+++ b/bin/omarchy-toggle-lid-suspend
@@ -12,7 +12,10 @@ SKIP_TTL=1800
 
 flag_set() {
   [[ -f $FLAG ]] || return 1
-  (( $(date +%s) - $(stat -c %Y "$FLAG") <= SKIP_TTL ))
+  if (( $(date +%s) - $(stat -c %Y "$FLAG") > SKIP_TTL )); then
+    rm -f "$FLAG"
+    return 1
+  fi
 }
 
 poke_guard() {

--- a/default/hypr/bindings/utilities.lua
+++ b/default/hypr/bindings/utilities.lua
@@ -34,6 +34,7 @@ o.bind("SUPER + CTRL + Delete", "Toggle laptop display", "omarchy-hyprland-monit
 o.bind("SUPER + CTRL + ALT + Delete", "Toggle laptop display mirroring", "omarchy-hyprland-monitor-internal-mirror toggle")
 o.bind("switch:on:Lid Switch", nil, "omarchy-system-lid-close", { locked = true })
 o.bind("switch:off:Lid Switch", nil, "omarchy-hyprland-monitor-clamshell", { locked = true })
+o.bind("SUPER + ALT + L", "Skip lid suspend once", "omarchy-toggle-lid-suspend skip-once")
 
 o.bind("PRINT", "Screenshot", "omarchy-capture-screenshot")
 o.bind("ALT + PRINT", "Screenrecording", "omarchy-capture-screenrecording --stop-recording || omarchy-menu toggle trigger.capture.screenrecord")

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -90,6 +90,7 @@
   "trigger.toggle.idle-lock": {"icon":"󰅶","label":"Stay Awake","action":"omarchy-toggle-idle"},
   "trigger.toggle.notifications": {"icon":"󰂛","label":"Notifications","action":"omarchy-toggle-notification-silencing"},
   "trigger.toggle.crash-capture": {"icon":"󱚡","label":"Crash Capture","action":"omarchy-toggle-crash-capture"},
+  "trigger.toggle.lid-suspend": {"icon":"󰒲","label":"Skip Lid Suspend","when":"omarchy-hw-laptop","action":"omarchy-toggle-lid-suspend skip-once"},
   "trigger.toggle.screensaver": {"icon":"󱄄","label":"Screensaver","action":"omarchy-toggle-screensaver"},
   "trigger.toggle.nightlight": {"icon":"󰔎","label":"Nightlight","action":"omarchy-toggle-nightlight"},
   "trigger.toggle.top-bar": {"icon":"󰍜","label":"Menu Bar","action":"omarchy-toggle-bar"},

--- a/default/systemd/user/omarchy-lid-guard.service
+++ b/default/systemd/user/omarchy-lid-guard.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Block lid-close suspend while agents are working
+After=graphical-session.target
+PartOf=graphical-session.target
+# No lid switch, nothing to guard.
+ConditionPathExists=/proc/acpi/button/lid
+ConditionEnvironment=WAYLAND_DISPLAY
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/omarchy-system-lid-guard
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=graphical-session.target

--- a/install/user/first-run/enable-user-units.sh
+++ b/install/user/first-run/enable-user-units.sh
@@ -18,4 +18,5 @@ systemctl --user enable --now \
   omarchy-sleep-lock.service \
   omarchy-migrate-notify.service \
   omarchy-fcitx5.service \
-  omarchy-crash-watch.service
+  omarchy-crash-watch.service \
+  omarchy-lid-guard.service

--- a/manual/07-hotkeys.md
+++ b/manual/07-hotkeys.md
@@ -10,6 +10,7 @@ You can see all the main keyboard bindings with `Super + K` (Tmux bindings with 
 | `Super + Alt + Space` | Apps menu |
 | `Super + Escape` | System menu (suspend, restart, etc)  |
 | `Super + Ctrl + L` | Lock computer |
+| `Super + Alt + L` | Skip suspend on next lid close |
 | `Super + W` or `Super + Q` | Close window             |
 | `Ctrl + Alt + Del` | Close all windows |
 | `Super + T`               | Toggle window between tiling/floating             |

--- a/manual/36-system-sleep.md
+++ b/manual/36-system-sleep.md
@@ -23,6 +23,6 @@ When set up, you'll see the hibernate option under _System_ (or `Super + Esc`), 
 Closing the lid suspends the machine, which can land mid-task — an update (see #10203) or a coding agent run. Two safeguards keep the lid from interrupting work:
 
 - Skip once: `Super + Alt + L` (or `omarchy toggle lid-suspend skip-once`) skips suspend for the next lid close only. The lid still locks, it just does not suspend. The skip is consumed when the lid re-opens and expires after 30 minutes.
-- Automatic: while herdr reports a working agent, lid close never suspends. No herdr installed, no guard — the lid behaves exactly as before.
+- Automatic: while herdr reports a working agent and the machine is on AC power, lid close never suspends. On battery, and without herdr installed, the lid behaves exactly as before.
 
 `omarchy toggle lid-suspend status` shows whether a skip is armed and whether the guard currently holds the lid.

--- a/manual/36-system-sleep.md
+++ b/manual/36-system-sleep.md
@@ -17,3 +17,12 @@ You toggle suspend by running `omarchy toggle suspend` from the terminal. That j
 You set up hibernation by running `omarchy hibernation setup` from the terminal. Hibernation creates a /swap subvolume on your boot drive the size of your physical RAM allocation, so make sure you have plenty of room to spare. On a 32GB machine, you'll always need 32GB+ free for this volume. Hibernation also requires the default Limine bootloader.
 
 When set up, you'll see the hibernate option under _System_ (or `Super + Esc`), and then you can see if it works consistently on your system. If not, you can remove it again by running `omarchy hibernation remove`.
+
+### Lid suspend guard
+
+Closing the lid suspends the machine, which can land mid-task — an update (see #10203) or a coding agent run. Two safeguards keep the lid from interrupting work:
+
+- Skip once: `Super + Alt + L` (or `omarchy toggle lid-suspend skip-once`) skips suspend for the next lid close only. The lid still locks, it just does not suspend. The skip is consumed when the lid re-opens and expires after 30 minutes.
+- Automatic: while herdr reports a working agent, lid close never suspends. No herdr installed, no guard — the lid behaves exactly as before.
+
+`omarchy toggle lid-suspend status` shows whether a skip is armed and whether the guard currently holds the lid.

--- a/migrations/1789231389.sh
+++ b/migrations/1789231389.sh
@@ -1,0 +1,9 @@
+echo "Keep lid-close awake while coding agents are working"
+
+systemctl --user daemon-reload >/dev/null 2>&1 || true
+
+# Report what systemctl actually said; "could not enable" on its own gives
+# nothing to act on.
+if ! error=$(systemctl --user enable --now omarchy-lid-guard.service 2>&1); then
+  echo "Could not enable omarchy-lid-guard.service: $error"
+fi

--- a/test/shell.d/lid-suspend-test.sh
+++ b/test/shell.d/lid-suspend-test.sh
@@ -35,6 +35,7 @@ export OMARCHY_LID_STATE_GLOB="$tmpdir/lid/state"
 
 # Scenario knobs read by the mocks below.
 export MOCK_HERDR_PRESENT=1 MOCK_HERDR_STATE=idle MOCK_KILL_RC=0 MOCK_ACTIVE_RC=0
+export MOCK_AC=1
 
 cat >"$mock_bin/omarchy-cmd-missing" <<'SH'
 #!/bin/bash
@@ -79,6 +80,11 @@ for command in omarchy-notification-send omarchy-system-lock; do
 echo $command "\$*" >>"\$CALL_LOG"
 SH
 done
+
+cat >"$mock_bin/omarchy-power-present" <<'SH'
+#!/bin/bash
+[[ ${MOCK_AC:-1} == 1 ]]
+SH
 chmod +x "$mock_bin"/*
 export PATH="$mock_bin:$PATH"
 
@@ -216,6 +222,24 @@ grep -q "^omarchy-system-lock" "$call_log" ||
 echo "state:      open" >"$tmpdir/lid/state"
 "$guard" reconcile
 pass "guarded lid close locks"
+
+# The agent guard engages on AC only: never on battery.
+export MOCK_HERDR_STATE=working MOCK_AC=0
+: >"$call_log"
+"$guard" reconcile
+(( $(inhibit_spawns) == 0 )) ||
+  fail "battery suspends despite working agents" "$(cat "$call_log")"
+pass "battery suspends despite working agents"
+export MOCK_AC=1
+: >"$call_log"
+"$guard" reconcile
+(( $(inhibit_spawns) == 1 )) ||
+  fail "AC inhibits for working agents" "$(cat "$call_log")"
+grep -q "agents working on AC" "$call_log" ||
+  fail "inhibitor reason names AC" "$(cat "$call_log")"
+export MOCK_HERDR_STATE=idle
+"$guard" reconcile
+pass "AC inhibits for working agents"
 
 # Status reports flag and inhibitor state.
 status_out=$("$toggle" status)

--- a/test/shell.d/lid-suspend-test.sh
+++ b/test/shell.d/lid-suspend-test.sh
@@ -1,0 +1,224 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+toggle="$ROOT/bin/omarchy-toggle-lid-suspend"
+guard="$ROOT/bin/omarchy-system-lid-guard"
+tmpdir=$(mktemp -d)
+
+cleanup() {
+  if [[ -f $XDG_RUNTIME_DIR/omarchy-lid-guard/inhibit.pid ]]; then
+    kill "$(cut -d' ' -f1 "$XDG_RUNTIME_DIR/omarchy-lid-guard/inhibit.pid")" 2>/dev/null || true
+  fi
+  if [[ -n ${innocent_pid:-} ]]; then
+    kill "$innocent_pid" 2>/dev/null || true
+  fi
+  rm -rf "$tmpdir"
+}
+trap cleanup EXIT
+
+export HOME="$tmpdir/home"
+export XDG_RUNTIME_DIR="$tmpdir/runtime"
+mkdir -p "$HOME" "$XDG_RUNTIME_DIR"
+mock_bin="$tmpdir/bin"
+call_log="$tmpdir/calls"
+mkdir -p "$mock_bin"
+: >"$call_log"
+export CALL_LOG="$call_log"
+
+# Canned lid state the guard reads instead of /proc.
+mkdir -p "$tmpdir/lid"
+echo "state:      open" >"$tmpdir/lid/state"
+export OMARCHY_LID_STATE_GLOB="$tmpdir/lid/state"
+
+# Scenario knobs read by the mocks below.
+export MOCK_HERDR_PRESENT=1 MOCK_HERDR_STATE=idle MOCK_KILL_RC=0 MOCK_ACTIVE_RC=0
+
+cat >"$mock_bin/omarchy-cmd-missing" <<'SH'
+#!/bin/bash
+[[ $1 == "herdr" && ${MOCK_HERDR_PRESENT:-1} == 1 ]] && exit 1
+exit 0
+SH
+
+cat >"$mock_bin/herdr" <<'SH'
+#!/bin/bash
+case "${MOCK_HERDR_STATE:-idle}" in
+  working)
+    echo '{"result":{"agents":[{"agent":"opencode","agent_status":"working"},{"agent":"claude","agent_status":"idle"}]}}'
+    ;;
+  idle)
+    echo '{"result":{"agents":[{"agent":"opencode","agent_status":"idle"}]}}'
+    ;;
+  *)
+    echo "not json at all"
+    exit 1
+    ;;
+esac
+SH
+
+cat >"$mock_bin/systemd-inhibit" <<'SH'
+#!/bin/bash
+echo "systemd-inhibit $*" >>"$CALL_LOG"
+[[ $1 == "--list" ]] && exit 0
+exec sleep 300
+SH
+
+cat >"$mock_bin/systemctl" <<'SH'
+#!/bin/bash
+echo "systemctl $*" >>"$CALL_LOG"
+[[ $2 == "kill" ]] && exit "${MOCK_KILL_RC:-0}"
+[[ $2 == "is-active" ]] && exit "${MOCK_ACTIVE_RC:-0}"
+exit 0
+SH
+
+for command in omarchy-notification-send omarchy-system-lock; do
+  cat >"$mock_bin/$command" <<SH
+#!/bin/bash
+echo $command "\$*" >>"\$CALL_LOG"
+SH
+done
+chmod +x "$mock_bin"/*
+export PATH="$mock_bin:$PATH"
+
+inhibit_spawns() {
+  grep -c "^systemd-inhibit --what=handle-lid-switch.*--mode=block" "$call_log"
+}
+
+inhibitor_pid() {
+  head -n 1 "$XDG_RUNTIME_DIR/omarchy-lid-guard/inhibit.pid" | cut -d' ' -f1
+}
+
+# Manual skip arms the flag, wakes the guard, and notifies.
+: >"$call_log"
+"$toggle" skip-once
+[[ -f $HOME/.local/state/omarchy/toggles/lid-suspend-skip-once ]] ||
+  fail "skip-once arms the flag" "flag missing"
+grep -q "systemctl --user kill -s USR1 omarchy-lid-guard.service" "$call_log" ||
+  fail "skip-once wakes the guard" "$(cat "$call_log")"
+grep -q "omarchy-notification-send" "$call_log" ||
+  fail "skip-once notifies" "$(cat "$call_log")"
+pass "skip-once arms the flag, wakes the guard, and notifies"
+
+# Toggle flips the armed skip back off.
+"$toggle" toggle
+[[ ! -f $HOME/.local/state/omarchy/toggles/lid-suspend-skip-once ]] ||
+  fail "toggle disarms an armed skip" "flag still present"
+pass "toggle disarms an armed skip"
+
+# Toggle arms when nothing is armed.
+"$toggle" toggle
+[[ -f $HOME/.local/state/omarchy/toggles/lid-suspend-skip-once ]] ||
+  fail "toggle arms a disarmed skip" "flag missing"
+pass "toggle arms a disarmed skip"
+
+# Allow clears, and a stale flag reads as unset.
+"$toggle" allow
+[[ ! -f $HOME/.local/state/omarchy/toggles/lid-suspend-skip-once ]] ||
+  fail "allow clears the flag" "flag still present"
+pass "allow clears the flag"
+
+# A working agent holds the lid inhibitor; a second pass reuses it.
+export MOCK_HERDR_STATE=working
+: >"$call_log"
+"$guard" reconcile
+(( $(inhibit_spawns) == 1 )) ||
+  fail "working agent starts one inhibitor" "$(cat "$call_log")"
+first_pid=$(inhibitor_pid)
+kill -0 "$first_pid" 2>/dev/null ||
+  fail "inhibitor process is alive" "pid $first_pid"
+"$guard" reconcile
+(( $(inhibit_spawns) == 1 )) ||
+  fail "reconcile reuses a live inhibitor" "$(cat "$call_log")"
+pass "working agent holds one lid inhibitor"
+
+# Idle agents release it.
+export MOCK_HERDR_STATE=idle
+"$guard" reconcile
+kill -0 "$first_pid" 2>/dev/null &&
+  fail "idle agents release the inhibitor" "pid $first_pid still alive"
+[[ ! -f $XDG_RUNTIME_DIR/omarchy-lid-guard/inhibit.pid ]] ||
+  fail "idle agents drop the pidfile" "pidfile still present"
+pass "idle agents release the inhibitor"
+
+# Missing or broken herdr fails open: suspend as usual, no inhibitor.
+export MOCK_HERDR_PRESENT=0
+: >"$call_log"
+"$guard" reconcile
+(( $(inhibit_spawns) == 0 )) ||
+  fail "missing herdr fails open" "$(cat "$call_log")"
+export MOCK_HERDR_PRESENT=1 MOCK_HERDR_STATE=broken
+"$guard" reconcile
+(( $(inhibit_spawns) == 0 )) ||
+  fail "unreadable herdr fails open" "$(cat "$call_log")"
+pass "missing or broken herdr fails open"
+export MOCK_HERDR_STATE=idle
+
+# A manual skip inhibits even with idle agents.
+: >"$call_log"
+"$toggle" skip-once >/dev/null
+"$guard" reconcile
+(( $(inhibit_spawns) == 1 )) ||
+  fail "manual skip inhibits with idle agents" "$(cat "$call_log")"
+guard_pid=$(inhibitor_pid)
+"$toggle" allow >/dev/null
+pass "manual skip inhibits with idle agents"
+
+# A stale pidfile never kills an unrelated process.
+export MOCK_HERDR_STATE=working
+sleep 300 & innocent_pid=$!
+printf '%s 0\nstale reason\n' "$innocent_pid" >"$XDG_RUNTIME_DIR/omarchy-lid-guard/inhibit.pid"
+kill "$guard_pid" 2>/dev/null || true
+: >"$call_log"
+"$guard" reconcile
+kill -0 "$innocent_pid" 2>/dev/null ||
+  fail "stale pidfile does not kill unrelated processes" "innocent pid $innocent_pid died"
+(( $(inhibit_spawns) == 1 )) ||
+  fail "stale pidfile is replaced" "$(cat "$call_log")"
+[[ $(inhibitor_pid) != "$innocent_pid" ]] ||
+  fail "stale pidfile is replaced" "pidfile still points at $innocent_pid"
+pass "stale pidfile neither kills nor is reused"
+kill "$innocent_pid" 2>/dev/null || true
+unset innocent_pid
+export MOCK_HERDR_STATE=idle
+kill "$(inhibitor_pid)" 2>/dev/null || true
+rm -f "$XDG_RUNTIME_DIR/omarchy-lid-guard/inhibit.pid"
+
+# An expired skip reads as unset and is cleaned up.
+date -u +%s >"$HOME/.local/state/omarchy/toggles/lid-suspend-skip-once"
+touch -d "2 hours ago" "$HOME/.local/state/omarchy/toggles/lid-suspend-skip-once"
+: >"$call_log"
+"$guard" reconcile
+[[ ! -f $HOME/.local/state/omarchy/toggles/lid-suspend-skip-once ]] ||
+  fail "expired skip is cleaned up" "flag still present"
+(( $(inhibit_spawns) == 0 )) ||
+  fail "expired skip does not inhibit" "$(cat "$call_log")"
+pass "expired skip reads as unset"
+
+# Re-opening the lid consumes the one-shot skip.
+date -u +%s >"$HOME/.local/state/omarchy/toggles/lid-suspend-skip-once"
+echo "closed" >"$XDG_RUNTIME_DIR/omarchy-lid-guard/prev-lid"
+echo "state:      open" >"$tmpdir/lid/state"
+"$guard" reconcile
+[[ ! -f $HOME/.local/state/omarchy/toggles/lid-suspend-skip-once ]] ||
+  fail "lid reopen consumes the skip" "flag still present"
+pass "lid reopen consumes the skip"
+
+# Closing the lid while guarded locks the session.
+date -u +%s >"$HOME/.local/state/omarchy/toggles/lid-suspend-skip-once"
+echo "open" >"$XDG_RUNTIME_DIR/omarchy-lid-guard/prev-lid"
+echo "state:      closed" >"$tmpdir/lid/state"
+: >"$call_log"
+"$guard" reconcile
+grep -q "^omarchy-system-lock" "$call_log" ||
+  fail "guarded lid close locks" "$(cat "$call_log")"
+echo "state:      open" >"$tmpdir/lid/state"
+"$guard" reconcile
+pass "guarded lid close locks"
+
+# Status reports flag and inhibitor state.
+status_out=$("$toggle" status)
+grep -q "no skip armed" <<<"$status_out" ||
+  fail "status reports a consumed skip" "$status_out"
+pass "status reports flag state"


### PR DESCRIPTION
Closes #11524.

## Problem

Closing the lid suspends the machine immediately, whatever is running. That regularly lands mid-task: #10203 tracks an update killed by a lid close, and the same fate hits coding agent runs — close the lid on the way to a meeting and hours of agent work stall on suspend.

There is currently no way to say "not this close," and the system has zero awareness of background work. Lid close is an unconditional suspend (modulo dock/docked config), full stop.

## Solution

Two safeguards, both fail-open:

1. **Skip once, anywhere.** `omarchy toggle lid-suspend skip-once` (`Super + Alt + L`) skips suspend for the next lid close only, on AC or battery — the user explicitly asked for it, so we assume they know what they're doing. The lid still locks, it just does not suspend. Consumed on reopen; disarms after 30 minutes.
2. **Automatic guard, AC only.** While herdr reports a working agent **and the machine is on AC power**, lid close never suspends. On battery the guard stays out of the way — a working agent must never silently drain a battery in a bag. Hyprland's lid-switch binds still fire, so `omarchy-system-lid-close` keeps locking and reconciling displays. No herdr installed, no guard — the lid behaves exactly as before.

`omarchy toggle lid-suspend status` shows whether a skip is armed and whether the guard currently holds the lid.

## Rabbit holes (out of scope)

- General activity detection (CPU, per-app heuristics) — herdr's working state is the only signal.
- Battery-level-aware guarding (e.g. "guard below 80%") — the rule is binary: AC guards, battery doesn't.
- Touching the lock path — `omarchy-system-lid-close` is untouched; the inhibitor only suppresses logind's suspend action.

## No-gos

- No new hard dependencies — herdr is optional, absence means fail-open.
- Never suspend a docked closed lid — clamshell stays awake.
- No persistent "never suspend on lid close" mode — the manual side is one-shot by design; the permanent toggles (`suspend-off`) already exist for that.
