### PR TITLE
Add duration backstop to launch feedback OSD (#11559)

### DIFF
--- a/shell/services/AppLibrary.qml
+++ b/shell/services/AppLibrary.qml
@@ -27,8 +27,8 @@ Item {
   property int launchToplevelCount: 0
   property var launchActiveToplevel: null
   // True while the launch OSD is on screen. It outlives the launch that opened
-  // it: the OSD shows with duration 0, so only closeLaunchFeedback() takes it
-  // down.
+  // it: closeLaunchFeedback() takes it down once the window appears, and the
+  // OSD carries a 15-second duration backstop if the close IPC races or drops.
   property bool launchOsdOpen: false
   property string launchOsdMessage: ""
 
@@ -242,7 +242,7 @@ Item {
     onTriggered: {
       if (root.toplevelCount() > root.launchToplevelCount || ToplevelManager.activeToplevel !== root.launchActiveToplevel) return
       root.launchOsdOpen = true
-      Quickshell.execDetached(["omarchy-shell", "osd", "show", JSON.stringify({ icon: "󱓞", message: root.launchOsdMessage, duration: 0 })])
+      Quickshell.execDetached(["omarchy-shell", "osd", "show", JSON.stringify({ icon: "󱓞", message: root.launchOsdMessage, duration: 15000 })])
     }
   }
 

--- a/test/shell.d/app-search-test.sh
+++ b/test/shell.d/app-search-test.sh
@@ -154,4 +154,9 @@ assert(
   openMatch[1].includes('root.appLibrary.refreshIcons()'),
   'menu refreshes the shared icon index when opened'
 )
+
+assert(
+  /omarchy-shell[\s\S]*?osd[\s\S]*?show[\s\S]*?duration:\s*15000/.test(appLibraryQml),
+  'app library launch feedback OSD carries a 15-second duration backstop'
+)
 JS


### PR DESCRIPTION
Fixes #11559

### Problem
`AppLibrary.qml` shows launch feedback with `duration: 0` when an application launch takes longer than 2 seconds. When the toplevel window registers nearly simultaneously with the 2-second delay timer, `omarchy-shell osd close` and `omarchy-shell osd show` can race over asynchronous IPC. If the close command is handled before the show command, the OSD remains permanently visible with `duration: 0` and no further timers scheduled to close it.

### Solution
- Provide a 15-second (`duration: 15000`) backstop on the launch feedback OSD matching the maximum `launchTimeout` interval. Even if the explicit `osd close` IPC races or drops, the OSD safely auto-dismisses after 15 seconds.
- Add test coverage in `test/shell.d/app-search-test.sh` verifying that launch feedback OSD specifies the duration backstop.