### PR TITLE
Prevent speedtest worker process leaks on abrupt termination (#11494)

### DIFF
--- a/bin/omarchy-network-speedtest
+++ b/bin/omarchy-network-speedtest
@@ -50,6 +50,9 @@ if [[ -z $fast_urls ]]; then
   exit 1
 fi
 
+script_pid=$$
+max_duration=30
+
 traffic_pids=()
 
 cleanup() {
@@ -72,15 +75,15 @@ traffic_worker() {
   local url_count=${#urls[@]}
   local idx=$RANDOM
   if [[ $direction == "down" ]]; then
-    while true; do
+    while kill -0 "$script_pid" 2>/dev/null; do
       url=${urls[$((idx % url_count))]}
-      curl -fsS -o /dev/null "$url" 2>/dev/null || return
+      curl --max-time 15 -fsS -o /dev/null "$url" 2>/dev/null || return
       idx=$((idx + 1))
     done
   else
-    while true; do
+    while kill -0 "$script_pid" 2>/dev/null; do
       url=${urls[$((idx % url_count))]}
-      dd if=/dev/zero bs=1M count=64 2>/dev/null | curl -fsS -o /dev/null -X POST --data-binary @- "$url" 2>/dev/null || return
+      dd if=/dev/zero bs=1M count=64 2>/dev/null | curl --max-time 15 -fsS -o /dev/null -X POST --data-binary @- "$url" 2>/dev/null || return
       idx=$((idx + 1))
     done
   fi
@@ -105,7 +108,11 @@ any_alive() {
   return 1
 }
 
+start_time=$SECONDS
+
 while any_alive; do
+  (( SECONDS - start_time >= max_duration )) && break
+
   sleep 1
   rx_after=$(cat "/sys/class/net/$iface/statistics/rx_bytes")
   tx_after=$(cat "/sys/class/net/$iface/statistics/tx_bytes")

--- a/test/shell.d/speedtest-test.sh
+++ b/test/shell.d/speedtest-test.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+stub_bin="$tmpdir/bin"
+mkdir -p "$stub_bin"
+
+cat >"$stub_bin/omarchy-cmd-present" <<'SH'
+#!/bin/bash
+exit 0
+SH
+
+cat >"$stub_bin/ip" <<'SH'
+#!/bin/bash
+echo "1.1.1.1 dev lo src 127.0.0.1 uid 1000"
+SH
+
+cat >"$stub_bin/curl" <<'SH'
+#!/bin/bash
+for arg in "$@"; do
+  if [[ $arg == *"api.fast.com"* ]]; then
+    cat <<'JSON'
+{"targets":[{"url":"http://127.0.0.1:9/mock1"},{"url":"http://127.0.0.1:9/mock2"}]}
+JSON
+    exit 0
+  fi
+done
+
+sleep 0.05
+exit 0
+SH
+
+chmod +x "$stub_bin"/*
+
+# Run speedtest in background, then kill parent with SIGKILL to simulate abrupt crash / panel teardown
+PATH="$stub_bin:$ROOT/bin:$PATH" "$ROOT/bin/omarchy-network-speedtest" down >/dev/null 2>&1 &
+speedtest_pid=$!
+
+sleep 0.3
+
+child_pids=$(pgrep -P "$speedtest_pid" || true)
+[[ -n $child_pids ]] || fail "speedtest workers were spawned"
+
+kill -9 "$speedtest_pid" 2>/dev/null || true
+wait "$speedtest_pid" 2>/dev/null || true
+
+# Wait up to 1.5 seconds for workers to detect that parent is gone and terminate
+for attempt in {1..15}; do
+  survivors=0
+  for cpid in $child_pids; do
+    if kill -0 "$cpid" 2>/dev/null; then
+      survivors=$(( survivors + 1 ))
+    fi
+  done
+  if (( survivors == 0 )); then
+    break
+  fi
+  sleep 0.1
+done
+
+leaked_workers=""
+for cpid in $child_pids; do
+  if kill -0 "$cpid" 2>/dev/null; then
+    leaked_workers="$leaked_workers $cpid"
+    kill -9 "$cpid" 2>/dev/null || true
+  fi
+done
+
+[[ -z $leaked_workers ]] || fail "speedtest workers leaked after parent was killed with SIGKILL: $leaked_workers"
+
+pass "speedtest workers terminate when parent process dies abruptly"


### PR DESCRIPTION
Fixes #11494

### Problem
When the speed test panel is dismissed mid-phase, the parent process can be killed abruptly (or before the 1-second foreground `sleep 1` returns to handle SIGTERM trap), reparenting the 8 unbounded `traffic_worker` subshells to systemd/init. These orphaned workers continue indefinitely saturating the network.

### Solution
1. In `bin/omarchy-network-speedtest`, capture `script_pid=$$` and make `traffic_worker` loop on `while kill -0 "$script_pid" 2>/dev/null; do`. If the parent process dies for any reason (including SIGKILL), the child workers immediately exit.
2. Add `--max-time 15` to `curl` requests within workers so requests cannot hang indefinitely.
3. Add a generous wall-clock deadline (`max_duration=30`) to the sampling loop.
4. Add regression test in `test/shell.d/speedtest-test.sh` verifying worker cleanup under SIGKILL.