### PR TITLE
Arbitrate MacBookPro11,5 dGPU to radeon

### DIFF
--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -42,6 +42,7 @@ run_logged "$OMARCHY_INSTALL/hardware/apple/fix-spi-keyboard.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-suspend-nvme.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-t2.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-brcmfmac-supplicant.sh"
+run_logged "$OMARCHY_INSTALL/hardware/apple/fix-radeon-si.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/lenovo/fix-yoga-pro7-bass-speakers.sh"
 

--- a/install/hardware/apple/fix-radeon-si.sh
+++ b/install/hardware/apple/fix-radeon-si.sh
@@ -1,0 +1,24 @@
+# MacBookPro11,5's Venus XT dGPU is Southern Islands: both radeon and
+# amdgpu claim it, and amdgpu's experimental SI support freezes these
+# machines (hard hangs running normally, black screen on switcheroo OFF).
+# Pin the arbitration to radeon, which binds cleanly and survives suspend
+# cycles. Verified on MacBookPro11,5 with radeon 2.51.0; MacBookPro11,4
+# carries the same dGPU and is the evident next candidate on field report.
+dmi_product="${OMARCHY_DMI_PRODUCT:-/sys/class/dmi/id/product_name}"
+limine_dir="${OMARCHY_LIMINE_ENTRY_TOOL_D:-/etc/limine-entry-tool.d}"
+dropin="$limine_dir/radeon-si.conf"
+
+product_name="$(cat "$dmi_product" 2>/dev/null || true)"
+
+if [[ $product_name == "MacBookPro11,5" ]]; then
+  echo "Detected MacBookPro11,5 dGPU; arbitrating Southern Islands to radeon"
+
+  [[ -d $limine_dir ]] || sudo mkdir -p "$limine_dir"
+  if [[ ! -f $dropin ]]; then
+    sudo tee "$dropin" >/dev/null <<'EOF'
+# MacBookPro11,5: Venus XT is Southern Islands; amdgpu's experimental SI
+# support hangs these machines, so pin the arbitration to radeon.
+KERNEL_CMDLINE[default]+=" radeon.si_support=1 amdgpu.si_support=0"
+EOF
+  fi
+fi

--- a/migrations/1789165591.sh
+++ b/migrations/1789165591.sh
@@ -1,0 +1,28 @@
+echo "Arbitrate MacBookPro11,5 dGPU to radeon"
+
+# See install/hardware/apple/fix-radeon-si.sh: amdgpu's experimental SI
+# support hangs these machines, so pin Southern Islands to radeon. The flags
+# only take effect in a rebuilt boot image, which is also what applies them
+# on fresh installs, so rebuild here -- but only when this run changed the
+# drop-in, and only ask for the reboot then.
+dmi_product="${OMARCHY_DMI_PRODUCT:-/sys/class/dmi/id/product_name}"
+limine_dir="${OMARCHY_LIMINE_ENTRY_TOOL_D:-/etc/limine-entry-tool.d}"
+dropin="$limine_dir/radeon-si.conf"
+
+product_name="$(cat "$dmi_product" 2>/dev/null || true)"
+[[ $product_name == "MacBookPro11,5" ]] || exit 0
+
+before=""
+[[ -f $dropin ]] && before=$(md5sum <"$dropin" 2>/dev/null || true)
+
+source "$OMARCHY_PATH/install/hardware/apple/fix-radeon-si.sh"
+
+after=""
+[[ -f $dropin ]] && after=$(md5sum <"$dropin" 2>/dev/null || true)
+
+if [[ -n $after && $before != "$after" ]]; then
+  if omarchy-cmd-present limine-mkinitcpio; then
+    sudo limine-mkinitcpio
+  fi
+  omarchy-state set reboot-required
+fi

--- a/test/shell.d/apple-radeon-si-test.sh
+++ b/test/shell.d/apple-radeon-si-test.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+leaf="$ROOT/install/hardware/apple/fix-radeon-si.sh"
+all="$ROOT/install/hardware/all.sh"
+migration="$ROOT/migrations/1789165591.sh"
+
+grep -Fq 'apple/fix-radeon-si.sh' "$all" ||
+  fail "the radeon SI quirk runs during hardware setup"
+pass "the radeon SI quirk runs during hardware setup"
+
+grep -Fq 'fix-radeon-si.sh' "$migration" ||
+  fail "the migration applies the radeon SI quirk" "$migration"
+pass "the migration applies the radeon SI quirk"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+calls="$test_tmp/calls.log"
+limine_dir="$test_tmp/etc/limine-entry-tool.d"
+conf="$limine_dir/radeon-si.conf"
+dmi_product="$test_tmp/dmi/product_name"
+mkdir -p "$stub_bin" "$test_tmp/dmi" "$limine_dir"
+
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+
+printf 'sudo' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+"$@"
+SH
+
+cat >"$stub_bin/omarchy-cmd-present" <<'SH'
+#!/bin/bash
+
+[[ $1 == limine-mkinitcpio ]] && (( ${LIMINE_MKINITCPIO:-1} == 1 ))
+SH
+
+cat >"$stub_bin/limine-mkinitcpio" <<'SH'
+#!/bin/bash
+
+echo 'limine-mkinitcpio' >>"$TEST_LOG"
+SH
+
+cat >"$stub_bin/omarchy-state" <<'SH'
+#!/bin/bash
+
+printf 'omarchy-state' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+SH
+
+chmod +x "$stub_bin"/*
+
+run_leaf() {
+  local product="$1" keep="${2:-0}"
+  if (( keep == 0 )); then
+    rm -rf "$test_tmp/etc"
+    mkdir -p "$limine_dir"
+  fi
+  printf '%s' "$product" >"$dmi_product"
+  : >"$calls"
+
+  OMARCHY_DMI_PRODUCT="$dmi_product" \
+    OMARCHY_LIMINE_ENTRY_TOOL_D="$limine_dir" \
+    PATH="$stub_bin:$PATH" TEST_LOG="$calls" \
+    bash -eE -o pipefail -c 'source "$1"' bash "$leaf" </dev/null
+}
+
+run_leaf "MacBookPro11,5" >/dev/null
+[[ -f $conf ]] || fail "an 11,5 gets the SI arbitration drop-in"
+grep -Fq 'radeon.si_support=1 amdgpu.si_support=0' "$conf" ||
+  fail "the drop-in pins SI to radeon" "$(cat "$conf")"
+pass "an 11,5 gets the SI arbitration drop-in"
+
+printf 'custom\n' >"$conf"
+run_leaf "MacBookPro11,5" 1 >/dev/null
+[[ $(<"$conf") == "custom" ]] || fail "an existing drop-in is not overwritten"
+pass "an existing drop-in is left in place"
+
+run_leaf "MacBookPro14,3" >/dev/null
+[[ ! -e $conf ]] || fail "other Macs are left alone"
+[[ ! -s $calls ]] || fail "other Macs escalate nothing" "$(cat "$calls")"
+pass "other Macs are left alone"
+
+run_leaf "ThinkPad X1" >/dev/null
+[[ ! -e $conf ]] || fail "non-Apple hardware is left alone"
+[[ ! -s $calls ]] || fail "non-Apple hardware escalates nothing" "$(cat "$calls")"
+pass "non-Apple hardware is left alone"
+
+run_migration() {
+  local product="$1"
+  printf '%s' "$product" >"$dmi_product"
+  : >"$calls"
+
+  OMARCHY_PATH="$ROOT" \
+    OMARCHY_DMI_PRODUCT="$dmi_product" \
+    OMARCHY_LIMINE_ENTRY_TOOL_D="$limine_dir" \
+    LIMINE_MKINITCPIO="${LIMINE_MKINITCPIO:-1}" \
+    PATH="$stub_bin:$PATH" TEST_LOG="$calls" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+rm -rf "$test_tmp/etc"
+mkdir -p "$limine_dir"
+run_migration "MacBookPro11,5"
+[[ -f $conf ]] || fail "the migration writes the drop-in on an 11,5"
+grep -Fxq 'limine-mkinitcpio' "$calls" ||
+  fail "the migration rebuilds the boot image when it changed the drop-in" "$(cat "$calls")"
+grep -Fq $'omarchy-state\tset\treboot-required' "$calls" ||
+  fail "the migration asks for the reboot that applies it" "$(cat "$calls")"
+pass "the migration installs and rebuilds on an 11,5"
+
+: >"$calls"
+run_migration "MacBookPro11,5"
+[[ ! -s $calls ]] || fail "a second run touches nothing" "$(cat "$calls")"
+pass "the migration is idempotent"
+
+run_migration "MacBookPro14,3"
+[[ ! -s $calls ]] || fail "the migration leaves other hardware alone" "$(cat "$calls")"
+pass "the migration leaves other hardware alone"


### PR DESCRIPTION
Related to #11382 (does not close it -- the power story stays open).

The 11,5's Venus XT is Southern Islands, claimed by both radeon and amdgpu. amdgpu's experimental SI support freezes these machines (hard hangs under normal use, black screen on switcheroo OFF -- both observed live), while radeon binds cleanly (2.51.0, zero errors) and survives suspend/resume cycles with working Wi-Fi.

- install/hardware/apple/fix-radeon-si.sh, gated on MacBookPro11,5: writes a limine drop-in with radeon.si_support=1 amdgpu.si_support=0. 11,4 carries the same dGPU and is the evident next candidate on field report; the gate stays narrow until one arrives.
- Wired into all.sh; migration 1789165591.sh sources the leaf for existing installs and rebuilds the boot image plus sets reboot-required only when this run changed the drop-in.
- test/shell.d/apple-radeon-si-test.sh 9/9 (gating, no-clobber, idempotent migration with change-guarded rebuild).

Proven live on MacBookPro11,5 across multiple boots and lid cycles, not just mocked -- including the failure modes that motivated it.