### PR TITLE
Disable tap-to-click by default

### DIFF
--- a/config/hypr/input.lua
+++ b/config/hypr/input.lua
@@ -29,6 +29,9 @@
 --       -- Use natural (inverse) scrolling.
 --       natural_scroll = true,
 --
+--       -- Allow tapping the pad to click (Omarchy default: off).
+--       tap_to_click = true,
+--
 --       -- Use two-finger clicks for right-click instead of lower-right corner.
 --       clickfinger_behavior = true,
 --

--- a/default/hypr/input.lua
+++ b/default/hypr/input.lua
@@ -65,6 +65,8 @@ hl.config({
       natural_scroll = false,
       clickfinger_behavior = true,
       scroll_factor = 0.4,
+      -- Physical click only; tapping the pad is not a button press.
+      tap_to_click = false,
     },
   },
 

--- a/manual/34-keyboard-mouse-trackpad.md
+++ b/manual/34-keyboard-mouse-trackpad.md
@@ -22,6 +22,9 @@ hl.config({
       -- Use natural (inverse) scrolling
       natural_scroll = true,
 
+      -- Allow tapping the pad to click (Omarchy default: off)
+      tap_to_click = true,
+
       -- Use two-finger clicks for right-click instead of lower-right corner
       clickfinger_behavior = true,
 
@@ -34,6 +37,8 @@ hl.config({
 -- Scroll faster in the terminal
 o.window("(Alacritty|kitty|foot)", { scroll_touchpad = 1.5 })
 ```
+
+Tap-to-click is off by default, so the trackpad only clicks on a physical press. Two-finger clicks still right-click. Turn tapping back on with `tap_to_click = true` as in the example above.
 
 You can [see all the input options](https://wiki.hypr.land/Configuring/Basics/Variables/#input) on the Hyprland wiki for inputs.
 

--- a/test/shell.d/hyprland-keyboard-layout-test.sh
+++ b/test/shell.d/hyprland-keyboard-layout-test.sh
@@ -83,3 +83,17 @@ lua_layouts=$(sed -n '/^local non_latin_layouts =/,+1p' "$input_lua" | grep -o '
 [[ $hooks_layouts == "$lua_layouts" ]] ||
   fail "non-latin layout lists stay in sync" "$(diff <(echo "$hooks_layouts") <(echo "$lua_layouts"))"
 pass "non-latin layout lists stay in sync with the initramfs hook"
+
+tap_to_click=$(OMARCHY_PATH="$ROOT" lua <<'LUA'
+package.path = os.getenv("OMARCHY_PATH") .. "/?.lua;" .. package.path
+hl = {
+  config = function(config)
+    print(tostring(config.input.touchpad.tap_to_click))
+  end,
+}
+o = { window = function() end }
+require("default.hypr.input")
+LUA
+)
+[[ $tap_to_click == "false" ]] || fail "package defaults disable tap-to-click" "$tap_to_click"
+pass "package defaults disable tap-to-click"


### PR DESCRIPTION
## Summary

- Turn tap-to-click off in the packaged Hyprland defaults so a light rest on the pad is not a click
- Document the opt-in in the user input template (`config/hypr/input.lua`, which seeds `/etc/skel`) and the keyboard/mouse/trackpad manual
- Leave physical clicks and two-finger clickfinger right-click as they are

Hyprland enables tapping by default. libinput does not, because accidental taps make the desktop feel buggy. Omarchy already overrides other Hyprland input defaults (`clickfinger_behavior`, `scroll_factor`); this is the same kind of opinionated default.

This belongs in `default/hypr/input.lua`, not only in skel. The user overlay in `~/.config/hypr/input.lua` is a stub of commented examples. Existing installs load the packaged defaults on every session, so changing that file is what actually turns tapping off for everyone on the next update. The `config/` template still documents how to turn it back on, and that is what new users get from `/etc/skel`.

No migration is needed: the packaged default applies on the next package update. Anyone who already set `tap_to_click` in their overlay keeps that override.

Re-enable with:

```lua
hl.config({
  input = {
    touchpad = {
      tap_to_click = true,
    },
  },
})
```

## Test plan

- [x] `bash test/shell.d/hyprland-keyboard-layout-test.sh` (includes the new default assertion)
- [x] Confirmed locally that `hyprctl getoption input:touchpad:tap-to-click` is `false` after setting this, and that physical clicks still work