### PR TITLE
Scope LocalSend firewall rule to private network ranges

### DIFF
--- a/install/config/firewall.sh
+++ b/install/config/firewall.sh
@@ -2,9 +2,14 @@
 ufw default deny incoming
 ufw default allow outgoing
 
-# Allow ports for LocalSend.
-ufw allow 53317/udp
-ufw allow 53317/tcp
+# Allow ports for LocalSend, scoped to private network ranges rather than
+# the whole internet. IPv6 addresses are frequently globally routable
+# without NAT, so an unscoped rule would expose the receiver beyond the
+# local network on many home/mobile connections.
+for net in 192.168.0.0/16 10.0.0.0/8 172.16.0.0/12; do
+  ufw allow from "$net" to any port 53317 proto tcp
+  ufw allow from "$net" to any port 53317 proto udp
+done
 
 # Allow Docker containers to use DNS on host.
 ufw allow in proto udp from 172.16.0.0/12 to 172.17.0.1 port 53 comment 'allow-docker-dns'


### PR DESCRIPTION
## Summary
- The default ufw rule for LocalSend (port 53317) allowed inbound traffic from `Anywhere`, including IPv6
- IPv6 addresses are frequently globally routable without NAT, so the unscoped rule could expose the LocalSend receiver to the public internet rather than just the local network the feature is intended for
- Scopes the rule to RFC1918 private ranges instead, matching the pattern already used by the existing Docker DNS rules in the same file

Fixes #11560

## Test plan
- [ ] Fresh install with this change, confirm `sudo ufw status verbose` shows the 53317 rules scoped to the three private ranges instead of `Anywhere`
- [ ] Confirm LocalSend still works for transfers between two devices on the same local network

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cj33gnpMqCKJ61t2rcqKZf