### PR TITLE
Suspend on MacBookPro14,2: keep Wi-Fi and USB-C working across S3 (two systemd-sleep hooks)

### DIFF
--- a/default/systemd/system-sleep/brcmfmac-reload
+++ b/default/systemd/system-sleep/brcmfmac-reload
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Reload the Broadcom brcmfmac Wi-Fi driver around every sleep on Macs.
+#
+# On resume from S3 the BCM43602 in the 2016-2017 MacBook Pros sometimes keeps
+# its PCI registers readable while its firmware is dead. brcmfmac then takes its
+# hot-resume path, trusts the dead firmware, every command times out, and only
+# a driver reload or a reboot brings Wi-Fi back. Which path it takes is a coin
+# flip. Unloading the driver before sleep forces the full re-probe with a
+# firmware reload after resume, the path that always works. Measured on a
+# MacBookPro14,2 over more than thirty suspend cycles: interface present within
+# a second of resume, associated within about ten seconds, same address.
+#
+# Never blocks sleep: every path exits 0. Logs to the journal as
+# brcmfmac-reload. Delete this file to undo.
+
+MODS="brcmfmac_wcc brcmfmac"      # unload order matters: brcmfmac_wcc uses brcmfmac
+STATE=/run/brcmfmac-reload.state
+
+log() { logger -t brcmfmac-reload -- "$*"; }
+loaded() { grep -q '^brcmfmac ' /proc/modules; }
+# Any network interface whose PCI device is bound to brcmfmac.
+iface() { ls -d /sys/bus/pci/drivers/brcmfmac/0000:*/net/* 2>/dev/null | head -1 | xargs -r basename; }
+
+case "$1" in
+  pre)
+    rm -f "$STATE"
+    if ! loaded; then
+      echo absent >"$STATE"; log "pre/$2: brcmfmac not loaded, nothing to do"
+    elif timeout 60 modprobe -r $MODS; then
+      echo unloaded >"$STATE"; log "pre/$2: unloaded $MODS"
+    else
+      echo failed >"$STATE"; log "pre/$2: WARNING unload failed, driver left loaded"
+    fi
+    ;;
+  post)
+    state=$(cat "$STATE" 2>/dev/null || echo unknown)
+    if [[ $state != unloaded ]] && loaded; then
+      # pre could not unload (or its state was lost): force the reload now
+      if timeout 60 modprobe -r $MODS; then
+        log "post/$2: late unload ok (pre state: $state)"
+      else
+        log "post/$2: WARNING late unload failed (pre state: $state); leaving driver as is"
+        rm -f "$STATE"; exit 0
+      fi
+    fi
+    if modprobe brcmfmac; then
+      for ((i = 0; i < 40; i++)); do [[ -n $(iface) ]] && break; sleep 0.5; done
+      if [[ -n $(iface) ]]; then
+        log "post/$2: reloaded, $(iface) present after $((i / 2))s"
+      else
+        log "post/$2: WARNING reloaded but no brcmfmac interface after 20s"
+      fi
+    else
+      log "post/$2: ERROR modprobe brcmfmac failed"
+    fi
+    rm -f "$STATE"
+    ;;
+esac
+exit 0

--- a/default/systemd/system-sleep/thunderbolt-remove-rescan
+++ b/default/systemd/system-sleep/thunderbolt-remove-rescan
@@ -1,0 +1,155 @@
+#!/bin/bash
+# Keep Thunderbolt and USB-C working across S3 on the 2016-2017 MacBook Pros
+# (MacBookPro13,x and 14,x, Intel Alpine Ridge).
+#
+# The platform firmware removes power from the Thunderbolt controllers in S3
+# whatever the kernel asks. After that dirty loss the switch bridges come back
+# with collapsed windows, the kernel cannot re-assign them at runtime ("bridge
+# window ... can't assign; no space"), pciehp removes the Thunderbolt-side xHCI
+# controllers, and USB-C is dead until a power cycle. Kernel-side levers
+# (d3cold_allowed, pcie_port_pm=off, pcie_ports=compat) do not help; the rails
+# are the platform's.
+#
+# What works: remove the Thunderbolt upstream ports cleanly before sleep, so the
+# chipset root ports keep their windows, and rescan after resume, so the tree
+# is re-enumerated with fresh assignment. Measured on a MacBookPro14,2 over
+# about thirty suspend cycles: a sleep of a minute or more brings the whole
+# tree back on the first rescan; a sleep of a few seconds hands back a
+# controller that never finished powering down, and the tree stays dead until
+# the next sleep of a few minutes (USB 2.0 keeps working meanwhile through the
+# chipset's own xHCI). The tree returns on new bus numbers below the upstream
+# ports, so nothing may key on addresses below them.
+#
+# Design:
+# - Upstream ports are found from the NHIs bound to the thunderbolt driver
+#   (NHI -> downstream port -> upstream port), never from fixed addresses.
+# - pre: sync first; a side with a mounted filesystem reached through its
+#   upstream port is NOT removed (it would be torn before the kernel's suspend
+#   sync) and gets the dead-until-later outcome instead of data loss.
+# - pre: S3 wake is disabled on the PCIe root ports (they share one wake line;
+#   nothing on them needs to wake a laptop). Not restored: the sysfs flag only
+#   governs system sleep, runtime hot-plug keys on the wake capability, and a
+#   reboot resets it.
+# - pre: wait until the Thunderbolt root ports report runtime_status=suspended
+#   (milliseconds in practice; capped at 5 s).
+# - post: one rescan; if the tree is not back within 2 s, retries go to a
+#   transient unit via systemd-run, because post hooks run while user.slice is
+#   frozen and a backgrounded subshell dies with the hook
+#   (systemd-suspend.service is Type=oneshot with KillMode=control-group).
+# - Acts on plain suspend only. Every path exits 0, so it can never block
+#   sleep. Journal tag: thunderbolt-remove-rescan. Delete this file to undo.
+
+STATE=/run/thunderbolt-remove-rescan.roots
+log()  { logger -t thunderbolt-remove-rescan -- "$*"; }
+xhci() { ls /sys/bus/pci/drivers/xhci_hcd 2>/dev/null | grep -c '^0000'; }
+
+# Print "<upstream port sysfs path> <root port sysfs path>" for every
+# Thunderbolt controller whose NHI is currently bound.
+thunderbolt_ports() {
+  local nhi d up
+  for nhi in /sys/bus/pci/drivers/thunderbolt/0000:*; do
+    [[ -e $nhi ]] || continue
+    d=$(readlink -f "$nhi") || continue
+    up=$(dirname "$(dirname "$d")")
+    [[ -e $up/remove ]] || continue
+    printf '%s %s\n' "$up" "$(dirname "$up")"
+  done | sort -u
+}
+roots_from_state() { [[ -f $STATE ]] && awk '{print $2}' "$STATE" | sort -u; }
+links() {
+  local rp s
+  for rp in $(roots_from_state); do
+    s=$(cat "$rp/current_link_speed" 2>/dev/null); printf '%s=%s ' "$(basename "$rp")" "${s:-?}"
+  done
+}
+state() { echo "xhci=$(xhci) pci=$(ls /sys/bus/pci/devices | wc -l) links: $(links)"; }
+
+# Is block device $1 (a name under /sys/class/block) reached through PCI device
+# $2 (a sysfs path)? Follows dm/md slaves, so LUKS or RAID on a USB-C disk counts.
+under_port() {
+  local p s
+  p=$(readlink -f "/sys/class/block/$1" 2>/dev/null) || return 1
+  [[ $p == "$2"/* ]] && return 0
+  for s in "/sys/class/block/$1"/slaves/*; do
+    [[ -e $s ]] && under_port "${s##*/}" "$2" && return 0
+  done
+  return 1
+}
+# Print the first mounted device reached through PCI device $1, if any.
+mounted_under() {
+  local dev b
+  while read -r dev _; do
+    [[ $dev == /dev/* ]] || continue
+    b=$(readlink -f "$dev" 2>/dev/null) || continue
+    under_port "${b##*/}" "$1" && { echo "$dev"; return 0; }
+  done < /proc/mounts
+  return 1
+}
+
+if [[ $2 != suspend && $1 != retry ]]; then
+  exit 0
+fi
+
+case "$1" in
+  pre)
+    sync
+    thunderbolt_ports >"$STATE"
+    n=0; skipped=0
+    while read -r up rp; do
+      [[ -n $up ]] || continue
+      if m=$(mounted_under "$up"); then
+        log "pre/$2: WARNING $m is mounted through $(basename "$up") - NOT removing it (USB-C on that side stays down until a later sleep; no torn filesystem)"
+        skipped=$((skipped + 1)); continue
+      fi
+      if echo 1 > "$up/remove" 2>/dev/null; then
+        n=$((n + 1)); log "pre/$2: removed $(basename "$up") (under $(basename "$rp"))"
+      else
+        log "pre/$2: WARNING could not remove $(basename "$up")"
+      fi
+    done <"$STATE"
+    log "pre/$2: removed $n upstream port(s), skipped $skipped; $(state)"
+    # S3 wake off on every PCIe root port (see the header); not restored.
+    w=""
+    for rp in /sys/devices/pci0000:00/0000:*; do
+      [[ $(cat "$rp/class" 2>/dev/null) == 0x0604* ]] || continue
+      echo disabled > "$rp/power/wakeup" 2>/dev/null
+      w="$w$(basename "$rp")=$(cat "$rp/power/wakeup" 2>/dev/null) "
+    done
+    log "pre/$2: S3 wake: $w"
+    # Settle: wait for the (now childless) Thunderbolt root ports to runtime-suspend, cap 5 s.
+    roots=$(roots_from_state)
+    if [[ -n $roots ]]; then
+      t0=$(date +%s%N)
+      for ((i = 0; i < 50; i++)); do
+        ok=1
+        for rp in $roots; do [[ $(cat "$rp/power/runtime_status" 2>/dev/null) == suspended ]] || ok=0; done
+        (( ok )) && break
+        sleep 0.1
+      done
+      ms=$(( ($(date +%s%N) - t0) / 1000000 ))
+      if (( ok )); then log "pre/$2: settled in ${ms} ms"; else log "pre/$2: WARNING settle cap hit after ${ms} ms - continuing"; fi
+    fi
+    ;;
+  post)
+    echo 1 > /sys/bus/pci/rescan 2>/dev/null || log "post/$2: WARNING rescan write failed"
+    for ((i = 0; i < 4; i++)); do (( $(xhci) >= 3 )) && break; sleep 0.5; done
+    if (( $(xhci) >= 3 )); then
+      log "post/$2: tree back after attempt 1 (~$((i * 500)) ms): $(state)"
+    else
+      log "post/$2: attempt 1 short after 2 s: $(state) - retrying in a transient unit"
+      systemd-run --quiet --no-block --collect --unit="thunderbolt-remove-rescan-retry-$(date +%s)" \
+        "$0" retry "$2" || log "post/$2: WARNING systemd-run failed; no further attempts"
+    fi
+    ;;
+  retry)
+    for ((a = 2; a <= 6; a++)); do
+      sleep 2
+      echo 1 > /sys/bus/pci/rescan 2>/dev/null
+      sleep 0.5
+      if (( $(xhci) >= 3 )); then log "post/$2: tree back after attempt $a: $(state)"; exit 0; fi
+      log "post/$2: attempt $a short: $(state)"
+    done
+    log "post/$2: WARNING tree NOT back after 6 attempts: $(state) - it returns after the next sleep of a few minutes"
+    ;;
+esac
+exit 0

--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -42,6 +42,7 @@ run_logged "$OMARCHY_INSTALL/hardware/apple/fix-spi-keyboard.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-suspend-nvme.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-t2.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-brcmfmac-supplicant.sh"
+run_logged "$OMARCHY_INSTALL/hardware/apple/fix-t1-suspend.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/lenovo/fix-yoga-pro7-bass-speakers.sh"
 

--- a/install/hardware/apple/fix-t1-suspend.sh
+++ b/install/hardware/apple/fix-t1-suspend.sh
@@ -1,0 +1,25 @@
+# Keep Wi-Fi and USB-C working across suspend on the 2016-2017 Touch Bar
+# MacBook Pros (Apple T1 generation: Alpine Ridge Thunderbolt, BCM43602 Wi-Fi).
+#
+# Two system-sleep hooks, both measured on a MacBookPro14,2:
+# - brcmfmac-reload: the BCM43602 firmware sometimes dies in S3 while its
+#   registers stay readable, and brcmfmac's hot-resume path then leaves Wi-Fi
+#   down until a reload. Unloading before sleep and reloading after makes every
+#   resume take the working path.
+# - thunderbolt-remove-rescan: the firmware powers the Thunderbolt controllers
+#   off in S3, the kernel cannot re-allocate their bridge windows on resume, and
+#   USB-C is dead until a power cycle. Removing the upstream ports before sleep
+#   and rescanning after brings the tree back. See the hooks for the details and
+#   the measured limits.
+product_name="$(cat /sys/class/dmi/id/product_name 2>/dev/null || true)"
+
+if [[ $product_name =~ MacBookPro13,[123]|MacBookPro14,[123] ]]; then
+  echo "Detected $product_name; installing the suspend hooks for Wi-Fi and USB-C"
+
+  sudo mkdir -p /usr/lib/systemd/system-sleep
+  for hook in brcmfmac-reload thunderbolt-remove-rescan; do
+    sudo install -m 0755 -o root -g root -T \
+      "${OMARCHY_PATH:-/usr/share/omarchy}/default/systemd/system-sleep/$hook" \
+      "/usr/lib/systemd/system-sleep/$hook"
+  done
+fi

--- a/migrations/1789242220.sh
+++ b/migrations/1789242220.sh
@@ -1,0 +1,20 @@
+echo "Keep Wi-Fi and USB-C working across suspend on 2016-2017 Touch Bar MacBook Pros"
+
+# The install-time fix only reaches machines set up after it shipped. See
+# install/hardware/apple/fix-t1-suspend.sh and the two hooks it installs.
+OMARCHY_PATH="${OMARCHY_PATH:-/usr/share/omarchy}"
+product_name="$(cat /sys/class/dmi/id/product_name 2>/dev/null || true)"
+[[ $product_name =~ MacBookPro13,[123]|MacBookPro14,[123] ]] || exit 0
+
+for hook in brcmfmac-reload thunderbolt-remove-rescan; do
+  source="$OMARCHY_PATH/default/systemd/system-sleep/$hook"
+  destination="/usr/lib/systemd/system-sleep/$hook"
+  # A hook the user already carries with the same content is left alone;
+  # anything else is replaced with the packaged copy.
+  if [[ -f $destination ]] && cmp -s "$source" "$destination"; then
+    continue
+  fi
+  sudo mkdir -p /usr/lib/systemd/system-sleep
+  sudo install -m 0755 -o root -g root -T "$source" "$destination"
+done
+# The hooks take effect at the next suspend; nothing to restart.


### PR DESCRIPTION
## Summary

This adds two `systemd-sleep` hooks and a short "Suspend" section for the recipe. With them, a 2017 13-inch MacBook Pro (MacBookPro14,2, Apple T1) suspends to S3 and comes back with Wi-Fi and USB-C working, which it does not do with the stock setup. Everything below was measured on one machine over about twenty suspend cycles on 2026-09-05.

Environment: Omarchy 4.0.2, kernel 7.1.9-arch1-2, Mac firmware 529.140.2.0.0, this repository at 8e479f0 (unmodified), `snd_hda_macbookpro` at ef27884.

## Problem 1: Wi-Fi dies on about half of resumes

On resume the BCM43602 sometimes keeps its PCI registers readable while its firmware is dead. `brcmfmac` then takes its hot-resume path, trusts the dead firmware, and every command times out. Wi-Fi is gone until the driver is reloaded or the machine rebooted. Which path it takes is a coin flip.

Fix: `brcmfmac-reload` unloads `brcmfmac_wcc` and `brcmfmac` before sleep and reloads them after, so every resume takes the full re-probe path. Measured on more than a dozen S3 cycles: interface present within a second of resume, associated within about ten seconds, same IP. The NVRAM calibration file is re-read on each reload, so nothing else changes.

## Problem 2: Thunderbolt and USB-C are dead after every suspend

The platform firmware removes power from the Alpine Ridge controllers in S3 regardless of what the kernel asks. On resume the bridges come back with collapsed windows, the kernel cannot re-allocate them at runtime ("can't assign; no space"), pciehp removes both Thunderbolt-side xHCI controllers, and USB-C is gone until a power cycle. The Touch Bar, keyboard, audio and camera survive because the T1 sits on the chipset's own xHCI.

Things that do not help, all measured: `d3cold_allowed=0` on every device in the tree (the ports failed from D3hot, not D3cold), `pcie_port_pm=off`, `pcie_ports=compat`, forcing the root ports to D0 and rescanning, and evaluating the firmware's own power-on methods with `acpi_call` (the GPIO pads read the same on a dead side and a live side; the rails belong to the platform).

What does help: remove the two Thunderbolt upstream ports (`03:00.0` and `79:00.0`, the children of root ports `00:1c.4` and `00:1d.0`) cleanly before sleep, and rescan after resume. The chipset root ports never lose their windows, so the rescan re-enumerates the whole tree with fresh assignment. `thunderbolt-remove-rescan` does that, plus:

- it runs `sync` first and skips a side if a mounted filesystem is reached through it (a USB-C disk would otherwise be torn before the kernel's suspend sync);
- it disables S3 wake on the four PCIe root ports (they share one wake line, and nothing on them needs to wake a laptop; runtime hot-plug is unaffected);
- it waits for the two root ports to runtime-suspend (typically 2 ms, capped at 5 s);
- after resume it rescans once and, if the tree is not back within 2 s, hands retries to a transient unit with `systemd-run --collect`, because post hooks run while `user.slice` is still frozen and a plain backgrounded subshell is killed with the hook;
- every path exits 0, so it can never block a suspend.

Measured behaviour with the hook installed:

- Sleeps of about 80 s or more: the full tree is back on the first rescan (32 PCI functions, six USB root hubs, three xHCI controllers, links at 8 GT/s). A tree that was live at sleep entry came back after 47 s.
- Sleeps of about 7 s or less: the tree is dead afterwards, and comes back on the next sleep of a few minutes (one side after about 80 s, both after about six minutes; 362 s is the shortest measured for both). A reboot is never needed. USB-C still works at USB 2.0 through the chipset controller in the meantime, so a short sleep costs SuperSpeed and Thunderbolt, not the ports.
- The tree comes back on new bus numbers below the upstream ports (the two xHCI controllers moved from `06:00.0` and `7c:00.0` to `2c:00.0` and `a2:00.0`, the same numbers on every cycle). Nothing may key on addresses below `03:00.0` or `79:00.0`.

Not covered: hibernate (the hook acts on plain suspend only), external displays over USB-C across a sleep, and Thunderbolt PCIe devices.

## One thing to expect

Lid-closed sleeps sometimes wake on their own about 6 to 8 s in and then re-suspend a few seconds later; that short sleep leaves the tree dead as above until the next long sleep. Every wake source the kernel can see was ruled out with controls (GPE counters, wakeup sources, the PM1 status register, the raw GPE0 block); the cause is firmware-side. `in ordinary use so far: one of three lid-closes`.

One more scope note: this is for the keyboard-mode Touch Bar stack (apple-ib-tb lineage). The t1bridge display-mode stack replaces those drivers and lists sleep/wake as not working; these hooks may still apply there since they touch Thunderbolt and Wi-Fi, not the T1, but that is untested.

## Files

- `default/systemd/system-sleep/brcmfmac-reload` and `default/systemd/system-sleep/thunderbolt-remove-rescan`: the two hooks, beside the packaged `keyboard-backlight`, `force-igpu` and `unmount-fuse`. Root-owned 0755, every path exits 0, `thunderbolt-remove-rescan` acts on plain suspend only.
- `install/hardware/apple/fix-t1-suspend.sh`: installs both when `product_name` matches `MacBookPro13,[123]` or `MacBookPro14,[123]`, wired into `install/hardware/all.sh` after `fix-brcmfmac-supplicant.sh`.
- `migrations/1789242220.sh`: the same for existing installs; leaves a hook alone if the user already carries an identical copy. Nothing to restart; the hooks take effect at the next suspend.

The Thunderbolt hook finds the upstream ports from the NHIs bound to the `thunderbolt` driver (NHI, downstream port, upstream port), so no PCI addresses are hard-coded; it disables S3 wake on the PCIe root ports (they share one wake line, and nothing on them needs to wake a laptop; runtime hot-plug keys on the wake capability, not this flag). Delete the two files to undo.

## How this was tested

Hands-off cycles with an RTC alarm as the only wake (`echo $(( $(date +%s) + 100 )) > /sys/class/rtc/rtc0/wakealarm; systemctl suspend`), with the tree counted before and after by `ls /sys/bus/pci/devices | wc -l`, `ls -d /sys/bus/usb/devices/usb*`, and `ls /sys/bus/pci/drivers/xhci_hcd`, and the journal grepped for `can't assign`, `Unable to change power state` and `Host halt failed`. Then five real lid-close cycles, then daily use. Anyone reproducing this should touch nothing for the first ten seconds of a lid-open sleep; an early wake strands the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
