### PR TITLE
Make screen recording stop single-flight and prevent duplicate toasts (#11508)

### DIFF
--- a/bin/omarchy-capture-screenrecording
+++ b/bin/omarchy-capture-screenrecording
@@ -35,6 +35,7 @@ RESOLUTION=""
 FULLSCREEN="false"
 STOP_RECORDING="false"
 RECORDING_FILE="/tmp/omarchy-screenrecord-filename"
+STOP_LOCK="${XDG_RUNTIME_DIR:-/tmp}/omarchy-screenrecord-stop.lock"
 REGION_FILE="${XDG_RUNTIME_DIR:-/tmp}/omarchy-screenrecord-region"
 LOG_FILE=$([[ ${OMARCHY_SCREENRECORD_DEBUG:-false} == "true" ]] && echo "/tmp/omarchy-screenrecord.log" || echo "/dev/null")
 
@@ -202,6 +203,9 @@ start_screenrecording() {
 }
 
 stop_screenrecording() {
+  exec {lock_fd}>"$STOP_LOCK"
+  flock -n "$lock_fd" || return 0
+
   pkill -SIGINT -f "^gpu-screen-recorder" # SIGINT required to save video properly
 
   # Wait a maximum of 5 seconds to finish before hard killing
@@ -220,23 +224,25 @@ stop_screenrecording() {
   else
     finalize_recording
     local filename=$(cat "$RECORDING_FILE" 2>/dev/null)
-    echo "$filename"
-    local preview="${filename%.mp4}-preview.png"
+    if [[ -n $filename && -f $filename ]]; then
+      echo "$filename"
+      local preview="${filename%.mp4}-preview.png"
 
-    # Generate a preview thumbnail from the first frame
-    ffmpeg -y -i "$filename" -ss 00:00:00.1 -vframes 1 -q:v 2 "$preview" -loglevel quiet 2>/dev/null
+      # Generate a preview thumbnail from the first frame
+      ffmpeg -y -i "$filename" -ss 00:00:00.1 -vframes 1 -q:v 2 "$preview" -loglevel quiet 2>/dev/null
 
-    omarchy-notification-send "Screen recording saved" "Open with Super + Alt + , (or click this)" \
-      -t 10000 --image "${preview:-$filename}" \
-      --exec mpv -- "$filename"
+      omarchy-notification-send "Screen recording saved" "Open with Super + Alt + , (or click this)" \
+        -t 10000 --image "${preview:-$filename}" \
+        --exec mpv -- "$filename"
 
-    # The shell loads the thumbnail into memory when the toast appears and never
-    # re-reads the file, so the preview only has to outlive that load -- not the
-    # toast. Clear it out of the recordings directory a moment later.
-    (
-      sleep 2
-      rm -f "$preview"
-    ) &
+      # The shell loads the thumbnail into memory when the toast appears and never
+      # re-reads the file, so the preview only has to outlive that load -- not the
+      # toast. Clear it out of the recordings directory a moment later.
+      (
+        sleep 2
+        rm -f "$preview"
+      ) &
+    fi
   fi
 
   rm -f "$RECORDING_FILE"

--- a/test/shell.d/screenrecording-test.sh
+++ b/test/shell.d/screenrecording-test.sh
@@ -299,3 +299,26 @@ grep -F 'move = { "(monitor_w-monitor_h*2/9-40)", "(monitor_h-monitor_h/4-40)" }
 grep -F 'move = { "(monitor_w-monitor_h*3/10-40)", "(monitor_h-monitor_h*27/80-40)" }' "$webcam_rules" >/dev/null || \
   fail "large webcam starts at its final corner position"
 pass "webcam size rules place the initial window in its final corner"
+
+# Test stop_screenrecording ignores invocations when stop lock is held or recording file is missing
+stop_lock="$tmp_dir/omarchy-screenrecord-stop.lock"
+rm -f "$stop_lock" "$tmp_dir/notification-args"
+(
+  exec {fd}>"$stop_lock"
+  flock -n "$fd"
+  # While lock is held in background, invoking screenrecording --stop-recording should exit immediately
+  # and not send any notification or block
+  "$ROOT/bin/omarchy-capture-screenrecording" --stop-recording || true
+)
+if [[ -s "$tmp_dir/notification-args" ]]; then
+  fail "stop_screenrecording does not notify when stop lock is held"
+fi
+pass "stop_screenrecording respects single-flight lock"
+
+# When not locked but recording file is missing/empty, stop_screenrecording does not send saved notification
+rm -f "$stop_lock" "$tmp_dir/notification-args"
+"$ROOT/bin/omarchy-capture-screenrecording" --stop-recording || true
+if [[ -s "$tmp_dir/notification-args" ]]; then
+  fail "stop_screenrecording does not notify when recording file is missing"
+fi
+pass "stop_screenrecording skips saved toast when recording file is missing"


### PR DESCRIPTION
Fixes #11508

### Problem
When `gpu-screen-recorder` takes a moment to exit after SIGINT (such as when draining queues or encoding at higher resolutions), triggering stop again (e.g. via hotkey or menu) calls `stop_screenrecording` concurrently. This results in:
1. Both callers reading `/tmp/omarchy-screenrecord-filename` before removal and racing to generate previews and post notifications, causing duplicate toasts and broken thumbnail images.
2. If the second call starts after the filename is cleared, it attempts preview generation and notification with an empty filename.

### Fix
1. Acquire a non-blocking lock on `${XDG_RUNTIME_DIR:-/tmp}/omarchy-screenrecord-stop.lock` at the top of `stop_screenrecording` using `exec {lock_fd}>...; flock -n "$lock_fd" || return 0`.
2. Guard thumbnail generation and notification by checking `[[ -n $filename && -f $filename ]]`.
3. Add regression tests in `test/shell.d/screenrecording-test.sh` verifying single-flight stop lock and that saved toasts are skipped when the recording file is missing.