### PR TITLE
Update limine tooling before upgrading packages on older CPUs

### DIFF
--- a/bin/omarchy-update-system-pkgs
+++ b/bin/omarchy-update-system-pkgs
@@ -13,6 +13,19 @@ if [[ ${OMARCHY_UPDATE_CONFLICT:-} == 1 && ${OMARCHY_UPDATE_INTERACTIVE:-} == 1 
   exec sudo env OMARCHY_UPDATE_PACMAN=1 pacman -Syu --overwrite '/usr/share/omarchy/*'
 fi
 
+# Before 1.38, limine-mkinitcpio-hook and limine-snapper-sync shipped binaries
+# that require AVX2, so they refuse to start on older CPUs. The upgrade below
+# installs a new kernel, and its pacman hook calls them to rebuild the UKI. When
+# they cannot run the kernel is replaced but the UKI is not, and the machine no
+# longer boots. Updating just that tooling first puts the hook back in working
+# order before the kernel moves.
+limine_entry_tool=/usr/lib/limine/limine-entry-tool
+
+if [[ -x $limine_entry_tool ]] && ! "$limine_entry_tool" --version &>/dev/null; then
+  echo -e "\e[32m\nUpdate limine tooling first (the installed build cannot run on this CPU)\e[0m"
+  sudo pacman -S --noconfirm --needed limine-mkinitcpio-hook limine-snapper-sync
+fi
+
 echo -e "\e[32m\nUpdate system packages\e[0m"
 
 errors=$(mktemp)


### PR DESCRIPTION
Closes #11526

## The problem

`limine-mkinitcpio-hook` and `limine-snapper-sync` shipped binaries built for `x86-64-v3` before 1.38, so they need AVX2 and refuse to start on older CPUs:

```
The current machine does not support all of the following CPU features that are
required by the image: [... AVX, AVX2, BMI1, BMI2, FMA, F16C].
ERROR: failed to get kernel cmdline for 'linux'.
```

That matters during an upgrade. `pacman -Syu` installs a new kernel, and the `90-mkinitcpio-install.hook` calls those binaries to rebuild the UKI. When they cannot run, the hook fails, pacman carries on (a `PostTransaction` failure does not abort a transaction), the old kernel's modules are removed, and the next boot starts a kernel whose modules are gone.

The user gets no warning. The hook error scrolls past among hundreds of other lines.

The AVX2 build itself is already fixed: 1.38.0-1.1 reports `x86 ISA needed: x86-64-baseline` and works. But a user on a pre-fix version cannot reach that fix safely, because the transaction that delivers it is the same one that needs the working binary.

## The change

Update that tooling on its own before the main upgrade, so the hook works before the kernel moves.

```bash
limine_entry_tool=/usr/lib/limine/limine-entry-tool

if [[ -x $limine_entry_tool ]] && ! "$limine_entry_tool" --version &>/dev/null; then
  echo -e "\e[32m\nUpdate limine tooling first (the installed build cannot run on this CPU)\e[0m"
  sudo pacman -S --noconfirm --needed limine-mkinitcpio-hook limine-snapper-sync
fi
```

13 lines, nothing removed. It sits after the conflict-retry `exec` so the retry path is unaffected, and uses the package database `omarchy-update-keyring` has already refreshed, so there is no partial-upgrade window.

## Testing

Tested on the affected hardware: Intel Celeron N4000 (Goldmont Plus), maximum ISA level `x86-64-v2`, no AVX2.

| Case | Result |
|---|---|
| Tool runs (1.38.0-1.1, current state of my machine) | skipped, no-op |
| Tool cannot start (AVX2 failure, simulated with a stub that exits non-zero) | update branch taken |
| `limine` not installed at all | skipped |
| Path present but not executable | skipped |

Honest limit: my machine has already been updated past the broken build, so I could not re-run the genuine failure end to end. I hit the original failure on this hardware earlier today, which is what prompted #11526, and the simulated case reproduces the same condition the check tests for.

## Note

Migration `1768236764.sh` adds `kernel-modules-hook`, which keeps the previous kernel's modules on disk. Users upgrading from before that migration do not have it, which is what turns a failed UKI rebuild into an unbootable machine rather than a recoverable one. Worth considering as an earlier dependency, though that is outside this PR.
