### PR TITLE
Pass themed icon and glyph in screenshot notification (#11506)

### DIFF
--- a/bin/omarchy-capture-screenshot
+++ b/bin/omarchy-capture-screenshot
@@ -68,7 +68,7 @@ case "$PROCESSING" in
 
     # Best-effort: the screenshot is already saved and on the clipboard, so a
     # notification outage must not report the capture itself as failed.
-    omarchy-notification-send "Screenshot saved to clipboard and file" "Edit with Super + Alt + , (or click this)" \
+    omarchy-notification-send -i applets-screenshooter -g  "Screenshot saved to clipboard and file" "Edit with Super + Alt + , (or click this)" \
       --image "$FILEPATH" \
       --exec "$SCREENSHOT_EDITOR" "$FILEPATH" || true
     ;;

--- a/test/shell.d/screenshot-test.sh
+++ b/test/shell.d/screenshot-test.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+stub_bin="$tmpdir/bin"
+mkdir -p "$stub_bin"
+
+cat >"$stub_bin/hyprctl" <<'SH'
+#!/bin/bash
+if [[ $1 == "getoption" ]]; then
+  echo '{"int": 0}'
+fi
+exit 0
+SH
+
+cat >"$stub_bin/omarchy-capture-region" <<'SH'
+#!/bin/bash
+echo "12345"
+echo "0,0 100x100"
+SH
+
+cat >"$stub_bin/grim" <<'SH'
+#!/bin/bash
+touch "$3"
+exit 0
+SH
+
+cat >"$stub_bin/wl-copy" <<'SH'
+#!/bin/bash
+cat >/dev/null
+exit 0
+SH
+
+cat >"$stub_bin/omarchy-notification-send" <<'SH'
+#!/bin/bash
+printf '%s\n' "$@" >"$OMARCHY_TEST_NOTIFICATION_ARGS"
+SH
+
+chmod +x "$stub_bin"/*
+
+export PATH="$stub_bin:$ROOT/bin:$PATH"
+export OMARCHY_TEST_NOTIFICATION_ARGS="$tmpdir/notification-args"
+export OMARCHY_SCREENSHOT_DIR="$tmpdir/screenshots"
+mkdir -p "$OMARCHY_SCREENSHOT_DIR"
+
+"$ROOT/bin/omarchy-capture-screenshot"
+
+grep -Fx -- "-i" "$OMARCHY_TEST_NOTIFICATION_ARGS" >/dev/null || fail "omarchy-capture-screenshot passes -i flag"
+grep -Fx -- "applets-screenshooter" "$OMARCHY_TEST_NOTIFICATION_ARGS" >/dev/null || fail "omarchy-capture-screenshot sets applets-screenshooter icon"
+grep -Fx -- "-g" "$OMARCHY_TEST_NOTIFICATION_ARGS" >/dev/null || fail "omarchy-capture-screenshot passes -g flag"
+grep -Fx -- "" "$OMARCHY_TEST_NOTIFICATION_ARGS" >/dev/null || fail "omarchy-capture-screenshot sets screenshot glyph"
+
+pass "omarchy-capture-screenshot sends notification with icon and glyph"


### PR DESCRIPTION
Fixes #11506

### Problem
`omarchy-capture-screenshot` invoked `omarchy-notification-send` without `-i/--icon` or `-g/--glyph`. In environments where `--image` isn't treated as the application icon or in third-party notification daemons, notifications fell back to a missing/generic placeholder icon.

### Fix
1. In `bin/omarchy-capture-screenshot`, pass `-i applets-screenshooter` and `-g ` to `omarchy-notification-send`.
2. Add automated regression tests in `test/shell.d/screenshot-test.sh` verifying that `-i applets-screenshooter` and `-g ` are passed to `omarchy-notification-send`.