### PR TITLE
Set DefaultTimeoutStopSec=5s for systemd user session manager

### DIFF
--- a/bin/omarchy-upgrade-to-quattro
+++ b/bin/omarchy-upgrade-to-quattro
@@ -1229,6 +1229,7 @@ run_final_system_package_upgrade() {
     --overwrite '/etc/systemd/resolved.conf.d/20-docker-dns.conf' \
     --overwrite '/etc/systemd/system.conf.d/10-faster-shutdown.conf' \
     --overwrite '/etc/systemd/system/user@.service.d/10-faster-shutdown.conf' \
+    --overwrite '/etc/systemd/user.conf.d/10-faster-shutdown.conf' \
     --overwrite '/etc/systemd/system/docker.service.d/no-block-boot.conf' \
     --overwrite '/etc/systemd/system/plocate-updatedb.service.d/ac-only.conf' \
     --overwrite '/etc/systemd/system.conf.d/20-omarchy-nofile.conf' \

--- a/etc/systemd/user.conf.d/10-faster-shutdown.conf
+++ b/etc/systemd/user.conf.d/10-faster-shutdown.conf
@@ -1,0 +1,2 @@
+[Manager]
+DefaultTimeoutStopSec=5s

--- a/migrations/1789235400.sh
+++ b/migrations/1789235400.sh
@@ -1,0 +1,15 @@
+echo "Configure 5s shutdown timeout for user services"
+
+as_root() {
+  if (( EUID == 0 )); then
+    "$@"
+  else
+    sudo "$@"
+  fi
+}
+
+as_root mkdir -p /etc/systemd/user.conf.d
+cat << 'EOF' | as_root tee /etc/systemd/user.conf.d/10-faster-shutdown.conf >/dev/null
+[Manager]
+DefaultTimeoutStopSec=5s
+EOF

--- a/test/shell.d/systemd-test.sh
+++ b/test/shell.d/systemd-test.sh
@@ -104,3 +104,13 @@ pass "systemd-oomd acts on sustained memory stall"
 grep -Fx 'systemctl enable systemd-oomd.service' "$ROOT/install/config/enable-services.sh" >/dev/null ||
   fail "new installs ship the oomd drop-ins with the daemon that reads them disabled"
 pass "new installs enable systemd-oomd"
+
+user_shutdown_conf="$ROOT/etc/systemd/user.conf.d/10-faster-shutdown.conf"
+system_shutdown_conf="$ROOT/etc/systemd/system.conf.d/10-faster-shutdown.conf"
+[[ -f $user_shutdown_conf ]] || fail "user manager 10-faster-shutdown.conf exists"
+[[ -f $system_shutdown_conf ]] || fail "system manager 10-faster-shutdown.conf exists"
+grep -Fx 'DefaultTimeoutStopSec=5s' "$user_shutdown_conf" >/dev/null || fail "user manager sets 5s shutdown timeout"
+grep -Fx 'DefaultTimeoutStopSec=5s' "$system_shutdown_conf" >/dev/null || fail "system manager sets 5s shutdown timeout"
+grep -F '/etc/systemd/user.conf.d/10-faster-shutdown.conf' "$upgrade_to_quattro" >/dev/null || fail "upgrade-to-quattro overwrites user faster shutdown drop-in"
+pass "system and user managers enforce 5s shutdown timeout"
+


### PR DESCRIPTION
## Summary
Omarchy configures PID 1 (`/etc/systemd/system.conf.d/10-faster-shutdown.conf`) and the session slice (`/etc/systemd/system/user@.service.d/10-faster-shutdown.conf`) with a 5-second shutdown timeout.

However, `systemd --user` did not receive a matching drop-in in `/etc/systemd/user.conf.d/`, causing individual user units to retain systemd's compiled-in 90-second default timeout (`DefaultTimeoutStopSec=90s`). When an uncooperative user process (such as a hanging browser child process, language server, or Electron application) stalls during shutdown or logout, this mismatch causes PID 1 to ungracefully SIGKILL the parent `user@.service` after 5s rather than allowing the user manager to enforce its own 5s timeout and perform orderly unit shutdown.

## Changes
- Add `etc/systemd/user.conf.d/10-faster-shutdown.conf` with `DefaultTimeoutStopSec=5s`
- Add overwrite flag for `etc/systemd/user.conf.d/10-faster-shutdown.conf` in `bin/omarchy-upgrade-to-quattro`
- Add migration `migrations/1789235400.sh` to apply the drop-in on existing installations
- Add unit test in `test/shell.d/systemd-test.sh` to ensure both system and user managers configure the 5s timeout

## Verification
- `test/shell.d/systemd-test.sh` runs and all 14 assertions pass.

## Related issues

Related to #5832 and #7085. This PR only aligns the user manager's default unit timeout with Omarchy's existing 5-second outer session timeout; it does not change the shutdown sequencing discussed in those issues.

CachyOS uses the same system/user manager alignment at 10 seconds:

- https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/lib/systemd/system.conf.d/00-timeout.conf
- https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/lib/systemd/user.conf.d/00-timeout.conf
