### PR TITLE
Skip Electron utility subprocess crashes in crash-watch

### DIFF
--- a/bin/omarchy-crash-watch
+++ b/bin/omarchy-crash-watch
@@ -52,13 +52,14 @@ journalctl -f -n 0 -o json "MESSAGE_ID=$COREDUMP_MESSAGE_ID" 2>/dev/null |
     # IFS whitespace, so an empty field collapses into the next delimiter and
     # every field after it shifts along one. A process can set its own comm to
     # nothing, and that crash used to be read as somebody else's and dropped.
-    IFS=$'\t' read -r uid comm pid exe signal < <(
+    IFS=$'\t' read -r uid comm pid exe signal cmdline < <(
       jq -r 'def field: if . == null or . == "" then "-" else . end;
              [(._UID | field),
               (.COREDUMP_COMM | field),
               (.COREDUMP_PID | field),
               (.COREDUMP_EXE | field),
-              (.COREDUMP_SIGNAL_NAME | field)] | @tsv' <<<"$entry" 2>/dev/null
+              (.COREDUMP_SIGNAL_NAME | field),
+              (.COREDUMP_CMDLINE | field)] | @tsv' <<<"$entry" 2>/dev/null
     )
 
     [[ $pid =~ ^[0-9]+$ ]] || continue
@@ -90,6 +91,12 @@ journalctl -f -n 0 -o json "MESSAGE_ID=$COREDUMP_MESSAGE_ID" 2>/dev/null |
     [[ -n $name && $name != "-" && $name != "." && $name != ".." ]] || name=unknown
 
     [[ -n $ignore_pattern && $name =~ $ignore_pattern ]] && continue
+
+    # Chromium/Electron utility children (--type=utility) dump core as a matter
+    # of course. The journaled COMM/EXE is the parent browser, so the name
+    # mute/ignore list cannot tell them from a real browser crash; the cmdline
+    # can. COREDUMP_CMDLINE uses spaces, not NULs.
+    [[ $cmdline == *" --type=utility"* || $cmdline == *"--type=utility "* ]] && continue
 
     # Never announce our own machinery, or it notifies about itself.
     [[ $name == omarchy-crash-* || $name == omarchy-agent-* ]] && continue

--- a/test/shell.d/crash-capture-test.sh
+++ b/test/shell.d/crash-capture-test.sh
@@ -96,11 +96,12 @@ reset_entries() {
 # One core dump as systemd-coredump journals it. The UID must be this user's, or
 # the watcher discards it as somebody else's crash before anything under test.
 crash_entry() {
-  local comm="$1" exe="$2"
+  local comm="$1" exe="$2" cmdline="${3:-}"
 
-  jq -cn --arg uid "$UID" --arg comm "$comm" --arg exe "$exe" \
+  jq -cn --arg uid "$UID" --arg comm "$comm" --arg exe "$exe" --arg cmd "$cmdline" \
     '{_UID: $uid, COREDUMP_COMM: $comm, COREDUMP_PID: "4242",
-      COREDUMP_EXE: $exe, COREDUMP_SIGNAL_NAME: "SIGSEGV"}' >>"$JOURNAL_ENTRIES"
+      COREDUMP_EXE: $exe, COREDUMP_SIGNAL_NAME: "SIGSEGV",
+      COREDUMP_CMDLINE: (if $cmd == "" then null else $cmd end)}' >>"$JOURNAL_ENTRIES"
 }
 
 # The stubbed journalctl ends after the entries, so the watcher's loop ends too.
@@ -251,6 +252,33 @@ run_watch
   fail "the fallback name cannot be muted, so the one crash most likely to repeat is the one that cannot be silenced"
 pass "the fallback name can be muted like any other"
 mute unknown off
+
+# Electron/Chromium utility children dump core as a matter of course. The
+# journaled COMM/EXE is the parent app, so only the cmdline can tell them from
+# a crash of the browser itself.
+reset_entries
+crash_entry antigravity-ide /usr/bin/antigravity-ide \
+  "/proc/self/exe --type=utility --utility-sub-type=node.mojom.NodeService"
+run_watch
+! announced antigravity-ide ||
+  fail "an Electron utility subprocess crash is toasted as if the app itself died"
+pass "Electron utility subprocess crashes are not announced"
+
+reset_entries
+crash_entry antigravity-ide /usr/bin/antigravity-ide
+run_watch
+announced antigravity-ide ||
+  fail "a crash of the Electron app itself is swallowed with its utility children"
+pass "a crash of the Electron app itself is still announced"
+
+reset_entries
+crash_entry antigravity-ide /usr/bin/antigravity-ide \
+  "/proc/self/exe --type=utility --utility-sub-type=node.mojom.NodeService"
+crash_entry nautilus /usr/bin/nautilus
+run_watch
+announced nautilus ||
+  fail "skipping a utility crash stops the watcher reading the next one"
+pass "skipping a utility crash does not stop the watcher"
 
 # What omarchy-crash-mute does on its own. That it agrees with the watcher is
 # already covered above, which drives it for every mute it makes.


### PR DESCRIPTION
## Problem

`omarchy-crash-watch` announces every coredump for the user UID. Electron/Chromium apps (Antigravity IDE, Chrome, …) spawn `--type=utility` children that dump core as a matter of course while the parent stays up. The journaled `COREDUMP_COMM` / `COREDUMP_EXE` is the parent, so name-based ignore/mute cannot tell a utility child from a real app crash. Result: noisy critical toasts for crashes the user does not need to care about.

Fixes #11440.

## Change

Skip journal entries whose `COREDUMP_CMDLINE` contains `--type=utility`. A crash of the Electron/Chromium process itself (no utility flag) still announces.

## Tests

`test/shell.d/crash-capture-test.sh`: utility cmdline stays silent; parent crash still toasts; skipping a utility entry does not stop the watcher.