### PR TITLE
Mount Btrfs subvolumes with noatime to avoid unnecessary write amplification

### DIFF
--- a/install/post-install/all.sh
+++ b/install/post-install/all.sh
@@ -1,3 +1,4 @@
+run_logged "$OMARCHY_INSTALL/post-install/fstab.sh"
 run_logged "$OMARCHY_INSTALL/post-install/pacman.sh"
 run_logged "$OMARCHY_INSTALL/post-install/udev.sh"
 run_logged "$OMARCHY_INSTALL/post-install/localdb.sh"

--- a/install/post-install/fstab.sh
+++ b/install/post-install/fstab.sh
@@ -1,0 +1,6 @@
+# Archinstall writes Btrfs subvolume mounts with 'relatime'. In Btrfs, every
+# access-time update triggers Copy-on-Write metadata writes that fragment
+# snapshots and add write amplification to SSD/NVMe. Tune Btrfs mounts to 'noatime'.
+if [[ -f /etc/fstab ]]; then
+  sed -i '/[[:space:]]btrfs[[:space:]]/s/\brelatime\b/noatime/g' /etc/fstab
+fi

--- a/install/post-install/fstab.sh
+++ b/install/post-install/fstab.sh
@@ -1,6 +1,5 @@
-# Archinstall writes Btrfs subvolume mounts with 'relatime'. In Btrfs, every
-# access-time update triggers Copy-on-Write metadata writes that fragment
-# snapshots and add write amplification to SSD/NVMe. Tune Btrfs mounts to 'noatime'.
+# Archinstall writes Btrfs subvolume mounts with 'relatime'. Avoid access-time
+# metadata updates on Omarchy's read-heavy, snapshotted Btrfs layout.
 if [[ -f /etc/fstab ]]; then
   sed -i '/[[:space:]]btrfs[[:space:]]/s/\brelatime\b/noatime/g' /etc/fstab
 fi

--- a/migrations/1789235200.sh
+++ b/migrations/1789235200.sh
@@ -1,0 +1,11 @@
+echo "Tune Btrfs mounts to noatime"
+
+if [[ -f /etc/fstab ]] && grep -qE '[[:space:]]btrfs[[:space:]].*\brelatime\b' /etc/fstab; then
+  sudo cp -a /etc/fstab "/etc/fstab.$(date +%Y%m%d%H%M%S).bak"
+  sudo sed -i '/[[:space:]]btrfs[[:space:]]/s/\brelatime\b/noatime/g' /etc/fstab
+
+  # Remount active Btrfs mountpoints with noatime immediately
+  awk '$3 == "btrfs" && $4 ~ /\brelatime\b/ { print $2 }' /proc/mounts 2>/dev/null | while read -r mp; do
+    sudo mount -o remount,noatime "$mp" 2>/dev/null || true
+  done
+fi

--- a/migrations/1789235200.sh
+++ b/migrations/1789235200.sh
@@ -4,8 +4,5 @@ if [[ -f /etc/fstab ]] && grep -qE '[[:space:]]btrfs[[:space:]].*\brelatime\b' /
   sudo cp -a /etc/fstab "/etc/fstab.$(date +%Y%m%d%H%M%S).bak"
   sudo sed -i '/[[:space:]]btrfs[[:space:]]/s/\brelatime\b/noatime/g' /etc/fstab
 
-  # Remount active Btrfs mountpoints with noatime immediately
-  awk '$3 == "btrfs" && $4 ~ /\brelatime\b/ { print $2 }' /proc/mounts 2>/dev/null | while read -r mp; do
-    sudo mount -o remount,noatime "$mp" 2>/dev/null || true
-  done
+  echo "Btrfs noatime mounts will take effect after reboot"
 fi

--- a/test/shell.d/fstab-test.sh
+++ b/test/shell.d/fstab-test.sh
@@ -11,6 +11,13 @@ all_post_install="$ROOT/install/post-install/all.sh"
 grep -F 'run_logged "$OMARCHY_INSTALL/post-install/fstab.sh"' "$all_post_install" >/dev/null || fail "all.sh invokes fstab.sh"
 pass "post-install orchestrates fstab.sh"
 
+migration="$ROOT/migrations/1789235200.sh"
+[[ -f $migration ]] || fail "noatime migration exists"
+[[ ! -x $migration ]] || fail "migration must be mode 0644"
+bash -n "$migration" || fail "noatime migration has invalid shell syntax"
+grep -F 'mount -o remount' "$migration" >/dev/null && fail "migration remounts live filesystems"
+pass "migration defers mount changes until reboot"
+
 # Test fstab transformation on mock fstab
 tmp_dir=$(mktemp -d)
 trap 'rm -rf "$tmp_dir"' EXIT

--- a/test/shell.d/fstab-test.sh
+++ b/test/shell.d/fstab-test.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+fstab_post_install="$ROOT/install/post-install/fstab.sh"
+all_post_install="$ROOT/install/post-install/all.sh"
+
+[[ -f $fstab_post_install ]] || fail "fstab.sh exists in install/post-install/"
+grep -F 'run_logged "$OMARCHY_INSTALL/post-install/fstab.sh"' "$all_post_install" >/dev/null || fail "all.sh invokes fstab.sh"
+pass "post-install orchestrates fstab.sh"
+
+# Test fstab transformation on mock fstab
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+mock_fstab="$tmp_dir/fstab"
+cat << 'MOCK' > "$mock_fstab"
+# <file system> <dir> <type> <options> <dump> <pass>
+UUID=1111-2222	/	btrfs	rw,relatime,compress=zstd:3,subvol=/@	0 0
+UUID=1111-2222	/home	btrfs	rw,relatime,compress=zstd:3,subvol=/@home	0 0
+UUID=3333-4444	/boot	vfat	rw,relatime,fmask=0077,dmask=0077	0 2
+/swap/swapfile	none	swap	defaults,pri=0	0 0
+MOCK
+
+sed -i '/[[:space:]]btrfs[[:space:]]/s/\brelatime\b/noatime/g' "$mock_fstab"
+
+grep -F 'UUID=1111-2222	/	btrfs	rw,noatime,compress=zstd:3,subvol=/@	0 0' "$mock_fstab" >/dev/null || fail "root btrfs mount updated to noatime"
+pass "root btrfs mount updated to noatime"
+
+grep -F 'UUID=1111-2222	/home	btrfs	rw,noatime,compress=zstd:3,subvol=/@home	0 0' "$mock_fstab" >/dev/null || fail "home btrfs mount updated to noatime"
+pass "home btrfs mount updated to noatime"
+
+grep -F 'UUID=3333-4444	/boot	vfat	rw,relatime,fmask=0077,dmask=0077	0 2' "$mock_fstab" >/dev/null || fail "vfat boot mount remains unchanged"
+pass "non-btrfs mounts remain untouched"


### PR DESCRIPTION
## Summary

Configures Btrfs subvolumes in `/etc/fstab` to mount with `noatime` instead of `relatime` on new and existing installations.

## Why

The Btrfs documentation recommends considering `noatime` for read-intensive workloads because avoiding access-time metadata updates reduces writes; it specifically calls out the cost of `relatime` when files older than 24 hours are read after being snapshotted. CachyOS also ships `noatime` in its installer mount defaults.

Omarchy uses a read-heavy desktop workload and Snapper-backed Btrfs subvolumes, so `noatime` is a reasonable distribution default. This deliberately trades POSIX access-time updates for fewer metadata writes; applications that require accurate atime semantics would need an override.

References:

- https://btrfs.readthedocs.io/en/latest/ch-mount-options.html
- https://github.com/CachyOS/cachyos-calamares/blob/cachyos/src/modules/mount/mount.conf

## Changes

- `install/post-install/fstab.sh`: replace `relatime` with `noatime` for Btrfs entries during installation.
- `install/post-install/all.sh`: run the Btrfs fstab adjustment during post-install finalization.
- `migrations/1789235200.sh`: back up and update `/etc/fstab` idempotently on existing installations. The new options take effect after reboot rather than remounting live filesystems during an update.
- `test/shell.d/fstab-test.sh`: verify orchestration, migration safety, Btrfs-only transformation, and preservation of non-Btrfs entries.

## Verification

- `bash test/shell.d/fstab-test.sh` passes.
- `./test/cli` passes.
- `bash -n migrations/1789235200.sh` passes.
- Verified on live hardware that `/` and `/home` mount cleanly with `noatime` after reboot.
