### PR TITLE
Enable Google BBR TCP congestion control and Fair Queueing (FQ)

### DIFF
--- a/etc/modules-load.d/bbr.conf
+++ b/etc/modules-load.d/bbr.conf
@@ -1,0 +1,2 @@
+# Load TCP BBR congestion control module
+tcp_bbr

--- a/etc/sysctl.d/99-omarchy-sysctl.conf
+++ b/etc/sysctl.d/99-omarchy-sysctl.conf
@@ -1,6 +1,12 @@
 # Solve common flakiness with SSH (MTU discovery on flaky links).
 net.ipv4.tcp_mtu_probing=1
 
+# Fair Queueing and Google BBR congestion control.
+# Models bottleneck bandwidth and round-trip propagation time to prevent
+# bufferbloat and avoid throughput collapse from Wi-Fi packet drops.
+net.core.default_qdisc=fq
+net.ipv4.tcp_congestion_control=bbr
+
 # Tune reclaim for swap on zram, which is orders of magnitude faster than the
 # disk swapfile these defaults assume.
 

--- a/etc/sysctl.d/99-omarchy-sysctl.conf
+++ b/etc/sysctl.d/99-omarchy-sysctl.conf
@@ -7,6 +7,14 @@ net.ipv4.tcp_mtu_probing=1
 net.core.default_qdisc=fq
 net.ipv4.tcp_congestion_control=bbr
 
+# Limit unsent data in local socket buffers to 16KB to prevent local bufferbloat
+# and preserve BBR's packet pacing accuracy.
+net.ipv4.tcp_notsent_lowat=16384
+
+# Prevent persistent TCP connections from dropping back to slow-start after idle periods.
+net.ipv4.tcp_slow_start_after_idle=0
+
+
 # Tune reclaim for swap on zram, which is orders of magnitude faster than the
 # disk swapfile these defaults assume.
 

--- a/migrations/1789235118.sh
+++ b/migrations/1789235118.sh
@@ -1,0 +1,4 @@
+echo "Enable Google BBR TCP congestion control and Fair Queueing"
+
+sudo modprobe tcp_bbr 2>/dev/null || true
+sudo sysctl -p /etc/sysctl.d/99-omarchy-sysctl.conf >/dev/null || true

--- a/test/shell.d/bbr-test.sh
+++ b/test/shell.d/bbr-test.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+sysctl_conf="$ROOT/etc/sysctl.d/99-omarchy-sysctl.conf"
+modules_conf="$ROOT/etc/modules-load.d/bbr.conf"
+
+grep -Eq '^[[:space:]]*net\.core\.default_qdisc[[:space:]]*=[[:space:]]*fq' "$sysctl_conf" || fail "default_qdisc is set to fq in 99-omarchy-sysctl.conf"
+pass "default_qdisc is set to fq"
+
+grep -Eq '^[[:space:]]*net\.ipv4\.tcp_congestion_control[[:space:]]*=[[:space:]]*bbr' "$sysctl_conf" || fail "tcp_congestion_control is set to bbr in 99-omarchy-sysctl.conf"
+pass "tcp_congestion_control is set to bbr"
+
+[[ -f $modules_conf ]] || fail "bbr.conf exists in etc/modules-load.d/"
+grep -Eq '^[[:space:]]*tcp_bbr[[:space:]]*$' "$modules_conf" || fail "tcp_bbr module is loaded in etc/modules-load.d/bbr.conf"
+pass "tcp_bbr is listed in etc/modules-load.d/bbr.conf"

--- a/test/shell.d/bbr-test.sh
+++ b/test/shell.d/bbr-test.sh
@@ -13,6 +13,13 @@ pass "default_qdisc is set to fq"
 grep -Eq '^[[:space:]]*net\.ipv4\.tcp_congestion_control[[:space:]]*=[[:space:]]*bbr' "$sysctl_conf" || fail "tcp_congestion_control is set to bbr in 99-omarchy-sysctl.conf"
 pass "tcp_congestion_control is set to bbr"
 
+grep -Eq '^[[:space:]]*net\.ipv4\.tcp_notsent_lowat[[:space:]]*=[[:space:]]*16384' "$sysctl_conf" || fail "tcp_notsent_lowat is set to 16384 in 99-omarchy-sysctl.conf"
+pass "tcp_notsent_lowat is set to 16384"
+
+grep -Eq '^[[:space:]]*net\.ipv4\.tcp_slow_start_after_idle[[:space:]]*=[[:space:]]*0' "$sysctl_conf" || fail "tcp_slow_start_after_idle is set to 0 in 99-omarchy-sysctl.conf"
+pass "tcp_slow_start_after_idle is set to 0"
+
+
 [[ -f $modules_conf ]] || fail "bbr.conf exists in etc/modules-load.d/"
 grep -Eq '^[[:space:]]*tcp_bbr[[:space:]]*$' "$modules_conf" || fail "tcp_bbr module is loaded in etc/modules-load.d/bbr.conf"
 pass "tcp_bbr is listed in etc/modules-load.d/bbr.conf"


### PR DESCRIPTION
## Summary

Enables Google BBR (Bottleneck Bandwidth and Round-trip propagation time) TCP congestion control and Fair Queueing (`fq` qdisc) by default on new and existing installations, paired with low-latency socket buffer pacing (`tcp_notsent_lowat = 16384`).

## Why

Linux defaults to the CUBIC congestion control algorithm. CUBIC was designed for wired networks and treats any packet loss as a signal of network congestion. On modern Wi-Fi and mobile connections, packet loss frequently occurs from transient radio interference or distance rather than queue exhaustion, causing CUBIC to aggressively cut throughput by up to 50% and introduce latency stalls.

BBR models the network's true bottleneck bandwidth and round-trip propagation time rather than reacting to packet loss. Paired with Fair Queueing (`fq`), it effectively mitigates bufferbloat on congested routers, sustains full throughput over lossy wireless links, and minimizes queueing latency.

To maximize BBR's packet pacing accuracy, this also tunes local TCP socket queuing:
- `net.ipv4.tcp_notsent_lowat = 16384`: Standard Linux allows local socket send buffers to balloon up to `UINT_MAX`, queuing megabytes of unsent data before handing off to the network card. Capping unsent data to 16KB eliminates local bufferbloat and allows BBR to maintain ultra-precise packet pacing.
- `net.ipv4.tcp_slow_start_after_idle = 0`: Prevents persistent HTTP/2, WebSocket, and SSH connections from dropping back into slow-start probing after brief pauses.

BBR and TCP socket pacing are standard across ChromeOS, Android, and high-performance Linux stacks.

## Change

- `etc/modules-load.d/bbr.conf`: Ensure the `tcp_bbr` module is loaded early during boot.
- `etc/sysctl.d/99-omarchy-sysctl.conf`: Set `net.core.default_qdisc=fq`, `net.ipv4.tcp_congestion_control=bbr`, `net.ipv4.tcp_notsent_lowat=16384`, and `net.ipv4.tcp_slow_start_after_idle=0`.
- `migrations/1789235118.sh`: Idempotently load `tcp_bbr` and apply the updated sysctl settings on existing installations.
- `test/shell.d/bbr-test.sh`: Add test assertions validating configuration, module declaration, and socket pacing sysctls.

## Verification

- `bash test/shell.d/bbr-test.sh` passes (all 5 assertions clean).
- `bash -n migrations/1789235118.sh` clean.
- Verified on real hardware: `sysctl net.ipv4.tcp_congestion_control` returns `bbr`, `sysctl net.core.default_qdisc` returns `fq`, and `sysctl net.ipv4.tcp_notsent_lowat` returns `16384`.