### PR TITLE
Scope LocalSend firewall rules to private and local subnets (#11560)

### DIFF
--- a/install/config/firewall.sh
+++ b/install/config/firewall.sh
@@ -2,9 +2,11 @@
 ufw default deny incoming
 ufw default allow outgoing
 
-# Allow ports for LocalSend.
-ufw allow 53317/udp
-ufw allow 53317/tcp
+# Allow ports for LocalSend from local/private networks (RFC1918 and IPv6 ULA/link-local).
+for net in 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16 fc00::/7 fe80::/10; do
+  ufw allow in proto udp from "$net" to any port 53317 comment 'localsend'
+  ufw allow in proto tcp from "$net" to any port 53317 comment 'localsend'
+done
 
 # Allow Docker containers to use DNS on host.
 ufw allow in proto udp from 172.16.0.0/12 to 172.17.0.1 port 53 comment 'allow-docker-dns'

--- a/test/shell.d/firewall-config-test.sh
+++ b/test/shell.d/firewall-config-test.sh
@@ -48,4 +48,12 @@ PATH="$stub_dir:$PATH" bash -eE -c 'source "$1"' bash "$ROOT/install/config/fire
 grep -q '^ufw-docker install$' "$TEST_LOG" || fail "ufw-docker rules are installed"
 grep -q '^systemctl enable ufw$' "$TEST_LOG" || fail "ufw is enabled for next boot"
 
+for net in 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16 fc00::/7 fe80::/10; do
+  grep -Fq "ufw allow in proto udp from $net to any port 53317 comment localsend" "$TEST_LOG" || \
+    fail "LocalSend UDP rule missing for $net"
+  grep -Fq "ufw allow in proto tcp from $net to any port 53317 comment localsend" "$TEST_LOG" || \
+    fail "LocalSend TCP rule missing for $net"
+done
+! grep -Fq 'ufw allow 53317' "$TEST_LOG" || fail "unscoped LocalSend port rule present"
+
 pass "firewall config installs ufw-docker rules without activating live UFW"


### PR DESCRIPTION
Fixes #11560

### Problem
`install/config/firewall.sh` opened port 53317 (used by LocalSend) globally for incoming TCP and UDP without restricting traffic to private/local network ranges. Because IPv6 addresses are frequently globally routable without NAT, this could expose LocalSend receivers directly to the public internet on IPv6.

### Fix
1. In `install/config/firewall.sh`, scope the incoming allow rules for port 53317 (UDP and TCP) to private and local network CIDRs:
   - IPv4 RFC1918 ranges (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`)
   - IPv6 ULA and link-local ranges (`fc00::/7`, `fe80::/10`)
2. Update `test/shell.d/firewall-config-test.sh` to verify that port 53317 rules are installed for all private/local subnets with appropriate comments and that unscoped rules are not emitted.