### PR TITLE
Require GPU Screen Recorder 6.1.2

### DIFF
--- a/migrations/1789156273.sh
+++ b/migrations/1789156273.sh
@@ -25,17 +25,13 @@ if installed_package=$(LC_ALL=C pacman -Q "$package" 2>/dev/null); then
     fi
   fi
 else
-  if query_error=$(LC_ALL=C pacman -Q "$package" 2>&1); then
-    query_status=0
-  else
-    query_status=$?
-  fi
-
-  if (( query_status != 1 )) || [[ $query_error != "error: package '$package' was not found" ]]; then
-    echo "Could not determine the installed GPU Screen Recorder version; the migration will retry." >&2
-    if [[ -n $query_error ]]; then
-      echo "$query_error" >&2
+  if installed_packages=$(LC_ALL=C pacman -Qq 2>/dev/null); then
+    if grep -Fxq "$package" <<<"$installed_packages"; then
+      echo "Could not determine the installed GPU Screen Recorder version; the migration will retry." >&2
+      exit 1
     fi
+  else
+    echo "Could not determine the installed GPU Screen Recorder version; the migration will retry." >&2
     exit 1
   fi
 fi

--- a/migrations/1789156273.sh
+++ b/migrations/1789156273.sh
@@ -3,22 +3,39 @@ echo "Upgrade GPU Screen Recorder to v6.1.2 or newer"
 package="gpu-screen-recorder"
 minimum_version="6.1.2"
 
-if installed_package=$(pacman -Q "$package" 2>/dev/null); then
+if installed_package=$(LC_ALL=C pacman -Q "$package" 2>/dev/null); then
   installed_version=${installed_package#"$package "}
   if (( $(vercmp "$installed_version" "$minimum_version") < 0 )); then
     # omarchy-pkg-add skips packages that are already installed, so ask pacman
     # for the required minimum explicitly and stay pending if it is unavailable.
     sudo pacman -S --noconfirm --needed "$package>=$minimum_version"
 
-    if installed_package=$(pacman -Q "$package" 2>/dev/null); then
+    if installed_package=$(LC_ALL=C pacman -Q "$package" 2>/dev/null); then
       installed_version=${installed_package#"$package "}
       if (( $(vercmp "$installed_version" "$minimum_version") < 0 )); then
         echo "GPU Screen Recorder v${minimum_version} or newer is required; v${installed_version} is still installed." >&2
         exit 1
       fi
     else
-      echo "GPU Screen Recorder is missing after its required upgrade." >&2
+      echo "Could not verify GPU Screen Recorder after its required upgrade." >&2
+      if [[ -n $installed_package ]]; then
+        echo "$installed_package" >&2
+      fi
       exit 1
     fi
+  fi
+else
+  if query_error=$(LC_ALL=C pacman -Q "$package" 2>&1); then
+    query_status=0
+  else
+    query_status=$?
+  fi
+
+  if (( query_status != 1 )) || [[ $query_error != "error: package '$package' was not found" ]]; then
+    echo "Could not determine the installed GPU Screen Recorder version; the migration will retry." >&2
+    if [[ -n $query_error ]]; then
+      echo "$query_error" >&2
+    fi
+    exit 1
   fi
 fi

--- a/migrations/1789156273.sh
+++ b/migrations/1789156273.sh
@@ -4,11 +4,18 @@ package="gpu-screen-recorder"
 minimum_version="6.1.2"
 
 if installed_package=$(LC_ALL=C pacman -Q "$package" 2>/dev/null); then
+  installed_name=${installed_package% *}
   installed_version=${installed_package##* }
   if (( $(vercmp "$installed_version" "$minimum_version") < 0 )); then
     # omarchy-pkg-add skips packages that are already installed, so ask pacman
     # for the required minimum explicitly and stay pending if it is unavailable.
-    sudo pacman -S --noconfirm --needed "$package>=$minimum_version"
+    if [[ $installed_name == "$package" ]]; then
+      sudo pacman -S --noconfirm --needed "$package>=$minimum_version"
+    else
+      # Providers conflict with the packaged recorder. Answer pacman's removal
+      # question so the replacement happens in one dependency-safe transaction.
+      sudo pacman -S --noconfirm --ask 4 --needed "$package>=$minimum_version"
+    fi
 
     if installed_package=$(LC_ALL=C pacman -Q "$package" 2>/dev/null); then
       installed_version=${installed_package##* }

--- a/migrations/1789156273.sh
+++ b/migrations/1789156273.sh
@@ -4,14 +4,14 @@ package="gpu-screen-recorder"
 minimum_version="6.1.2"
 
 if installed_package=$(LC_ALL=C pacman -Q "$package" 2>/dev/null); then
-  installed_version=${installed_package#"$package "}
+  installed_version=${installed_package##* }
   if (( $(vercmp "$installed_version" "$minimum_version") < 0 )); then
     # omarchy-pkg-add skips packages that are already installed, so ask pacman
     # for the required minimum explicitly and stay pending if it is unavailable.
     sudo pacman -S --noconfirm --needed "$package>=$minimum_version"
 
     if installed_package=$(LC_ALL=C pacman -Q "$package" 2>/dev/null); then
-      installed_version=${installed_package#"$package "}
+      installed_version=${installed_package##* }
       if (( $(vercmp "$installed_version" "$minimum_version") < 0 )); then
         echo "GPU Screen Recorder v${minimum_version} or newer is required; v${installed_version} is still installed." >&2
         exit 1
@@ -25,12 +25,10 @@ if installed_package=$(LC_ALL=C pacman -Q "$package" 2>/dev/null); then
     fi
   fi
 else
-  if installed_packages=$(LC_ALL=C pacman -Qq 2>/dev/null); then
-    if grep -Fxq "$package" <<<"$installed_packages"; then
-      echo "Could not determine the installed GPU Screen Recorder version; the migration will retry." >&2
-      exit 1
-    fi
-  else
+  if missing_dependencies=$(LC_ALL=C pacman -T "$package" 2>/dev/null); then
+    echo "Could not determine the installed GPU Screen Recorder version; the migration will retry." >&2
+    exit 1
+  elif ! grep -Fxq "$package" <<<"$missing_dependencies"; then
     echo "Could not determine the installed GPU Screen Recorder version; the migration will retry." >&2
     exit 1
   fi

--- a/migrations/1789156273.sh
+++ b/migrations/1789156273.sh
@@ -1,0 +1,24 @@
+echo "Upgrade GPU Screen Recorder to v6.1.2 or newer"
+
+package="gpu-screen-recorder"
+minimum_version="6.1.2"
+
+if installed_package=$(pacman -Q "$package" 2>/dev/null); then
+  installed_version=${installed_package#"$package "}
+  if (( $(vercmp "$installed_version" "$minimum_version") < 0 )); then
+    # omarchy-pkg-add skips packages that are already installed, so ask pacman
+    # for the required minimum explicitly and stay pending if it is unavailable.
+    sudo pacman -S --noconfirm --needed "$package>=$minimum_version"
+
+    if installed_package=$(pacman -Q "$package" 2>/dev/null); then
+      installed_version=${installed_package#"$package "}
+      if (( $(vercmp "$installed_version" "$minimum_version") < 0 )); then
+        echo "GPU Screen Recorder v${minimum_version} or newer is required; v${installed_version} is still installed." >&2
+        exit 1
+      fi
+    else
+      echo "GPU Screen Recorder is missing after its required upgrade." >&2
+      exit 1
+    fi
+  fi
+fi

--- a/test/acceptance.d/system-test.sh
+++ b/test/acceptance.d/system-test.sh
@@ -24,6 +24,22 @@ verify_core_packages() {
   pass "all Omarchy core packages are installed (${#missing[@]} missing)"
 }
 
+verify_core_package_versions() {
+  local package="gpu-screen-recorder"
+  local minimum_version="6.1.2"
+  local installed_package installed_version
+
+  if installed_package=$(LC_ALL=C pacman -Q "$package" 2>/dev/null); then
+    installed_version=${installed_package#"$package "}
+  else
+    fail "GPU Screen Recorder meets its minimum version" "$package is not installed"
+  fi
+
+  (( $(vercmp "$installed_version" "$minimum_version") >= 0 )) ||
+    fail "GPU Screen Recorder meets its minimum version" "v${minimum_version} or newer is required; v${installed_version} is installed"
+  pass "GPU Screen Recorder meets its minimum version (v${installed_version})"
+}
+
 verify_defaults() {
   [[ $(omarchy-default-browser) == "chromium" ]] || fail "Chromium is the default browser"
   pass "Chromium is the default browser"
@@ -112,7 +128,7 @@ verify_user_setup() {
   pass "Omarchy user state and shell configuration exist"
 }
 
-for check in verify_core_packages verify_defaults verify_services verify_runtime_tools verify_user_setup; do
+for check in verify_core_packages verify_core_package_versions verify_defaults verify_services verify_runtime_tools verify_user_setup; do
   if ! ("$check"); then
     status=1
   fi

--- a/test/acceptance.d/system-test.sh
+++ b/test/acceptance.d/system-test.sh
@@ -30,7 +30,7 @@ verify_core_package_versions() {
   local installed_package installed_version
 
   if installed_package=$(LC_ALL=C pacman -Q "$package" 2>/dev/null); then
-    installed_version=${installed_package#"$package "}
+    installed_version=${installed_package##* }
   else
     fail "GPU Screen Recorder meets its minimum version" "$package is not installed"
   fi

--- a/test/shell.d/gpu-screen-recorder-migration-test.sh
+++ b/test/shell.d/gpu-screen-recorder-migration-test.sh
@@ -29,6 +29,14 @@ case "$1" in
       exit 1
     fi
     ;;
+  -Qq)
+    if [[ ${PACKAGE_LIST_QUERY_ERROR:-} == "true" ]]; then
+      echo "error: failed to read the local package database" >&2
+      exit 2
+    elif [[ -f $PACKAGE_STATE ]]; then
+      echo "gpu-screen-recorder"
+    fi
+    ;;
   -S)
     printf '%s' "$PACKAGE_UPGRADE_VERSION" >"$PACKAGE_STATE"
     ;;
@@ -70,13 +78,20 @@ run_migration ""
 [[ ! -s $sudo_log ]] || fail "the migration reinstalls a removed recorder" "$(<"$sudo_log")"
 pass "the migration leaves a removed recorder alone"
 
-if PACKAGE_QUERY_ERROR=true run_migration ""; then
+if PACKAGE_QUERY_ERROR=true run_migration "6.1.1-1"; then
   fail "the migration accepts a failed package query"
 fi
 grep -Fq "Could not determine the installed GPU Screen Recorder version" "$output" ||
   fail "the migration explains that a failed package query will retry" "$(<"$output")"
 [[ ! -s $sudo_log ]] || fail "the migration upgrades after a failed package query" "$(<"$sudo_log")"
 pass "the migration remains pending when the package query fails"
+
+if PACKAGE_QUERY_ERROR=true PACKAGE_LIST_QUERY_ERROR=true run_migration ""; then
+  fail "the migration accepts an unreadable package database"
+fi
+grep -Fq "Could not determine the installed GPU Screen Recorder version" "$output" ||
+  fail "the migration explains that an unreadable package database will retry" "$(<"$output")"
+pass "the migration remains pending when the package database cannot be listed"
 
 for installed_version in 6.1.2-1 6.2.0-1; do
   run_migration "$installed_version"

--- a/test/shell.d/gpu-screen-recorder-migration-test.sh
+++ b/test/shell.d/gpu-screen-recorder-migration-test.sh
@@ -42,6 +42,10 @@ case "$1" in
     fi
     ;;
   -S)
+    if [[ -f $PACKAGE_NAME_STATE && $(<"$PACKAGE_NAME_STATE") != "gpu-screen-recorder" && " $* " != *" --ask 4 "* ]]; then
+      echo "error: unresolvable package conflicts detected" >&2
+      exit 1
+    fi
     printf 'gpu-screen-recorder' >"$PACKAGE_NAME_STATE"
     printf '%s' "$PACKAGE_UPGRADE_VERSION" >"$PACKAGE_STATE"
     ;;
@@ -110,6 +114,15 @@ pass "the migration leaves supported recorder releases alone"
 run_migration "6.1.2.r1.gdeadbeef-1" "6.1.2-1" "gpu-screen-recorder-git"
 [[ ! -s $sudo_log ]] || fail "the migration replaces a supported recorder provider" "$(<"$sudo_log")"
 pass "the migration leaves a supported recorder provider alone"
+
+run_migration "6.1.1.r1.gdeadbeef-1" "6.1.2-1" "gpu-screen-recorder-git"
+grep -qxF $'pacman\t-S\t--noconfirm\t--ask\t4\t--needed\tgpu-screen-recorder>=6.1.2' "$sudo_log" ||
+  fail "the migration does not approve replacing an older recorder provider" "$(<"$sudo_log")"
+[[ $(<"$package_name_state") == "gpu-screen-recorder" ]] ||
+  fail "the migration leaves an older recorder provider installed" "$(<"$package_name_state")"
+[[ $(<"$package_state") == "6.1.2-1" ]] ||
+  fail "the migration does not install the required recorder release after replacing a provider" "$(<"$package_state")"
+pass "the migration replaces an older recorder provider"
 
 run_migration "6.1.1-1"
 grep -qxF $'pacman\t-S\t--noconfirm\t--needed\tgpu-screen-recorder>=6.1.2' "$sudo_log" ||

--- a/test/shell.d/gpu-screen-recorder-migration-test.sh
+++ b/test/shell.d/gpu-screen-recorder-migration-test.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+migration="$ROOT/migrations/1789156273.sh"
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+package_state="$test_tmp/package-version"
+sudo_log="$test_tmp/sudo.log"
+output="$test_tmp/output"
+mkdir -p "$stub_bin"
+
+cat >"$stub_bin/pacman" <<'STUB'
+#!/bin/bash
+
+case "$1" in
+  -Q)
+    [[ $2 == "gpu-screen-recorder" && -f $PACKAGE_STATE ]] || exit 1
+    printf 'gpu-screen-recorder %s\n' "$(<"$PACKAGE_STATE")"
+    ;;
+  -S)
+    printf '%s' "$PACKAGE_UPGRADE_VERSION" >"$PACKAGE_STATE"
+    ;;
+  *)
+    exit 2
+    ;;
+esac
+STUB
+
+cat >"$stub_bin/sudo" <<'STUB'
+#!/bin/bash
+
+printf '%s' "$1" >>"$SUDO_LOG"
+shift
+printf '\t%s' "$@" >>"$SUDO_LOG"
+printf '\n' >>"$SUDO_LOG"
+exec pacman "$@"
+STUB
+
+chmod +x "$stub_bin/pacman" "$stub_bin/sudo"
+
+run_migration() {
+  local installed_version="$1"
+  local upgrade_version="${2:-6.1.2-1}"
+
+  : >"$sudo_log"
+  : >"$output"
+  if [[ -n $installed_version ]]; then
+    printf '%s' "$installed_version" >"$package_state"
+  else
+    rm -f "$package_state"
+  fi
+
+  PACKAGE_STATE="$package_state" PACKAGE_UPGRADE_VERSION="$upgrade_version" SUDO_LOG="$sudo_log" \
+    PATH="$stub_bin:/usr/bin" bash -euo pipefail "$migration" >"$output" 2>&1
+}
+
+run_migration ""
+[[ ! -s $sudo_log ]] || fail "the migration reinstalls a removed recorder" "$(<"$sudo_log")"
+pass "the migration leaves a removed recorder alone"
+
+for installed_version in 6.1.2-1 6.2.0-1; do
+  run_migration "$installed_version"
+  [[ ! -s $sudo_log ]] || fail "the migration reinstalls a supported recorder" "$(<"$sudo_log")"
+done
+pass "the migration leaves supported recorder releases alone"
+
+run_migration "6.1.1-1"
+grep -qxF $'pacman\t-S\t--noconfirm\t--needed\tgpu-screen-recorder>=6.1.2' "$sudo_log" ||
+  fail "the migration upgrades an older recorder" "$(<"$sudo_log")"
+[[ $(<"$package_state") == "6.1.2-1" ]] ||
+  fail "the migration installs the required recorder release" "$(<"$package_state")"
+pass "the migration upgrades an older recorder"
+
+if run_migration "6.1.1-1" "6.1.1-2"; then
+  fail "the migration accepts a recorder that remains below v6.1.2"
+fi
+grep -Fq "v6.1.2 or newer is required; v6.1.1-2 is still installed" "$output" ||
+  fail "the migration explains why the upgrade remains pending" "$(<"$output")"
+pass "the migration remains pending until the required release is installed"

--- a/test/shell.d/gpu-screen-recorder-migration-test.sh
+++ b/test/shell.d/gpu-screen-recorder-migration-test.sh
@@ -9,6 +9,7 @@ test_tmp=$(mktemp -d)
 trap 'rm -rf "$test_tmp"' EXIT
 
 stub_bin="$test_tmp/bin"
+package_name_state="$test_tmp/package-name"
 package_state="$test_tmp/package-version"
 sudo_log="$test_tmp/sudo.log"
 output="$test_tmp/output"
@@ -23,21 +24,25 @@ case "$1" in
       echo "error: failed to read the local package database" >&2
       exit 2
     elif [[ $2 == "gpu-screen-recorder" && -f $PACKAGE_STATE ]]; then
-      printf 'gpu-screen-recorder %s\n' "$(<"$PACKAGE_STATE")"
+      printf '%s %s\n' "$(<"$PACKAGE_NAME_STATE")" "$(<"$PACKAGE_STATE")"
     else
       echo "error: package 'gpu-screen-recorder' was not found" >&2
       exit 1
     fi
     ;;
-  -Qq)
-    if [[ ${PACKAGE_LIST_QUERY_ERROR:-} == "true" ]]; then
+  -T)
+    if [[ ${PACKAGE_DEPTEST_ERROR:-} == "true" ]]; then
       echo "error: failed to read the local package database" >&2
       exit 2
     elif [[ -f $PACKAGE_STATE ]]; then
-      echo "gpu-screen-recorder"
+      exit 0
+    else
+      echo "$2"
+      exit 127
     fi
     ;;
   -S)
+    printf 'gpu-screen-recorder' >"$PACKAGE_NAME_STATE"
     printf '%s' "$PACKAGE_UPGRADE_VERSION" >"$PACKAGE_STATE"
     ;;
   *)
@@ -61,16 +66,19 @@ chmod +x "$stub_bin/pacman" "$stub_bin/sudo"
 run_migration() {
   local installed_version="$1"
   local upgrade_version="${2:-6.1.2-1}"
+  local installed_name="${3:-gpu-screen-recorder}"
 
   : >"$sudo_log"
   : >"$output"
   if [[ -n $installed_version ]]; then
+    printf '%s' "$installed_name" >"$package_name_state"
     printf '%s' "$installed_version" >"$package_state"
   else
+    rm -f "$package_name_state"
     rm -f "$package_state"
   fi
 
-  PACKAGE_STATE="$package_state" PACKAGE_UPGRADE_VERSION="$upgrade_version" SUDO_LOG="$sudo_log" \
+  PACKAGE_NAME_STATE="$package_name_state" PACKAGE_STATE="$package_state" PACKAGE_UPGRADE_VERSION="$upgrade_version" SUDO_LOG="$sudo_log" \
     PATH="$stub_bin:/usr/bin" bash -euo pipefail "$migration" >"$output" 2>&1
 }
 
@@ -78,26 +86,30 @@ run_migration ""
 [[ ! -s $sudo_log ]] || fail "the migration reinstalls a removed recorder" "$(<"$sudo_log")"
 pass "the migration leaves a removed recorder alone"
 
-if PACKAGE_QUERY_ERROR=true run_migration "6.1.1-1"; then
-  fail "the migration accepts a failed package query"
+if PACKAGE_QUERY_ERROR=true run_migration "6.1.2.r1.gdeadbeef-1" "6.1.2-1" "gpu-screen-recorder-git"; then
+  fail "the migration accepts a failed provider package query"
 fi
 grep -Fq "Could not determine the installed GPU Screen Recorder version" "$output" ||
   fail "the migration explains that a failed package query will retry" "$(<"$output")"
 [[ ! -s $sudo_log ]] || fail "the migration upgrades after a failed package query" "$(<"$sudo_log")"
-pass "the migration remains pending when the package query fails"
+pass "the migration remains pending when a provider package query fails"
 
-if PACKAGE_QUERY_ERROR=true PACKAGE_LIST_QUERY_ERROR=true run_migration ""; then
+if PACKAGE_QUERY_ERROR=true PACKAGE_DEPTEST_ERROR=true run_migration ""; then
   fail "the migration accepts an unreadable package database"
 fi
 grep -Fq "Could not determine the installed GPU Screen Recorder version" "$output" ||
   fail "the migration explains that an unreadable package database will retry" "$(<"$output")"
-pass "the migration remains pending when the package database cannot be listed"
+pass "the migration remains pending when package dependencies cannot be checked"
 
 for installed_version in 6.1.2-1 6.2.0-1; do
   run_migration "$installed_version"
   [[ ! -s $sudo_log ]] || fail "the migration reinstalls a supported recorder" "$(<"$sudo_log")"
 done
 pass "the migration leaves supported recorder releases alone"
+
+run_migration "6.1.2.r1.gdeadbeef-1" "6.1.2-1" "gpu-screen-recorder-git"
+[[ ! -s $sudo_log ]] || fail "the migration replaces a supported recorder provider" "$(<"$sudo_log")"
+pass "the migration leaves a supported recorder provider alone"
 
 run_migration "6.1.1-1"
 grep -qxF $'pacman\t-S\t--noconfirm\t--needed\tgpu-screen-recorder>=6.1.2' "$sudo_log" ||

--- a/test/shell.d/gpu-screen-recorder-migration-test.sh
+++ b/test/shell.d/gpu-screen-recorder-migration-test.sh
@@ -19,8 +19,15 @@ cat >"$stub_bin/pacman" <<'STUB'
 
 case "$1" in
   -Q)
-    [[ $2 == "gpu-screen-recorder" && -f $PACKAGE_STATE ]] || exit 1
-    printf 'gpu-screen-recorder %s\n' "$(<"$PACKAGE_STATE")"
+    if [[ ${PACKAGE_QUERY_ERROR:-} == "true" ]]; then
+      echo "error: failed to read the local package database" >&2
+      exit 2
+    elif [[ $2 == "gpu-screen-recorder" && -f $PACKAGE_STATE ]]; then
+      printf 'gpu-screen-recorder %s\n' "$(<"$PACKAGE_STATE")"
+    else
+      echo "error: package 'gpu-screen-recorder' was not found" >&2
+      exit 1
+    fi
     ;;
   -S)
     printf '%s' "$PACKAGE_UPGRADE_VERSION" >"$PACKAGE_STATE"
@@ -62,6 +69,14 @@ run_migration() {
 run_migration ""
 [[ ! -s $sudo_log ]] || fail "the migration reinstalls a removed recorder" "$(<"$sudo_log")"
 pass "the migration leaves a removed recorder alone"
+
+if PACKAGE_QUERY_ERROR=true run_migration ""; then
+  fail "the migration accepts a failed package query"
+fi
+grep -Fq "Could not determine the installed GPU Screen Recorder version" "$output" ||
+  fail "the migration explains that a failed package query will retry" "$(<"$output")"
+[[ ! -s $sudo_log ]] || fail "the migration upgrades after a failed package query" "$(<"$sudo_log")"
+pass "the migration remains pending when the package query fails"
 
 for installed_version in 6.1.2-1 6.2.0-1; do
   run_migration "$installed_version"


### PR DESCRIPTION
## Summary

- Upgrade existing GPU Screen Recorder installations below v6.1.2
- Verify the required version before completing the migration
- Leave removed and already-supported installations unchanged

## Testing

- bash test/shell.d/gpu-screen-recorder-migration-test.sh
- bash -n migrations/1789156273.sh test/shell.d/gpu-screen-recorder-migration-test.sh

Reported-by: lain.ovh (reserach@lain.ovh)