### PR TITLE
Show portrait wallpaper twins on portrait screens

### DIFF
--- a/shell/Ui/BackgroundMedia.qml
+++ b/shell/Ui/BackgroundMedia.qml
@@ -15,6 +15,7 @@ Item {
   property bool reloading: false
   readonly property var current: video ? videoLoader.item : imageLoader.item
   readonly property bool ready: current ? current.ready : false
+  readonly property bool failed: current ? current.failed === true : false
   readonly property bool video: Util.isVideoPath(path)
   // Cache-bust images selected in a running lock session. FFmpeg treats the
   // query as part of a local filename, so videos must keep their plain URL.
@@ -76,6 +77,7 @@ Item {
 
     Image {
       readonly property bool ready: status === Image.Ready
+      readonly property bool failed: status === Image.Error
       source: root.imageUrl
       fillMode: Image.PreserveAspectCrop
       asynchronous: true

--- a/shell/plugins/background/Background.qml
+++ b/shell/plugins/background/Background.qml
@@ -244,6 +244,17 @@ Item {
 
       property bool maskReady: false
 
+      // Themes may ship portrait twins under backgrounds/portrait/<same name>:
+      // portrait screens use the twin, landscape screens the plain file. A
+      // missing twin falls back to the linked file for that path.
+      property string orientFailedFor: ""
+      function oriented(path) {
+        const p = String(path || "")
+        if (p === orientFailedFor) return p
+        const plain = p.replace(/\/portrait\/([^/]+)$/, "/$1")
+        return panel.screen.height > panel.screen.width ? plain.replace(/\/([^/]+)$/, "/portrait/$1") : plain
+      }
+
       function maybeStartReveal() {
         if (!root.incomingBackground || root.revealProgress !== 0 || maskReady) return
         if (incomingFrame.status !== Image.Ready) return
@@ -262,8 +273,12 @@ Item {
       BackgroundMedia {
         id: base
         anchors.fill: parent
-        path: root.displayedBackground
+        path: panel.oriented(root.displayedBackground)
         reloads: root.displayedReloads
+        onFailedChanged: {
+          // The failing source is the twin; remember it so this path shows the plain file.
+          if (failed && panel.oriented(root.displayedBackground) !== root.displayedBackground) panel.orientFailedFor = root.displayedBackground
+        }
         playbackEnabled: !root.sessionObscured && !root.powerSaverActive && !panel.fullscreenHere
         audioEnabled: panel.firstScreen
         onReadyChanged: {
@@ -278,7 +293,7 @@ Item {
       Image {
         id: oldFrame
         anchors.fill: parent
-        source: root.imageUrl(root.oldBackground)
+        source: root.imageUrl(panel.oriented(root.oldBackground))
         fillMode: Image.PreserveAspectCrop
         asynchronous: true
         cache: false
@@ -304,7 +319,7 @@ Item {
         Image {
           id: incomingFrame
           anchors.fill: parent
-          source: root.imageUrl(root.incomingBackground)
+          source: root.imageUrl(panel.oriented(root.incomingBackground))
           fillMode: Image.PreserveAspectCrop
           asynchronous: true
           cache: false

--- a/test/shell.d/background-test.sh
+++ b/test/shell.d/background-test.sh
@@ -19,3 +19,31 @@ assert(
   'background theme transition applies pending colors even if image reveal stalls'
 )
 JS
+
+run_node_test <<'JS'
+const fs = require('fs')
+
+const backgroundQml = fs.readFileSync(path.join(root, 'shell/plugins/background/Background.qml'), 'utf8')
+const mediaQml = fs.readFileSync(path.join(root, 'shell/Ui/BackgroundMedia.qml'), 'utf8')
+
+// Every frame a screen paints goes through the per-screen orientation lookup.
+assert(
+  backgroundQml.includes('path: panel.oriented(root.displayedBackground)') &&
+    backgroundQml.includes('source: root.imageUrl(panel.oriented(root.oldBackground))') &&
+    backgroundQml.includes('source: root.imageUrl(panel.oriented(root.incomingBackground))'),
+  'background base, old and incoming frames resolve the portrait twin per screen'
+)
+assert(mediaQml.includes('readonly property bool failed:'), 'BackgroundMedia reports a failed image so a missing twin can fall back')
+
+// Run the lookup itself against a fake panel.
+const fn = backgroundQml.match(/function oriented\(path\) \{[\s\S]*?\n      \}/)[0]
+const oriented = (screen, orientFailedFor, p) => new Function('panel', 'orientFailedFor', 'path', `${fn.replace('function oriented(path)', 'const oriented = (path) =>')}; return oriented(path)`)({ screen }, orientFailedFor, p)
+const portrait = { width: 1440, height: 2560 }
+const landscape = { width: 3840, height: 2160 }
+const plain = '/theme/backgrounds/1-moonrise.png'
+const twin = '/theme/backgrounds/portrait/1-moonrise.png'
+assert(oriented(portrait, '', plain) === twin, 'portrait screen swaps to backgrounds/portrait/<same name>')
+assert(oriented(landscape, '', plain) === plain, 'landscape screen keeps the plain file')
+assert(oriented(landscape, '', twin) === plain, 'landscape screen swaps a portrait twin back to the plain file')
+assert(oriented(portrait, plain, plain) === plain, 'a path whose twin failed to load stays on the plain file')
+JS


### PR DESCRIPTION
Discussion with the design and alternatives: omacom/omarchy#11533

## What

A theme may ship `backgrounds/portrait/<same file name>`. The background plugin picks the twin on screens taller than wide and the plain file elsewhere — for the base frame and both transition frames — so one `current/background` link serves a landscape and a rotated monitor at once.

- No change to the picker, `bg next` or theme switching: they already list `backgrounds/` with `-maxdepth 1`, so the subfolder is never offered as a wallpaper.
- Missing twin → `BackgroundMedia` now reports `failed`, and that panel falls back to the linked file for that path. Themes without the folder behave exactly as before.
- `test/shell.d/background-test.sh`: asserts all three frames go through the lookup, and runs the extracted `oriented()` against a fake portrait/landscape panel plus the fallback case.

## Why

On a 3840x2160 + rotated 2560x1440 setup the portrait screen shows the landscape image cropped to its middle third; the subject is usually cut off. Themes had no way to express an alternative.

## Testing

- `test/shell.d/background-test.sh` passes (8 assertions).
- `./test/shell`: the same five files fail on untouched `quattro` in this environment (no `omarchy-pkgs` checkout, portal/locale) — unrelated.
- Live on Hyprland with DP-2 (landscape) + DP-1 (transform 1): `omarchy theme bg set` via the Ctrl+Super+Space picker shows the twin on the portrait screen; verified with an IPC probe and `grim -o` captures of both outputs. Capture after `omarchy theme bg set` (left: DP-2 3840x2160, right: DP-1 rotated 1440x2560, empty workspaces):

![landscape and portrait screens sharing one background link](https://raw.githubusercontent.com/kravens/omarchy-bitcoin-frontier-theme/f7b99d7e5187db2beff87f4b8c7d8d09c8c0680f/docs/portrait-twins.jpg)

Reference theme using the convention: https://github.com/kravens/omarchy-bitcoin-frontier-theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT1S32i88jEjdjDRz892aP


