### PR TITLE
Restore a window from the scratchpad to the active workspace

### DIFF
--- a/default/hypr/bindings/tiling.lua
+++ b/default/hypr/bindings/tiling.lua
@@ -30,6 +30,23 @@ o.bind("SUPER + ALT + S", "Move window to scratchpad", hl.dsp.window.move({ work
 o.bind("SUPER + grave", "Toggle scratchpad", hl.dsp.workspace.toggle_special("scratchpad"))
 o.bind("SUPER + SHIFT + grave", "Move window to scratchpad", hl.dsp.window.move({ workspace = "special:scratchpad", follow = false }))
 
+local function restore_window_from_scratchpad()
+  local window = hl.get_active_window()
+  if not window or not window.workspace or not window.workspace.special then
+    return
+  end
+
+  local workspace = hl.get_active_workspace()
+  if not workspace or workspace.special then
+    return
+  end
+
+  hl.dispatch(hl.dsp.window.move({ workspace = tostring(workspace.id) }))
+end
+
+o.bind("SUPER + SHIFT + ALT + S", "Restore window from scratchpad", restore_window_from_scratchpad)
+o.bind("SUPER + CTRL + grave", "Restore window from scratchpad", restore_window_from_scratchpad)
+
 o.bind("SUPER + TAB", "Next workspace", hl.dsp.focus({ workspace = "e+1" }))
 o.bind("SUPER + SHIFT + TAB", "Previous workspace", hl.dsp.focus({ workspace = "e-1" }))
 o.bind("SUPER + CTRL + TAB", "Former workspace", hl.dsp.focus({ workspace = "previous" }))

--- a/manual/07-hotkeys.md
+++ b/manual/07-hotkeys.md
@@ -28,6 +28,7 @@ You can see all the main keyboard bindings with `Super + K` (Tmux bindings with 
 | `Super + Shift + Alt + 1/2/3/4` | Move window to workspace without following |
 | `Super + S` / `Super + Grave` | Toggle scratchpad |
 | `Super + Alt + S` / `Super + Shift + Grave` | Move window to scratchpad |
+| `Super + Shift + Alt + S` / `Super + Ctrl + Grave` | Restore window from scratchpad |
 | `Super + Shift + Alt + Arrows` | Move workspaces to directional monitor |
 | `Super + Arrow`  | Move focus to window in direction of arrow              |
 | `Super + Shift + Arrow`  | Swap window with another in direction of arrow     |


### PR DESCRIPTION
`Super + Alt + S` throws a window into the scratchpad and nothing brings it back. Today the only way to get it onto the workspace you're on is to close it and start it over.

I live in the scratchpad — it's where my terminal and my chat sit between uses — so I hit this every day. Parking a window costs one key, getting it back costs a restart.

So: `Super + Shift + Alt + S` and `Super + Ctrl + Grave`. With a scratchpad window focused, the window moves to the active workspace and Hyprland hides the overlay on its own. Focus a normal window and nothing happens, so a stray keypress can't surprise anyone.

Both keys are free on `quattro`, and the callback follows the Lua-function bindings already in `utilities.lua` and `clipboard.lua`. The manual gets the matching row.

Ran it on Hyprland 0.56.2: the window lands on the active workspace, the scratchpad closes, and `hyprctl configerrors` stays quiet. Suggestion thread: #11542.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

