### PR TITLE
Fix BCM4377 Bluetooth hang and D3 suspend abort on T2 Macs

### DIFF
--- a/bin/omarchy-t2-bcm4377-rebind
+++ b/bin/omarchy-t2-bcm4377-rebind
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# omarchy:summary=Rebind the BCM4377 Bluetooth function until the adapter is usable
+# omarchy:group=hw
+# omarchy:hidden=true
+# omarchy:requires-sudo=true
+
+# The BCM4377 on T2 Macs often fails its first initialisation (HCI command
+# timeouts, or probe error -110). Unbinding and rebinding hci_bcm4377, sometimes
+# more than once, brings it up. BlueZ can report Powered: yes while the class
+# stays 0x00000000 and scans find nothing — that happens at boot, not only
+# after suspend.
+
+set -euo pipefail
+
+MAX_TRIES=${MAX_TRIES:-5}
+DRV=/sys/bus/pci/drivers/hci_bcm4377
+
+DEV=""
+for d in /sys/bus/pci/devices/*; do
+  [[ -r $d/vendor && -r $d/device ]] || continue
+  if [[ $(<"$d/vendor") == "0x14e4" && $(<"$d/device") == "0x5fa0" ]]; then
+    DEV=$(basename "$d")
+    break
+  fi
+done
+
+if [[ -z $DEV ]]; then
+  echo "omarchy-t2-bcm4377-rebind: no BCM4377 Bluetooth function found, nothing to do"
+  exit 0
+fi
+
+modprobe hci_bcm4377 2>/dev/null || true
+
+# Returns 0 only if BlueZ says powered *and* the adapter class is set.
+# A hung BCM4377 still reports Powered: yes with Class: 0x00000000 (0).
+alive() {
+  [[ -e /sys/class/bluetooth/hci0 ]] || return 1
+  timeout 5 bluetoothctl power on >/dev/null 2>&1 || true
+  local show
+  show=$(timeout 5 bluetoothctl show 2>/dev/null) || return 1
+  echo "$show" | grep -q 'Powered: yes' || return 1
+  echo "$show" | grep -q 'Class: 0x00000000' && return 1
+  return 0
+}
+
+if alive; then
+  echo "omarchy-t2-bcm4377-rebind: $DEV already powered, nothing to do"
+  exit 0
+fi
+
+for i in $(seq 1 "$MAX_TRIES"); do
+  echo "omarchy-t2-bcm4377-rebind: attempt $i/$MAX_TRIES on $DEV"
+  if [[ -L /sys/bus/pci/devices/$DEV/driver ]]; then
+    echo "$DEV" >"$DRV/unbind" 2>/dev/null || true
+    sleep 2
+  fi
+  echo "$DEV" >"$DRV/bind" 2>/dev/null || true
+  sleep 3
+  systemctl restart bluetooth.service
+  sleep 3
+  if alive; then
+    echo "omarchy-t2-bcm4377-rebind: Bluetooth powered on after attempt $i"
+    exit 0
+  fi
+done
+
+echo "omarchy-t2-bcm4377-rebind: gave up after $MAX_TRIES attempts" >&2
+exit 1

--- a/bin/omarchy-t2-bcm4377-suspend
+++ b/bin/omarchy-t2-bcm4377-suspend
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+# omarchy:summary=Unload BCM4377 Wi-Fi and Bluetooth around suspend
+# omarchy:group=hw
+# omarchy:args=<pre|post>
+# omarchy:hidden=true
+# omarchy:requires-sudo=true
+
+# brcmfmac times out in brcmf_pcie_pm_enter_D3 (pci_pm_suspend returns -5),
+# which aborts both deep and s2idle. Unload has to happen before sleep.target:
+# a systemd-sleep hook runs after user.slice is frozen, when NetworkManager
+# still holds the interface and `modprobe -r brcmfmac` can fail.
+#
+# hci_bcm4377 must be unloaded too. Left bound, it wakes hung and later raises
+# a PCIe error that DPC-isolates the whole combo chip (Wi-Fi dies until reboot).
+# Stop bluetoothd first so the module can actually leave.
+#
+# Reloading brcmfmac the instant the system wakes has hard-crashed this chip.
+# Defer that reload ~15s, then rebind Bluetooth.
+
+set -euo pipefail
+
+has_bcm4377() {
+  local dev
+  for dev in /sys/bus/pci/devices/*; do
+    [[ -r $dev/vendor && -r $dev/device ]] || continue
+    if [[ $(<"$dev/vendor") == "0x14e4" ]]; then
+      case $(<"$dev/device") in
+        0x4488|0x5fa0) return 0 ;;
+      esac
+    fi
+  done
+  return 1
+}
+
+loaded() {
+  [[ -d /sys/module/$1 ]]
+}
+
+wifi_ifaces() {
+  local path driver
+  for path in /sys/class/net/*/device/driver; do
+    [[ -e $path ]] || continue
+    driver=$(basename "$(readlink -f "$path")")
+    [[ $driver == "brcmfmac" ]] || continue
+    basename "$(dirname "$(dirname "$path")")"
+  done
+}
+
+release_wifi() {
+  local iface
+  for iface in $(wifi_ifaces); do
+    nmcli device disconnect "$iface" >/dev/null 2>&1 || true
+    ip link set "$iface" down >/dev/null 2>&1 || true
+  done
+}
+
+unload_bluetooth() {
+  loaded hci_bcm4377 || return 0
+  systemctl stop bluetooth.service >/dev/null 2>&1 || true
+  modprobe -r hci_bcm4377 || true
+  if loaded hci_bcm4377; then
+    echo "warning: failed to unload hci_bcm4377" >&2
+  else
+    echo "unloaded hci_bcm4377 before suspend"
+  fi
+}
+
+pre() {
+  has_bcm4377 || exit 0
+
+  unload_bluetooth
+
+  loaded brcmfmac || exit 0
+
+  release_wifi
+
+  local attempt
+  for attempt in 1 2 3 4 5; do
+    loaded brcmfmac_wcc && modprobe -r brcmfmac_wcc || true
+    if ! loaded brcmfmac || modprobe -r brcmfmac; then
+      echo "unloaded brcmfmac before suspend (attempt $attempt)"
+      exit 0
+    fi
+    sleep 0.4
+  done
+
+  echo "failed to unload brcmfmac; BCM4377 will abort suspend" >&2
+  exit 1
+}
+
+post() {
+  has_bcm4377 || exit 0
+
+  systemctl stop t2-wifi-reload.service t2-wifi-reload.timer \
+    omarchy-t2-bcm4377-reload.service omarchy-t2-bcm4377-reload.timer >/dev/null 2>&1 || true
+  systemd-run --collect --on-active=15s --unit=omarchy-t2-bcm4377-reload \
+    /bin/bash -c 'modprobe brcmfmac; modprobe brcmfmac_wcc || true; systemctl start omarchy-t2-bcm4377-rebind.service'
+  echo "scheduled brcmfmac/bluetooth reload in 15s"
+}
+
+case "${1:-}" in
+  pre) pre ;;
+  post) post ;;
+  *)
+    echo "usage: omarchy-t2-bcm4377-suspend <pre|post>" >&2
+    exit 2
+    ;;
+esac

--- a/default/systemd/system/omarchy-t2-bcm4377-rebind.service
+++ b/default/systemd/system/omarchy-t2-bcm4377-rebind.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Rebind BCM4377 Bluetooth until the adapter is usable
+Documentation=https://github.com/omacom/omarchy/issues/11264
+After=bluetooth.service
+Wants=bluetooth.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/omarchy-t2-bcm4377-rebind
+TimeoutStartSec=120
+
+[Install]
+WantedBy=multi-user.target

--- a/default/systemd/system/omarchy-t2-bcm4377-suspend.service
+++ b/default/systemd/system/omarchy-t2-bcm4377-suspend.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Unload BCM4377 Wi-Fi and Bluetooth around suspend
+Documentation=https://github.com/omacom/omarchy/issues/11264
+Before=sleep.target
+StopWhenUnneeded=yes
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+TimeoutStartSec=15
+TimeoutStopSec=15
+ExecStart=/usr/bin/omarchy-t2-bcm4377-suspend pre
+ExecStop=/usr/bin/omarchy-t2-bcm4377-suspend post
+
+[Install]
+WantedBy=sleep.target

--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -41,6 +41,7 @@ run_logged "$OMARCHY_INSTALL/hardware/framework/qmk-hid.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-spi-keyboard.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-suspend-nvme.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-t2.sh"
+run_logged "$OMARCHY_INSTALL/hardware/apple/fix-t2-bcm4377.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-brcmfmac-supplicant.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/lenovo/fix-yoga-pro7-bass-speakers.sh"

--- a/install/hardware/apple/fix-t2-bcm4377.sh
+++ b/install/hardware/apple/fix-t2-bcm4377.sh
@@ -1,0 +1,39 @@
+# BCM4377 combo (Wi-Fi 14e4:4488, Bluetooth 14e4:5fa0) flakes on first Bluetooth
+# probe and cannot enter D3, which aborts suspend. Other T2 chips do not share
+# this; gate on the combo PCI IDs, not the T2 bridge. See
+# https://github.com/omacom/omarchy/issues/11264
+#
+# Unload happens in a Before=sleep.target oneshot so NetworkManager can release
+# the interface. A systemd-sleep hook runs after user.slice is frozen, and
+# reloading brcmfmac the instant the machine wakes has hard-crashed this chip.
+systemd_dir="${OMARCHY_T2_BCM4377_SYSTEMD_DIR:-/etc/systemd/system}"
+sleep_hook="${OMARCHY_T2_BCM4377_SLEEP_HOOK:-/usr/lib/systemd/system-sleep/t2-wifi-suspend}"
+omarchy_path="${OMARCHY_PATH:-/usr/share/omarchy}"
+unit_dir="$omarchy_path/default/systemd/system"
+
+if lspci -nn | grep -E "14e4:(4488|5fa0)" >/dev/null; then
+  echo "Detected BCM4377 Wi-Fi/Bluetooth; installing boot rebind and suspend unload"
+
+  mkdir -p "$systemd_dir"
+  install -m 644 "$unit_dir/omarchy-t2-bcm4377-rebind.service" \
+    "$systemd_dir/omarchy-t2-bcm4377-rebind.service"
+  install -m 644 "$unit_dir/omarchy-t2-bcm4377-suspend.service" \
+    "$systemd_dir/omarchy-t2-bcm4377-suspend.service"
+
+  # Community workarounds that race these units on resume (immediate brcmfmac
+  # reload) or duplicate the boot rebind.
+  systemctl disable --now t2-brcmfmac-suspend.service >/dev/null 2>&1 || true
+  systemctl disable --now bt-bcm4377-rebind.service >/dev/null 2>&1 || true
+  systemctl disable --now t2-wifi-suspend.service >/dev/null 2>&1 || true
+  rm -f "$sleep_hook"
+
+  systemctl daemon-reload
+  systemctl enable omarchy-t2-bcm4377-rebind.service
+  systemctl enable omarchy-t2-bcm4377-suspend.service
+
+  # ISO finalization is a chroot; starting the oneshot there cannot talk to a
+  # real adapter. On a live system, unstick Bluetooth without waiting for reboot.
+  if systemctl is-system-running >/dev/null 2>&1; then
+    systemctl start omarchy-t2-bcm4377-rebind.service >/dev/null 2>&1 || true
+  fi
+fi

--- a/manual/44-mac-support.md
+++ b/manual/44-mac-support.md
@@ -61,6 +61,7 @@ The Apple T2 Security Chip was introduced in 2017. The T2 chip was discontinued 
 - MacBook Pro 13-inch (2018, four Thunderbolt 3 ports) – Model: A1989
 - MacBook Pro 15-inch (2018) – Model: A1990
 - MacBook Air (Retina, 13-inch, 2018) – Model: A1932
+- MacBook Air (Retina, 13-inch, 2020) – Model: A2179
 - Mac mini (2018) – Model: A1998
 - MacBook Pro 13-inch (2019, two Thunderbolt 3 ports) – Model: A2159
 - MacBook Pro 13-inch (2019, four Thunderbolt 3 ports) – Model: A2178
@@ -68,4 +69,4 @@ The Apple T2 Security Chip was introduced in 2017. The T2 chip was discontinued 
 - MacBook Pro 13-inch (2020, two Thunderbolt 3 ports) – Model: A2265
 - MacBook Pro 15-inch (2020) – Model: A1990
 
-On these models, the installer automatically sets up the patched `linux-t2` kernel, the T2 audio configuration, Apple's Broadcom Wi-Fi/Bluetooth firmware, and fan control via `t2fanrd`. The Touch Bar runs on the kernel's built-in Boot Camp-style support.
+On these models, the installer automatically sets up the patched `linux-t2` kernel, the T2 audio configuration, Apple's Broadcom Wi-Fi/Bluetooth firmware, and fan control via `t2fanrd`. The Touch Bar runs on the kernel's built-in Boot Camp-style support. Machines with the BCM4377 combo chip (including the 2020 MacBook Air) also get a boot-time Bluetooth rebind and a pre-sleep unload of Wi-Fi/Bluetooth, so the adapter comes up and the lid can sleep.

--- a/migrations/1789234234.sh
+++ b/migrations/1789234234.sh
@@ -1,0 +1,24 @@
+echo "Rebind BCM4377 Bluetooth after boot and unload the combo chip around suspend"
+
+# Existing T2 installs load hci_bcm4377 but leave a hung adapter (Powered: yes,
+# class 0x00000000) and cannot suspend: brcmfmac times out entering D3. Gate on
+# the combo PCI IDs so other T2 chips are left alone. See
+# install/hardware/apple/fix-t2-bcm4377.sh and omacom/omarchy#11264.
+
+as_root() {
+  if (( EUID == 0 )); then
+    "$@"
+  else
+    sudo "$@"
+  fi
+}
+
+if ! lspci -nn | grep -E "14e4:(4488|5fa0)" >/dev/null; then
+  exit 0
+fi
+
+as_root env \
+  OMARCHY_PATH="${OMARCHY_PATH:-/usr/share/omarchy}" \
+  OMARCHY_T2_BCM4377_SYSTEMD_DIR="${OMARCHY_T2_BCM4377_SYSTEMD_DIR:-/etc/systemd/system}" \
+  OMARCHY_T2_BCM4377_SLEEP_HOOK="${OMARCHY_T2_BCM4377_SLEEP_HOOK:-/usr/lib/systemd/system-sleep/t2-wifi-suspend}" \
+  bash -euo pipefail -c 'source "$1"' bash "$OMARCHY_PATH/install/hardware/apple/fix-t2-bcm4377.sh"

--- a/test/shell.d/t2-bcm4377-test.sh
+++ b/test/shell.d/t2-bcm4377-test.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+leaf="$ROOT/install/hardware/apple/fix-t2-bcm4377.sh"
+fix_t2="$ROOT/install/hardware/apple/fix-t2.sh"
+all="$ROOT/install/hardware/all.sh"
+migration="$ROOT/migrations/1789234234.sh"
+rebind="$ROOT/bin/omarchy-t2-bcm4377-rebind"
+suspend="$ROOT/bin/omarchy-t2-bcm4377-suspend"
+rebind_unit="$ROOT/default/systemd/system/omarchy-t2-bcm4377-rebind.service"
+suspend_unit="$ROOT/default/systemd/system/omarchy-t2-bcm4377-suspend.service"
+
+grep -q 'apple/fix-t2-bcm4377.sh' "$all" ||
+  fail "the BCM4377 workaround runs during hardware setup"
+! grep -q 'omarchy-t2-bcm4377' "$fix_t2" ||
+  fail "only the BCM4377 leaf owns the combo-chip units"
+grep -q 'Class: 0x00000000' "$rebind" ||
+  fail "the rebind treats an unset adapter class as hung"
+grep -q 'WantedBy=sleep.target' "$suspend_unit" ||
+  fail "suspend unload is a sleep.target unit, not a systemd-sleep hook"
+grep -q 'Before=sleep.target' "$suspend_unit" ||
+  fail "suspend unload runs before sleep.target"
+grep -q 'omarchy-t2-bcm4377-rebind.service' "$suspend" ||
+  fail "resume reloads Bluetooth through the rebind unit"
+pass "BCM4377 setup is a dedicated leaf with a class-aware rebind"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+calls="$test_tmp/calls.log"
+systemd_dir="$test_tmp/systemd"
+sleep_hook="$test_tmp/system-sleep/t2-wifi-suspend"
+mkdir -p "$stub_bin" "$test_tmp/system-sleep"
+
+cat >"$stub_bin/lspci" <<'SH'
+#!/bin/bash
+
+# Chatty like real lspci: keep writing well past the pipe buffer after the
+# match, so a grep -q consumer would kill this stub with SIGPIPE and pipefail
+# would read that as "no such hardware" (#6608).
+if (( ${T2_HARDWARE:-0} == 1 )); then
+  echo '01:00.0 Bridge [0680]: Apple Inc. T2 Security Chip [106b:1801]'
+fi
+if [[ -n ${WIFI_ID:-} ]]; then
+  echo "03:00.0 Network controller [0280]: Broadcom Inc. Wireless [14e4:$WIFI_ID]"
+fi
+if [[ -n ${BT_ID:-} ]]; then
+  echo "03:00.1 Network controller [0280]: Broadcom Inc. Bluetooth [14e4:$BT_ID]"
+fi
+for _ in {1..4096}; do
+  echo '02:00.0 Host bridge [0600]: Filler Device [ffff:0000]'
+done
+SH
+
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+
+printf 'sudo' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+"$@"
+SH
+
+cat >"$stub_bin/systemctl" <<'SH'
+#!/bin/bash
+
+printf 'systemctl' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+case "$1" in
+  is-system-running) exit 1 ;;
+esac
+exit 0
+SH
+
+chmod +x "$stub_bin"/*
+
+run_leaf() {
+  local wifi_id="${1:-}" bt_id="${2:-}" t2="${3:-0}"
+  rm -rf "$systemd_dir"
+  mkdir -p "$systemd_dir" "$(dirname "$sleep_hook")"
+  printf 'legacy-hook\n' >"$sleep_hook"
+  : >"$calls"
+
+  WIFI_ID="$wifi_id" BT_ID="$bt_id" T2_HARDWARE="$t2" PATH="$stub_bin:$PATH" \
+    TEST_LOG="$calls" \
+    OMARCHY_PATH="$ROOT" \
+    OMARCHY_T2_BCM4377_SYSTEMD_DIR="$systemd_dir" \
+    OMARCHY_T2_BCM4377_SLEEP_HOOK="$sleep_hook" \
+    bash -eE -o pipefail -c 'source "$1"' bash "$leaf" </dev/null
+}
+
+run_leaf 4488 5fa0 1 >/dev/null
+[[ -f $systemd_dir/omarchy-t2-bcm4377-rebind.service ]] ||
+  fail "a BCM4377 machine gets the rebind unit"
+[[ -f $systemd_dir/omarchy-t2-bcm4377-suspend.service ]] ||
+  fail "a BCM4377 machine gets the suspend unit"
+cmp -s "$rebind_unit" "$systemd_dir/omarchy-t2-bcm4377-rebind.service" ||
+  fail "the installed rebind unit matches the packaged file"
+grep -Fq $'systemctl\tenable\tomarchy-t2-bcm4377-rebind.service' "$calls" ||
+  fail "the rebind unit is enabled" "$(cat "$calls")"
+grep -Fq $'systemctl\tenable\tomarchy-t2-bcm4377-suspend.service' "$calls" ||
+  fail "the suspend unit is enabled" "$(cat "$calls")"
+grep -Fq $'systemctl\tdisable\t--now\tt2-brcmfmac-suspend.service' "$calls" ||
+  fail "leftover community suspend units are disabled" "$(cat "$calls")"
+grep -Fq $'systemctl\tdisable\t--now\tbt-bcm4377-rebind.service' "$calls" ||
+  fail "leftover community rebind units are disabled" "$(cat "$calls")"
+[[ ! -e $sleep_hook ]] || fail "the leftover systemd-sleep hook is removed"
+! grep -Fq $'systemctl\tstart\tomarchy-t2-bcm4377-rebind.service' "$calls" ||
+  fail "ISO/chroot setup does not start the rebind oneshot" "$(cat "$calls")"
+pass "a BCM4377 machine gets the units and leftover workarounds are retired"
+
+run_leaf 4464 "" 1 >/dev/null
+[[ ! -e $systemd_dir/omarchy-t2-bcm4377-rebind.service ]] ||
+  fail "a T2 Mac without BCM4377 is left alone"
+[[ ! -s $calls ]] || fail "a T2 Mac without BCM4377 escalates nothing" "$(cat "$calls")"
+pass "a T2 Mac without BCM4377 is left alone"
+
+run_leaf "" "" 0 >/dev/null
+[[ ! -e $systemd_dir/omarchy-t2-bcm4377-suspend.service ]] ||
+  fail "unrelated hardware is left alone"
+pass "unrelated hardware is left alone"
+
+run_migration() {
+  local wifi_id="${1:-}" bt_id="${2:-}" t2="${3:-0}"
+  rm -rf "$systemd_dir"
+  mkdir -p "$systemd_dir" "$(dirname "$sleep_hook")"
+  printf 'legacy-hook\n' >"$sleep_hook"
+  : >"$calls"
+
+  WIFI_ID="$wifi_id" BT_ID="$bt_id" T2_HARDWARE="$t2" PATH="$stub_bin:$PATH" \
+    TEST_LOG="$calls" \
+    OMARCHY_PATH="$ROOT" \
+    OMARCHY_T2_BCM4377_SYSTEMD_DIR="$systemd_dir" \
+    OMARCHY_T2_BCM4377_SLEEP_HOOK="$sleep_hook" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+run_migration 4488 5fa0 1
+[[ -f $systemd_dir/omarchy-t2-bcm4377-rebind.service ]] ||
+  fail "the migration installs the rebind unit on existing BCM4377 installs"
+grep -Fq $'sudo\tenv' "$calls" ||
+  fail "the migration escalates to install machine-wide units" "$(cat "$calls")"
+grep -Fq $'systemctl\tenable\tomarchy-t2-bcm4377-suspend.service' "$calls" ||
+  fail "the migration enables the suspend unit" "$(cat "$calls")"
+[[ ! -e $sleep_hook ]] || fail "the migration removes the leftover sleep hook"
+pass "the migration repairs an existing BCM4377 install"
+
+run_migration 4464 "" 1
+[[ ! -e $systemd_dir/omarchy-t2-bcm4377-rebind.service ]] ||
+  fail "the migration skips T2 Macs without BCM4377"
+[[ ! -s $calls ]] || fail "the migration escalates nothing on other T2 chips" "$(cat "$calls")"
+pass "the migration skips T2 Macs without BCM4377"


### PR DESCRIPTION
Fixes #11264.

On MacBookAir9,1 (and other T2 machines with the BCM4377 combo chip) two things are broken out of the box even after `hci_bcm4377` is module-loaded:

1. **Bluetooth looks powered and finds nothing.** After boot, `hci0` exists, rfkill is clear, and BlueZ reports `Powered: yes` with `Class: 0x00000000`. HCI commands time out (`0x0c56`, `0x200b`). A scan returns zero devices. One PCI unbind/bind sets a real class (`0x006c010c`) and discovery works. The oneshot retries that rebind and treats an unset class as hung, because `Powered: yes` is a lie on this chip.

2. **Suspend never happens.** `brcmfmac` times out in `brcmf_pcie_pm_enter_D3` (`pci_pm_suspend` returns -5). logind retries every ~30s with the lid closed, so the machine stays awake and warm. Unloading `brcmfmac` first lets deep suspend work. `hci_bcm4377` has to go too: left bound it wakes hung and a minute later DPC-isolates the whole chip, taking Wi-Fi with it. Reloading `brcmfmac` the instant the machine wakes has hard-crashed this model; the reload waits 15s.

This is **not** every T2 Mac. Gate is the combo PCI IDs (`14e4:4488` Wi-Fi, `14e4:5fa0` Bluetooth), not the T2 bridge.

Unload is a `Before=sleep.target` oneshot so NetworkManager can release the iface. A systemd-sleep hook runs after user.slice is frozen, which is why `modprobe -r brcmfmac` can fail there, and why it races any existing sleep.target Wi-Fi unloader that reloads immediately on resume.

Existing community units (`t2-brcmfmac-suspend.service`, `bt-bcm4377-rebind.service`, `/usr/lib/systemd/system-sleep/t2-wifi-suspend`) are disabled/removed so they cannot fight the packaged path.

New installs get this from `install/hardware/apple/fix-t2-bcm4377.sh`. Existing installs get it from `migrations/1789234234.sh`.

Signed-off-by: Grok <grok@x.ai>