### PR TITLE
Add expandable hourly rain tables to the weather panel

### DIFF
--- a/shell/plugins/panels/weather/Model.js
+++ b/shell/plugins/panels/weather/Model.js
@@ -265,6 +265,389 @@ function iconForCode(code, night) {
   }
 }
 
+// ---- Rain tables: MET Norway amounts + Open-Meteo probabilities ----
+//
+// Slots are pure data for the expandable day tables. MET Norway carries
+// rain amounts, temperatures, and symbol codes but no probability of
+// precipitation outside the Nordics; Open-Meteo hourly
+// precipitation_probability fills that column. MET instants are UTC;
+// slot boundaries are local wall time, derived from the system time zone,
+// so midnight and DST transitions fall out of the local Date getters.
+// Any value without data stays null and formats as a dash.
+var MET_USER_AGENT = "omarchy-weather/1.0 https://github.com/omacom/omarchy"
+var MET_FETCH_MIN_INTERVAL_MS = 30 * 60 * 1000
+var MET_CACHE_SUBDIR = "weather"
+var MET_API_URL = "https://api.met.no/weatherapi/locationforecast/2.0/complete"
+var TWO_HOUR_SLOT_COUNT = 12
+var MISSING_VALUE = "–"
+
+function pad2(value) {
+  var n = parseInt(value, 10)
+  if (isNaN(n)) return "00"
+  return (n < 10 ? "0" : "") + n
+}
+
+function round1(value) {
+  if (value === null || value === undefined) return null
+  var n = parseFloat(String(value))
+  return isNaN(n) ? null : Math.round(n * 10) / 10
+}
+
+// Coordinates for MET Norway: at most 4 decimals. Null when unparseable.
+function roundCoord(value) {
+  var n = parseFloat(String(value))
+  if (isNaN(n)) return null
+  return Math.round(n * 10000) / 10000
+}
+
+function metUrl(lat, lon) {
+  var la = roundCoord(lat)
+  var lo = roundCoord(lon)
+  if (la === null || lo === null) return ""
+  return MET_API_URL + "?lat=" + la + "&lon=" + lo
+}
+
+// Coordinates shared by the Open-Meteo and MET Norway fetches: saved
+// coordinates when present, else the area wttr.in reported for auto-detect.
+// Pure so Panel.qml delegates to it (and tests drive the real rule).
+function forecastCoords(configuredLocationState, sourceReport, fallbackArea) {
+  var lat = parseFloat(String(configuredLocationState ? configuredLocationState.latitude : null))
+  var lon = parseFloat(String(configuredLocationState ? configuredLocationState.longitude : null))
+  if (isNaN(lat) || isNaN(lon)) {
+    var area = sourceReport && sourceReport.nearest_area && sourceReport.nearest_area[0] ? sourceReport.nearest_area[0] : fallbackArea
+    if (!area) return null
+    lat = parseFloat(String(area.latitude || ""))
+    lon = parseFloat(String(area.longitude || ""))
+  }
+  if (isNaN(lat) || isNaN(lon)) return null
+  return [lat, lon]
+}
+
+function floorUtcHour(ms) {
+  return Math.floor(ms / 3600000) * 3600000
+}
+
+function localDateOf(ms) {
+  var d = new Date(ms)
+  return d.getFullYear() + "-" + pad2(d.getMonth() + 1) + "-" + pad2(d.getDate())
+}
+
+function localHourOf(ms) {
+  return new Date(ms).getHours()
+}
+
+function localHourKey(ms) {
+  return localDateOf(ms) + "T" + pad2(localHourOf(ms))
+}
+
+function localDayLabel(ms) {
+  return pad2(new Date(ms).getHours())
+}
+
+// UTC instant of a local wall hour on a local date. Parsing without a zone
+// keeps it in the system time zone, so DST transitions resolve correctly.
+function localWallMs(dateString, hour) {
+  var day = String(dateString || "").slice(0, 10)
+  var h = parseInt(hour, 10)
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(day) || isNaN(h) || h < 0 || h > 24) return NaN
+  if (h === 24) {
+    var next = shiftDateString(day, 1)
+    return next === "" ? NaN : localWallMs(next, 0)
+  }
+  return new Date(day + "T" + pad2(h) + ":00:00").getTime()
+}
+
+function shiftDateString(day, deltaDays) {
+  var base = new Date(day + "T12:00:00").getTime()
+  if (isNaN(base)) return ""
+  return localDateOf(base + deltaDays * 86400000)
+}
+
+// MET Locationforecast timeseries → UTC-hour lookups. next_1_hours carries
+// only precipitation_amount; instant carries air_temperature on every entry
+// (kept separately so quarter-start temperatures outlive hourly coverage).
+function indexMetTimeseries(timeseries) {
+  var hourly = {}
+  var sixHour = {}
+  var instant = {}
+  var list = timeseries && timeseries.length ? timeseries : []
+  for (var i = 0; i < list.length; i++) {
+    var entry = list[i] || {}
+    var ms = Date.parse(entry.time)
+    if (isNaN(ms)) continue
+    var data = entry.data || {}
+    var details = data.instant && data.instant.details ? data.instant.details : null
+    var temp = details ? details.air_temperature : null
+    if (temp === undefined) temp = null
+    if (temp !== null && !isNaN(parseFloat(String(temp)))) instant[ms] = parseFloat(String(temp))
+    if (data.next_1_hours) {
+      var one = data.next_1_hours.details || {}
+      var onePrecip = one.precipitation_amount === undefined ? null : one.precipitation_amount
+      hourly[ms] = {
+        tempC: instant[ms] !== undefined ? instant[ms] : null,
+        precipMm: onePrecip,
+        symbol: data.next_1_hours.summary ? data.next_1_hours.summary.symbol_code || null : null
+      }
+    }
+    if (data.next_6_hours) {
+      var six = data.next_6_hours.details || {}
+      sixHour[ms] = {
+        precipMm: six.precipitation_amount === undefined ? null : six.precipitation_amount,
+        symbol: data.next_6_hours.summary ? data.next_6_hours.summary.symbol_code || null : null,
+        tminC: six.air_temperature_min === undefined ? null : six.air_temperature_min,
+        tmaxC: six.air_temperature_max === undefined ? null : six.air_temperature_max
+      }
+    }
+  }
+  return { hourly: hourly, sixHour: sixHour, instant: instant }
+}
+
+// Open-Meteo hourly precipitation_probability → local "YYYY-MM-DDTHH" map.
+// Hourly times already arrive in local wall time (timezone=auto).
+function indexPrecipitationProbability(hourly) {
+  var index = {}
+  if (!hourly || !hourly.time || !hourly.precipitation_probability) return index
+  for (var i = 0; i < hourly.time.length; i++) {
+    var key = String(hourly.time[i] || "").slice(0, 13)
+    if (!/^\d{4}-\d{2}-\d{2}T\d{2}$/.test(key)) continue
+    var p = hourly.precipitation_probability[i]
+    if (p === null || p === undefined || p === "") index[key] = null
+    else index[key] = isNaN(parseFloat(String(p))) ? null : parseFloat(String(p))
+  }
+  return index
+}
+
+function chanceForHours(probIndex, hoursMs) {
+  var best = null
+  for (var i = 0; i < hoursMs.length; i++) {
+    var p = probIndex[localHourKey(hoursMs[i])]
+    if (p === null || p === undefined) continue
+    if (best === null || p > best) best = p
+  }
+  return best
+}
+
+// Wetter hour wins; the first hour wins ties and beats missing data.
+function pickWetterSymbol(candidates) {
+  var best = null
+  var bestPrecip = -1
+  for (var i = 0; i < candidates.length; i++) {
+    var c = candidates[i] || {}
+    if (!c.symbol) continue
+    var p = (c.precipMm === null || c.precipMm === undefined) ? -1 : parseFloat(String(c.precipMm))
+    if (isNaN(p)) p = -1
+    if (best === null || p > bestPrecip) {
+      best = c
+      bestPrecip = p
+    }
+  }
+  return best ? best.symbol : null
+}
+
+// MET symbol_code (e.g. partlycloudy_night) onto the widget's glyphs via the
+// existing wttr.in code mapping. Unknown codes fall back to the cloudy glyph,
+// matching iconForCode's default.
+var MET_SYMBOL_CODES = {
+  clearsky: 113, fair: 116, partlycloudy: 116, cloudy: 119, fog: 143,
+  lightrainshowers: 263, rainshowers: 308, heavyrainshowers: 359,
+  lightrainshowersandthunder: 200, rainshowersandthunder: 389, heavyrainshowersandthunder: 389,
+  lightrain: 266, rain: 308, heavyrain: 359,
+  lightrainandthunder: 200, rainandthunder: 389, heavyrainandthunder: 389,
+  lightsleet: 311, sleet: 320, heavysleet: 377,
+  lightsleetshowers: 362, sleetshowers: 365, heavysleetshowers: 374,
+  lightsnow: 323, snow: 326, heavysnow: 338,
+  lightsnowshowers: 326, snowshowers: 368, heavysnowshowers: 338,
+  lightsnowandthunder: 392, snowandthunder: 395, heavysnowandthunder: 395,
+  lightfog: 143
+}
+
+function iconForMetSymbol(symbolCode) {
+  var raw = String(symbolCode || "")
+  if (raw === "") return ""
+  var night = /_night$/.test(raw)
+  var base = raw.replace(/_(day|night|polartwilight)$/, "")
+  var code = MET_SYMBOL_CODES[base]
+  if (code === undefined) code = 119
+  return iconForCode(code, night)
+}
+
+function tempForHour(met, ms) {
+  if (met && met.instant && met.instant[ms] !== undefined) return met.instant[ms]
+  if (met && met.hourly && met.hourly[ms]) return met.hourly[ms].tempC
+  return null
+}
+
+// Next 24 elapsed hours as 2-hour slots from the current hour. Labels are
+// local HH-HH; aggregation is over exact UTC hours so midnight and DST need
+// no special cases.
+function buildTwoHourSlots(metIndex, probIndex, nowMs, count) {
+  var met = metIndex || { hourly: {}, sixHour: {}, instant: {} }
+  met.hourly = met.hourly || {}
+  met.sixHour = met.sixHour || {}
+  met.instant = met.instant || {}
+  var probs = probIndex || {}
+  var n = (count === undefined || count === null) ? TWO_HOUR_SLOT_COUNT : Math.max(0, parseInt(count, 10) || 0)
+  var start = floorUtcHour(nowMs)
+  if (isNaN(start)) return []
+  var slots = []
+  for (var i = 0; i < n; i++) {
+    var h0 = start + i * 2 * 3600000
+    var h1 = h0 + 3600000
+    var e0 = met.hourly[h0] || null
+    var e1 = met.hourly[h1] || null
+    var rain = null
+    if (e0 && e0.precipMm !== null && e0.precipMm !== undefined) rain = parseFloat(String(e0.precipMm))
+    if (e1 && e1.precipMm !== null && e1.precipMm !== undefined) {
+      var second = parseFloat(String(e1.precipMm))
+      rain = (rain === null || isNaN(rain) ? 0 : rain) + second
+    }
+    if (rain !== null && isNaN(rain)) rain = null
+    var symbol = pickWetterSymbol([
+      e0 ? { precipMm: e0.precipMm, symbol: e0.symbol } : null,
+      e1 ? { precipMm: e1.precipMm, symbol: e1.symbol } : null
+    ])
+    slots.push({
+      startMs: h0,
+      endMs: h0 + 2 * 3600000,
+      label: localDayLabel(h0) + "-" + localDayLabel(h0 + 2 * 3600000),
+      tempC: tempForHour(met, h0),
+      rainMm: round1(rain),
+      chance: chanceForHours(probs, [h0, h1]),
+      symbol: symbol,
+      icon: symbol ? iconForMetSymbol(symbol) : ""
+    })
+  }
+  return slots
+}
+
+// A local calendar day as 00-06/06-12/12-18/18-24 slots. Rain sums hourly
+// values where they fully cover the quarter, else falls back to the
+// next_6_hours amount at the quarter start. DST-short/long quarters simply
+// contain fewer/more UTC hours.
+function buildSixHourSlots(metIndex, probIndex, dateString) {
+  var day = String(dateString || "").slice(0, 10)
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(day)) return []
+  var met = metIndex || { hourly: {}, sixHour: {}, instant: {} }
+  met.hourly = met.hourly || {}
+  met.sixHour = met.sixHour || {}
+  met.instant = met.instant || {}
+  var probs = probIndex || {}
+  var slots = []
+  for (var q = 0; q < 4; q++) {
+    var qStart = localWallMs(day, q * 6)
+    var qEnd = localWallMs(day, q * 6 + 6)
+    if (isNaN(qStart) || isNaN(qEnd)) continue
+    var hours = []
+    for (var h = qStart; h < qEnd; h += 3600000) hours.push(h)
+    var rain = null
+    var fullCover = hours.length > 0
+    var sum = 0
+    for (var k = 0; k < hours.length; k++) {
+      var e = met.hourly[hours[k]]
+      if (!e || e.precipMm === null || e.precipMm === undefined || isNaN(parseFloat(String(e.precipMm)))) {
+        fullCover = false
+        break
+      }
+      sum += parseFloat(String(e.precipMm))
+    }
+    var fallbackSix = null
+    if (fullCover) {
+      rain = sum
+    } else {
+      fallbackSix = met.sixHour[qStart] || null
+      if (!fallbackSix) {
+        for (var m = 0; m < hours.length; m++) {
+          if (met.sixHour[hours[m]]) {
+            fallbackSix = met.sixHour[hours[m]]
+            break
+          }
+        }
+      }
+      rain = fallbackSix ? fallbackSix.precipMm : null
+      if (rain !== null && rain !== undefined && isNaN(parseFloat(String(rain)))) rain = null
+    }
+    var cands = []
+    for (var c = 0; c < hours.length; c++) {
+      var he = met.hourly[hours[c]]
+      if (he) cands.push({ precipMm: he.precipMm, symbol: he.symbol })
+    }
+    var symbol = pickWetterSymbol(cands)
+    if (!symbol && fallbackSix) symbol = fallbackSix.symbol
+    slots.push({
+      startMs: qStart,
+      endMs: qEnd,
+      label: pad2(q * 6) + "-" + pad2(q * 6 + 6),
+      tempC: tempForHour(met, qStart),
+      rainMm: round1(rain),
+      chance: chanceForHours(probs, hours),
+      symbol: symbol,
+      icon: symbol ? iconForMetSymbol(symbol) : ""
+    })
+  }
+  return slots
+}
+
+// Total rain over displayed slots; null when every slot is missing.
+function dayRainTotal(slots) {
+  var total = null
+  var list = slots || []
+  for (var i = 0; i < list.length; i++) {
+    var r = list[i] ? list[i].rainMm : null
+    if (r === null || r === undefined || isNaN(parseFloat(String(r)))) continue
+    total = (total === null ? 0 : total) + parseFloat(String(r))
+  }
+  return round1(total)
+}
+
+function formatSlotTemp(celsius, useImperial) {
+  if (celsius === null || celsius === undefined || celsius === "") return MISSING_VALUE
+  var n = parseFloat(String(celsius))
+  if (isNaN(n)) return MISSING_VALUE
+  var v = useImperial ? (n * 9 / 5 + 32) : n
+  return String(Math.round(v)) + "°"
+}
+
+function formatRain(mm) {
+  var r = round1(mm)
+  return r === null ? MISSING_VALUE : r.toFixed(1)
+}
+
+function formatChance(p) {
+  if (p === null || p === undefined || p === "") return MISSING_VALUE
+  var n = parseFloat(String(p))
+  return isNaN(n) ? MISSING_VALUE : String(Math.round(n)) + "%"
+}
+
+function formatDayRain(mm) {
+  var r = round1(mm)
+  return r === null ? MISSING_VALUE : r.toFixed(1) + " mm"
+}
+
+// Day rows: today plus up to three following days, so the next-24-hours
+// 2-hour table has a home and later days expand to 6-hour quarters.
+function openMeteoDayRows(dailyForecastReport, todayString) {
+  var daily = dailyForecastReport && dailyForecastReport.daily ? dailyForecastReport.daily : null
+  if (!daily || !daily.time) return []
+  var today = String(todayString || "").slice(0, 10)
+  var rows = []
+  for (var i = 0; i < daily.time.length && rows.length < 4; ++i) {
+    var date = String(daily.time[i] || "").slice(0, 10)
+    if (date < today) continue
+    var maxC = daily.temperature_2m_max ? daily.temperature_2m_max[i] : ""
+    var minC = daily.temperature_2m_min ? daily.temperature_2m_min[i] : ""
+    rows.push({
+      date: date,
+      isToday: date === today,
+      maxtempC: roundedTemp(maxC),
+      mintempC: roundedTemp(minC),
+      maxtempF: roundedTemp(celsiusToFahrenheit(maxC)),
+      mintempF: roundedTemp(celsiusToFahrenheit(minC)),
+      openMeteoWeatherCode: daily.weather_code ? daily.weather_code[i] : null
+    })
+  }
+  return rows
+}
+
 if (typeof module !== "undefined") {
   module.exports = {
     parseLocationFile: parseLocationFile,
@@ -290,6 +673,35 @@ if (typeof module !== "undefined") {
     bareTempForDay: bareTempForDay,
     dayIcon: dayIcon,
     iconForOpenMeteoCode: iconForOpenMeteoCode,
-    iconForCode: iconForCode
+    iconForCode: iconForCode,
+    MET_USER_AGENT: MET_USER_AGENT,
+    MET_FETCH_MIN_INTERVAL_MS: MET_FETCH_MIN_INTERVAL_MS,
+    MET_CACHE_SUBDIR: MET_CACHE_SUBDIR,
+    MET_API_URL: MET_API_URL,
+    TWO_HOUR_SLOT_COUNT: TWO_HOUR_SLOT_COUNT,
+    MISSING_VALUE: MISSING_VALUE,
+    pad2: pad2,
+    roundCoord: roundCoord,
+    metUrl: metUrl,
+    forecastCoords: forecastCoords,
+    floorUtcHour: floorUtcHour,
+    localDateOf: localDateOf,
+    localHourOf: localHourOf,
+    localHourKey: localHourKey,
+    localWallMs: localWallMs,
+    shiftDateString: shiftDateString,
+    indexMetTimeseries: indexMetTimeseries,
+    indexPrecipitationProbability: indexPrecipitationProbability,
+    chanceForHours: chanceForHours,
+    pickWetterSymbol: pickWetterSymbol,
+    iconForMetSymbol: iconForMetSymbol,
+    buildTwoHourSlots: buildTwoHourSlots,
+    buildSixHourSlots: buildSixHourSlots,
+    dayRainTotal: dayRainTotal,
+    formatSlotTemp: formatSlotTemp,
+    formatRain: formatRain,
+    formatChance: formatChance,
+    formatDayRain: formatDayRain,
+    openMeteoDayRows: openMeteoDayRows
   }
 }

--- a/shell/plugins/panels/weather/Panel.qml
+++ b/shell/plugins/panels/weather/Panel.qml
@@ -89,8 +89,10 @@ Panel {
     if (savingLocation) savingLocationQueryStarted = true
     forecastRetries = 0
     dailyForecastRetries = 0
+    metRetries = 0
     forecastProc.running = false
     dailyForecastProc.running = false
+    metFetchProc.running = false
     Qt.callLater(refresh)
   }
 
@@ -134,7 +136,20 @@ Panel {
   readonly property var openMeteoCurrent: Model.openMeteoCurrentCondition(dailyForecastReport)
   readonly property var current: (hasConfiguredCoordinates && openMeteoCurrent) ? openMeteoCurrent : ((report && report.current_condition && report.current_condition[0]) ? report.current_condition[0] : openMeteoCurrent)
   readonly property var areaInfo: report && report.nearest_area && report.nearest_area[0] ? report.nearest_area[0] : null
-  readonly property var forecastDays: buildForecastDays()
+  // Day rows: today plus up to three following days. Today expands to
+  // 2-hour slots for the next 24 hours; later days expand to 6-hour
+  // quarters. Rain amounts come from MET Norway, chances from Open-Meteo.
+  readonly property var dayRows: Model.openMeteoDayRows(dailyForecastReport, Qt.formatDate(new Date(), "yyyy-MM-dd"))
+  property string expandedDate: ""
+
+  // MET Norway state. metTimeseries is the cached Locationforecast
+  // timeseries array; the fetcher script owns throttle/Expires/304 logic.
+  property var metTimeseries: null
+  property string metStatus: ""
+  property int metRetries: 0
+  readonly property string metCacheDir: Quickshell.env("HOME") + "/.cache/omarchy/" + Model.MET_CACHE_SUBDIR
+  readonly property var metIndex: Model.indexMetTimeseries(metTimeseries)
+  readonly property var rainProbIndex: Model.indexPrecipitationProbability(dailyForecastReport && dailyForecastReport.hourly)
   readonly property string reportCountry: areaInfo && areaInfo.country && areaInfo.country[0] ? areaInfo.country[0].value : ""
 
   readonly property bool useImperial: Model.shouldUseImperial(setting("unit", ""), Qt.locale().name, reportCountry)
@@ -155,31 +170,29 @@ Panel {
     // starve retries for the rest of the session.
     forecastRetries = 0
     dailyForecastRetries = 0
+    metRetries = 0
     if (!forecastProc.running) forecastProc.running = true
     if (root.locationQuery === "" && !locationProc.running) locationProc.running = true
     // With stored coordinates this fetches open-meteo right away — no need
     // to wait for the slow wttr response. Without them it's a no-op until
     // wttr reports the detected area.
     refreshDailyForecast(null)
+    refreshMet()
   }
 
   function refreshDailyForecast(sourceReport) {
     if (dailyForecastProc.running) return
 
-    var lat = parseFloat(String(root.configuredLocationState.latitude))
-    var lon = parseFloat(String(root.configuredLocationState.longitude))
-    if (isNaN(lat) || isNaN(lon)) {
-      var area = sourceReport && sourceReport.nearest_area && sourceReport.nearest_area[0] ? sourceReport.nearest_area[0] : root.areaInfo
-      if (!area) return
-      lat = parseFloat(String(area.latitude || ""))
-      lon = parseFloat(String(area.longitude || ""))
-    }
-    if (isNaN(lat) || isNaN(lon)) return
+    var coords = root.forecastCoords(sourceReport)
+    if (!coords) return
+    var lat = coords[0]
+    var lon = coords[1]
 
     var url = "https://api.open-meteo.com/v1/forecast"
       + "?latitude=" + encodeURIComponent(String(lat))
       + "&longitude=" + encodeURIComponent(String(lon))
       + "&daily=weather_code,temperature_2m_max,temperature_2m_min"
+      + "&hourly=precipitation_probability"
       + "&current=temperature_2m,apparent_temperature,relative_humidity_2m,wind_speed_10m,weather_code,is_day"
       + "&forecast_days=4"
       + "&timezone=auto"
@@ -279,8 +292,64 @@ Panel {
     geocodeProc.running = true
   }
 
-  function buildForecastDays() {
-    return Model.buildForecastDays(report, dailyForecastReport, Qt.formatDate(new Date(), "yyyy-MM-dd"))
+  // Slots for an expanded day row: 2-hour slots for today (next 24 hours),
+  // 6-hour quarters for later days. Re-evaluates when either source updates.
+  function slotsForDay(day) {
+    if (!day) return []
+    if (day.isToday) return Model.buildTwoHourSlots(root.metIndex, root.rainProbIndex, Date.now())
+    return Model.buildSixHourSlots(root.metIndex, root.rainProbIndex, day.date)
+  }
+
+  function rainTotalForDay(day) {
+    return Model.formatDayRain(Model.dayRainTotal(root.slotsForDay(day)))
+  }
+
+  function toggleDay(dateString) {
+    root.expandedDate = root.expandedDate === dateString ? "" : dateString
+  }
+
+  function dayRowName(day) {
+    if (!day) return ""
+    if (day.isToday) return "Today"
+    return root.dayName(day.date)
+  }
+
+  function slotTemp(slot) {
+    return Model.formatSlotTemp(slot ? slot.tempC : null, root.useImperial)
+  }
+
+  function slotRain(slot) {
+    return Model.formatRain(slot ? slot.rainMm : null)
+  }
+
+  function slotChance(slot) {
+    return Model.formatChance(slot ? slot.chance : null)
+  }
+
+  function slotIcon(slot) {
+    var glyph = slot ? slot.icon : ""
+    return glyph || Model.MISSING_VALUE
+  }
+
+  // Coordinates shared by the Open-Meteo and MET Norway fetches: saved
+  // coordinates when present, else the area wttr.in reported for auto-detect.
+  function forecastCoords(sourceReport) {
+    return Model.forecastCoords(root.configuredLocationState, sourceReport, root.areaInfo)
+  }
+
+  function refreshMet() {
+    if (metFetchProc.running) return
+    var coords = root.forecastCoords(null)
+    if (!coords) return
+    var script = String(Qt.resolvedUrl("met-fetch.sh")).replace(/^file:\/\//, "")
+    metFetchProc.command = [script, String(coords[0]), String(coords[1]), root.metCacheDir]
+    metFetchProc.running = true
+  }
+
+  function scheduleMetRetry() {
+    if (metRetries >= 3) return
+    metRetries++
+    metRetryTimer.restart()
   }
 
   function openMeteoForecastDays() {
@@ -351,8 +420,10 @@ Panel {
             root.finishSavingLocation()
           // Stored coordinates already drove the fast open-meteo fetch from
           // refresh(); only auto-detect needs the area wttr reported.
-          if (isNaN(parseFloat(String(root.configuredLocationState.latitude))))
+          if (isNaN(parseFloat(String(root.configuredLocationState.latitude)))) {
             root.refreshDailyForecast(parsed)
+            root.refreshMet()
+          }
         } catch (e) {
           // Keep last-good report visible, but try again shortly.
           root.scheduleForecastRetry()
@@ -446,8 +517,10 @@ Panel {
         root.savingLocationQueryStarted = true
         root.forecastRetries = 0
         root.dailyForecastRetries = 0
+        root.metRetries = 0
         forecastProc.running = false
         dailyForecastProc.running = false
+        metFetchProc.running = false
         Qt.callLater(root.refresh)
       }
     }
@@ -462,6 +535,58 @@ Panel {
         var raw = String(text || "").trim()
         if (!raw) return
         root.wttrLocation = raw.split(",")[0]
+      }
+    }
+  }
+
+  // MET Norway fetch via the caching helper: it throttles to one request
+  // per 30 minutes, revalidates with If-Modified-Since, and honours
+  // Expires. The body cache is parsed below; a 304 keeps it untouched.
+  Process {
+    id: metFetchProc
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: {
+        var raw = String(text || "").trim()
+        if (!raw) {
+          root.scheduleMetRetry()
+          return
+        }
+        try {
+          var status = JSON.parse(raw)
+          root.metStatus = status.status || ""
+          if (root.metStatus === "ok" || root.metStatus === "not-modified")
+            metBodyFile.reload()
+          else if (root.metStatus !== "throttled" && root.metStatus !== "fresh")
+            root.scheduleMetRetry()
+        } catch (e) {
+          root.scheduleMetRetry()
+        }
+      }
+    }
+    onExited: function(exitCode) {
+      if (exitCode !== 0) root.scheduleMetRetry()
+    }
+  }
+
+  Timer {
+    id: metRetryTimer
+    interval: 2500
+    onTriggered: root.refreshMet()
+  }
+
+  // Cached Locationforecast body. Loads once at startup so yesterday's data
+  // is visible instantly; reloaded after every successful fetch.
+  property FileView metBodyFile: FileView {
+    path: root.metCacheDir + "/body.json"
+    printErrors: false
+    onLoaded: {
+      try {
+        var parsed = JSON.parse(text())
+        var series = parsed && parsed.properties ? parsed.properties.timeseries : null
+        if (series) root.metTimeseries = series
+      } catch (e) {
+        // Keep last-good series visible.
       }
     }
   }
@@ -798,84 +923,221 @@ Panel {
         font.pixelSize: Style.font.bodySmall
         font.italic: true
       }
-
       // ---- Divider between current conditions and forecast.
       Rectangle {
-        visible: root.forecastDays.length > 0
+        visible: root.dayRows.length > 0
         width: parent.width
         height: Style.spacing.hairline
         color: root.bar.foreground
         opacity: 0.12
       }
 
-      // ---- Forecast row: each cell has the day icon left of a day-name + hi/lo column.
-      //      Wrapped in an Item so the block of cells can be centered within the popup.
-      Item {
-        visible: root.forecastDays.length > 0
+      // ---- Day rows: icon, name, hi/lo, and total rain. Clicking a row
+      //      expands its slot table (2-hour slots for today, 6-hour
+      //      quarters for later days): time, icon, temp, rain mm, chance %.
+      Column {
+        visible: root.dayRows.length > 0
         width: parent.width
-        height: forecastRow.height
+        spacing: Style.space(2)
 
-        Row {
-          id: forecastRow
-          anchors.horizontalCenter: parent.horizontalCenter
-          spacing: Style.space(44)
+        Repeater {
+          model: root.dayRows
 
-          Repeater {
-            model: root.forecastDays
+          Column {
+            required property var modelData
+            width: parent.width
+            spacing: 0
 
-            Row {
-              required property var modelData
-              required property int index
-              spacing: Style.space(10)
+            Item {
+              width: parent.width
+              height: dayHead.height + Style.space(12)
 
-              Text {
-                textFormat: Text.PlainText
+              Row {
+                id: dayHead
+                anchors.left: parent.left
+                anchors.leftMargin: Style.space(16)
                 anchors.verticalCenter: parent.verticalCenter
-                text: root.dayIcon(modelData)
-                color: root.bar.foreground
-                font.family: root.bar.fontFamily
-                font.pixelSize: Style.font.display
-              }
-
-              Column {
-                anchors.verticalCenter: parent.verticalCenter
-                spacing: Style.space(2)
+                spacing: Style.space(10)
 
                 Text {
                   textFormat: Text.PlainText
-                  text: root.dayName(modelData.date).toUpperCase()
-                  color: Qt.darker(root.bar.foreground, 1.4)
+                  anchors.verticalCenter: parent.verticalCenter
+                  text: root.dayIcon(modelData)
+                  color: root.bar.foreground
                   font.family: root.bar.fontFamily
-                  font.pixelSize: Style.font.caption
-                  font.letterSpacing: 1
+                  font.pixelSize: Style.font.display
                 }
 
-                Row {
-                  spacing: Style.space(6)
+                Column {
+                  anchors.verticalCenter: parent.verticalCenter
+                  spacing: Style.space(2)
 
                   Text {
                     textFormat: Text.PlainText
-                    text: root.bareTempForDay(modelData, "max")
+                    text: root.dayRowName(modelData).toUpperCase()
+                    color: Qt.darker(root.bar.foreground, 1.4)
+                    font.family: root.bar.fontFamily
+                    font.pixelSize: Style.font.caption
+                    font.letterSpacing: 1
+                  }
+
+                  Row {
+                    spacing: Style.space(6)
+
+                    Text {
+                      textFormat: Text.PlainText
+                      text: root.bareTempForDay(modelData, "max")
+                      color: root.bar.foreground
+                      font.family: root.bar.fontFamily
+                      font.pixelSize: Style.font.body
+                    }
+                    Text {
+                      textFormat: Text.PlainText
+                      text: root.bareTempForDay(modelData, "min")
+                      color: Qt.darker(root.bar.foreground, 1.5)
+                      font.family: root.bar.fontFamily
+                      font.pixelSize: Style.font.body
+                    }
+                  }
+                }
+              }
+
+              Row {
+                anchors.right: parent.right
+                anchors.rightMargin: Style.space(16)
+                anchors.verticalCenter: parent.verticalCenter
+                spacing: Style.space(8)
+
+                Text {
+                  textFormat: Text.PlainText
+                  anchors.verticalCenter: parent.verticalCenter
+                  text: root.rainTotalForDay(modelData)
+                  color: Qt.darker(root.bar.foreground, 1.4)
+                  font.family: root.bar.fontFamily
+                  font.pixelSize: Style.font.bodySmall
+                }
+                Text {
+                  textFormat: Text.PlainText
+                  anchors.verticalCenter: parent.verticalCenter
+                  text: root.expandedDate === modelData.date ? "▾" : "▸"
+                  color: Qt.darker(root.bar.foreground, 1.5)
+                  font.family: root.bar.fontFamily
+                  font.pixelSize: Style.font.bodySmall
+                }
+              }
+
+              Rectangle {
+                anchors.fill: parent
+                radius: Style.cornerRadius
+                color: dayMouse.containsMouse ? Style.hoverFillFor(root.bar.foreground, Color.accent) : "transparent"
+              }
+
+              MouseArea {
+                id: dayMouse
+                anchors.fill: parent
+                hoverEnabled: true
+                cursorShape: Qt.PointingHandCursor
+                onClicked: root.toggleDay(modelData.date)
+              }
+            }
+
+            Column {
+              visible: root.expandedDate === modelData.date
+              width: parent.width
+              spacing: Style.space(2)
+
+              Row {
+                anchors.left: parent.left
+                anchors.leftMargin: Style.space(58)
+                spacing: 0
+
+                Text { width: Style.space(46); text: "TIME"; color: Qt.darker(root.bar.foreground, 1.5); font.family: root.bar.fontFamily; font.pixelSize: Style.font.caption; font.letterSpacing: 1 }
+                Text { width: Style.space(30); text: "" }
+                Text { width: Style.space(40); text: "TEMP"; color: Qt.darker(root.bar.foreground, 1.5); font.family: root.bar.fontFamily; font.pixelSize: Style.font.caption; font.letterSpacing: 1 }
+                Text { width: Style.space(52); text: "MM"; color: Qt.darker(root.bar.foreground, 1.5); font.family: root.bar.fontFamily; font.pixelSize: Style.font.caption; font.letterSpacing: 1 }
+                Text { width: Style.space(44); text: "%"; color: Qt.darker(root.bar.foreground, 1.5); font.family: root.bar.fontFamily; font.pixelSize: Style.font.caption; font.letterSpacing: 1 }
+              }
+
+              Repeater {
+                model: root.slotsForDay(modelData)
+
+                Row {
+                  required property var modelData
+                  anchors.left: parent.left
+                  anchors.leftMargin: Style.space(58)
+                  spacing: 0
+
+                  Text {
+                    width: Style.space(46)
+                    textFormat: Text.PlainText
+                    text: modelData.label
+                    color: Qt.darker(root.bar.foreground, 1.4)
+                    font.family: root.bar.fontFamily
+                    font.pixelSize: Style.font.bodySmall
+                  }
+                  Text {
+                    width: Style.space(30)
+                    textFormat: Text.PlainText
+                    text: root.slotIcon(modelData)
                     color: root.bar.foreground
                     font.family: root.bar.fontFamily
                     font.pixelSize: Style.font.body
                   }
                   Text {
+                    width: Style.space(40)
                     textFormat: Text.PlainText
-                    text: root.bareTempForDay(modelData, "min")
-                    color: Qt.darker(root.bar.foreground, 1.5)
+                    text: root.slotTemp(modelData)
+                    color: root.bar.foreground
                     font.family: root.bar.fontFamily
-                    font.pixelSize: Style.font.body
+                    font.pixelSize: Style.font.bodySmall
+                  }
+                  Text {
+                    width: Style.space(52)
+                    textFormat: Text.PlainText
+                    text: root.slotRain(modelData)
+                    color: root.bar.foreground
+                    font.family: root.bar.fontFamily
+                    font.pixelSize: Style.font.bodySmall
+                  }
+                  Text {
+                    width: Style.space(44)
+                    textFormat: Text.PlainText
+                    text: root.slotChance(modelData)
+                    color: Qt.darker(root.bar.foreground, 1.4)
+                    font.family: root.bar.fontFamily
+                    font.pixelSize: Style.font.bodySmall
                   }
                 }
+              }
+
+              Item {
+                width: parent.width
+                height: Style.space(8)
               }
             }
           }
         }
       }
+
+      // MET Norway requires attribution for its data.
+      Item {
+        visible: root.dayRows.length > 0
+        width: parent.width
+        height: creditLine.height
+
+        Text {
+          id: creditLine
+          anchors.horizontalCenter: parent.horizontalCenter
+          text: "Data: MET Norway, Open-Meteo"
+          color: Qt.darker(root.bar.foreground, 1.6)
+          font.family: root.bar.fontFamily
+          font.pixelSize: Style.font.caption
+          font.italic: true
+        }
+      }
+        }
+      }
     }
-  }
-  }
   }
 
 }

--- a/shell/plugins/panels/weather/met-fetch.sh
+++ b/shell/plugins/panels/weather/met-fetch.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# Fetch MET Norway Locationforecast for one coordinate pair with client-side
+# caching: at most one network request per 30 minutes, If-Modified-Since
+# revalidation, and Expires honoured. Prints a one-line JSON status to stdout.
+#
+# Usage: met-fetch.sh <lat> <lon> <cacheDir>
+# Exit 0 when usable cached data exists (fresh, throttled, ok, not-modified);
+# exit 1 on network/HTTP errors with no usable cache update.
+set -u
+
+USER_AGENT="omarchy-weather/1.0 https://github.com/omacom/omarchy"
+MIN_INTERVAL=1800
+
+lat_raw="${1:-}"
+lon_raw="${2:-}"
+cache_dir="${3:-}"
+if [[ -z "$lat_raw" || -z "$lon_raw" || -z "$cache_dir" ]]; then
+  echo '{"status":"error","reason":"usage: met-fetch.sh <lat> <lon> <cacheDir>"}'
+  exit 1
+fi
+
+# At most 4 decimals, matching the API guidance.
+if ! lat=$(printf "%.4f" "$lat_raw" 2>/dev/null) || ! lon=$(printf "%.4f" "$lon_raw" 2>/dev/null); then
+  echo '{"status":"error","reason":"invalid coordinates"}'
+  exit 1
+fi
+
+mkdir -p "$cache_dir" || {
+  echo '{"status":"error","reason":"cannot create cache dir"}'
+  exit 1
+}
+
+meta="$cache_dir/meta"
+body="$cache_dir/body.json"
+headers="$cache_dir/headers.txt"
+
+last_fetch=""
+expires=""
+last_modified=""
+meta_lat=""
+meta_lon=""
+if [[ -f "$meta" ]]; then
+  # shellcheck disable=SC1090
+  source "$meta" 2>/dev/null || true
+fi
+
+now=$(date +%s)
+json_escape() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  printf "%s" "$s"
+}
+
+if [[ "$meta_lat" == "$lat" && "$meta_lon" == "$lon" && -f "$body" ]]; then
+  if [[ -n "$last_fetch" && $((now - last_fetch)) -lt $MIN_INTERVAL ]]; then
+    echo "{\"status\":\"throttled\",\"last_fetch\":$last_fetch}"
+    exit 0
+  fi
+  if [[ -n "$expires" && "$now" -lt "$expires" ]]; then
+    echo "{\"status\":\"fresh\",\"expires\":$expires}"
+    exit 0
+  fi
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo '{"status":"error","reason":"curl not found"}'
+  exit 1
+fi
+
+url="https://api.met.no/weatherapi/locationforecast/2.0/complete?lat=${lat}&lon=${lon}"
+tmp_body="${body}.tmp"
+tmp_headers="${headers}.tmp"
+curl_args=(-sS --max-time 15 -D "$tmp_headers" -o "$tmp_body" -H "User-Agent: $USER_AGENT")
+if [[ "$meta_lat" == "$lat" && "$meta_lon" == "$lon" && -n "$last_modified" && -f "$body" ]]; then
+  curl_args+=(-H "If-Modified-Since: $last_modified")
+fi
+http_code=$(curl "${curl_args[@]}" -w "%{http_code}" "$url" 2>/dev/null) || http_code="000"
+
+finish_meta() {
+  # $1 = expires epoch or empty, $2 = last-modified string or empty
+  {
+    echo "meta_lat=\"$lat\""
+    echo "meta_lon=\"$lon\""
+    echo "last_fetch=\"$now\""
+    echo "expires=\"$1\""
+    echo "last_modified=\"$(json_escape "$2")\""
+  } >"$meta"
+}
+
+parse_header() {
+  grep -i -m1 "^$1:" "$tmp_headers" 2>/dev/null | cut -d: -f2- | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | tr -d '\r'
+}
+
+case "$http_code" in
+  200)
+    new_expires=""
+    exp_str=$(parse_header "Expires")
+    if [[ -n "$exp_str" ]]; then
+      new_expires=$(date -d "$exp_str" +%s 2>/dev/null || true)
+    fi
+    new_modified=$(parse_header "Last-Modified")
+    mv -f "$tmp_body" "$body"
+    mv -f "$tmp_headers" "$headers"
+    finish_meta "$new_expires" "$new_modified"
+    echo "{\"status\":\"ok\",\"http_code\":200,\"expires\":\"$new_expires\"}"
+    exit 0
+    ;;
+  304)
+    rm -f "$tmp_body" "$tmp_headers"
+    # Revalidation counts as a check: back off so a tight refresh loop
+    # cannot poll the API.
+    finish_meta "$expires" "$last_modified"
+    echo '{"status":"not-modified","http_code":304}'
+    exit 0
+    ;;
+  *)
+    rm -f "$tmp_body" "$tmp_headers"
+    if [[ -f "$body" ]]; then
+      echo "{\"status\":\"error\",\"http_code\":\"$(json_escape "$http_code")\",\"cached\":true}"
+    else
+      echo "{\"status\":\"error\",\"http_code\":\"$(json_escape "$http_code")\",\"cached\":false}"
+    fi
+    exit 1
+    ;;
+esac

--- a/test/shell.d/weather-rain-test.sh
+++ b/test/shell.d/weather-rain-test.sh
@@ -1,0 +1,328 @@
+#!/bin/bash
+
+# Rain tables for the weather panel: MET Norway amounts plus Open-Meteo
+# chance-of-rain in expandable day rows. Guards the two faults that once
+# slipped through: a manifest without schemaVersion, and day rows nested
+# inside the self-hiding fetching indicator.
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+WEATHER_DIR="$ROOT/shell/plugins/panels/weather"
+
+run_node_test <<'JS'
+process.env.TZ = 'Europe/Ljubljana'
+
+const fs = require('fs')
+const weather = requireFromRoot('shell/plugins/panels/weather/Model.js')
+const panelPath = root + '/shell/plugins/panels/weather/Panel.qml'
+const panelSource = fs.readFileSync(panelPath, 'utf8')
+const lines = panelSource.split('\n')
+
+// ---- Manifest: the registry rejects manifests without schemaVersion. ----
+const manifest = JSON.parse(fs.readFileSync(root + '/shell/plugins/panels/weather/manifest.json', 'utf8'))
+assertEqual(manifest.schemaVersion, 1, 'weather manifest carries schemaVersion')
+assertEqual(manifest.id, 'omarchy.weather', 'weather manifest keeps the stock id')
+assertDeepEqual(
+  Object.keys(manifest),
+  ['schemaVersion', 'id', 'name', 'version', 'author', 'description', 'kinds', 'entryPoints', 'barWidget'],
+  'weather manifest keeps the stock key shape'
+)
+assertDeepEqual(Object.keys(manifest.entryPoints), ['barWidget'], 'weather manifest keeps the stock entry points')
+assertDeepEqual(
+  Object.keys(manifest.barWidget),
+  ['displayName', 'description', 'category', 'allowMultiple', 'settingsForm'],
+  'weather manifest keeps the stock bar widget shape'
+)
+assertEqual(manifest.entryPoints.barWidget, 'BarWidget.qml', 'weather manifest keeps the stock bar widget entry point')
+
+// ---- Neutral fetcher identity: MET Norway requires an identifying
+// User-Agent; it must name the upstream project and agree between the model
+// and the fetch script. ----
+assertEqual(weather.MET_CACHE_SUBDIR, 'weather', 'weather caches MET data under a neutral Omarchy directory')
+assert(weather.MET_USER_AGENT.includes('omacom/omarchy'), 'weather MET user agent identifies the upstream project')
+const fetchSource = fs.readFileSync(root + '/shell/plugins/panels/weather/met-fetch.sh', 'utf8')
+assert(fetchSource.includes(weather.MET_USER_AGENT), 'weather fetch script sends the same user agent as the model')
+
+// ---- Structural reader for Panel.qml: the panel cannot run under plain
+// node, so render-structure regressions are pinned by parsing the real QML:
+// block spans, nesting, and effective `visible:` bindings. ----
+function parseBlocks(textLines) {
+  const text = textLines.join('\n')
+  const blocks = []
+  const stack = []
+  let inString = false
+  let line = 1
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i]
+    if (c === '\n') { line++; continue }
+    if (inString) {
+      if (c === '"') inString = false
+      continue
+    }
+    if (c === '"') { inString = true; continue }
+    if (c === '/' && text[i + 1] === '/') {
+      while (i < text.length && text[i] !== '\n') i++
+      line++
+      continue
+    }
+    if (c === '{') {
+      const m = textLines[line - 1].match(/([A-Za-z][A-Za-z0-9_.]*)\s*\{[^}]*$/)
+      stack.push({ name: m ? m[1] : '{', startLine: line })
+    } else if (c === '}') {
+      const open = stack.pop()
+      if (open) blocks.push({ name: open.name, startLine: open.startLine, endLine: line })
+    }
+  }
+  return blocks
+}
+
+function innermostContaining(blocks, markerLine) {
+  let best = null
+  for (const b of blocks) {
+    if (b.startLine <= markerLine && markerLine <= b.endLine) {
+      if (!best || b.startLine >= best.startLine) best = b
+    }
+  }
+  return best
+}
+
+function findLine(pattern) {
+  const idx = lines.findIndex((l) => pattern.test(l))
+  return idx === -1 ? -1 : idx + 1
+}
+
+// The block's OWN `visible:` binding: first such line at the block's own
+// depth, so nested children's bindings never leak into the ancestor.
+function ownVisible(block) {
+  let depth = 0
+  let inString = false
+  for (let n = block.startLine; n <= block.endLine; n++) {
+    let line = lines[n - 1]
+    if (n === block.startLine) {
+      const open = line.indexOf('{')
+      line = open === -1 ? '' : line.slice(open + 1)
+    } else {
+      const m = line.match(/^\s*visible:\s*(.+?)\s*$/)
+      if (m && depth === 0) return m[1]
+    }
+    for (let i = 0; i < line.length; i++) {
+      const c = line[i]
+      if (inString) {
+        if (c === '"') inString = false
+        continue
+      }
+      if (c === '"') { inString = true; continue }
+      if (c === '/' && line[i + 1] === '/') break
+      if (c === '{') depth++
+      else if (c === '}') depth--
+    }
+  }
+  return null
+}
+
+// Effective `visible:` along the ancestor chain, evaluated for a panel that
+// HAS current conditions and day rows. Unknown bindings default to visible;
+// the bindings that matter evaluate exactly.
+function effectiveVisible(block, rows) {
+  const chain = blocks
+    .filter((b) => b.startLine <= block.startLine && block.endLine <= b.endLine)
+    .sort((a, b) => a.startLine - b.startLine)
+  for (const ancestor of chain) {
+    const expr = ownVisible(ancestor)
+    if (!expr) continue
+    if (expr === '!root.current') return false
+    if (/dayRows\.length/.test(expr) && rows.length === 0) return false
+  }
+  return true
+}
+
+const blocks = parseBlocks(lines)
+const dayRepeaterLine = findLine(/model:\s*root\.dayRows/)
+assert(dayRepeaterLine > 0, 'weather panel repeats over the day rows')
+const daySection = innermostContaining(blocks, dayRepeaterLine)
+assert(daySection, 'weather day section sits inside a QML block')
+const fetchingLine = findLine(/Fetching forecast/)
+assert(fetchingLine > 0, 'weather fetching indicator exists')
+const fetching = innermostContaining(blocks, fetchingLine)
+assert(fetching, 'weather fetching indicator sits inside a QML block')
+assert(
+  dayRepeaterLine > fetching.endLine,
+  'weather day rows never nest inside the self-hiding fetching indicator'
+)
+assert(
+  effectiveVisible(daySection, [{ date: '2026-09-12' }]) === true,
+  'weather day section stays visible once current conditions arrive'
+)
+const creditLine = findLine(/Data: MET Norway, Open-Meteo/)
+assert(creditLine > 0, 'weather panel credits its data sources')
+assert(creditLine > fetching.endLine, 'weather credit line never nests inside the fetching indicator')
+assert(
+  effectiveVisible(innermostContaining(blocks, creditLine), [{ date: '2026-09-12' }]) === true,
+  'weather credit line stays visible with the day rows'
+)
+
+// The QML fetch handlers cannot run under node, so their contract is pinned
+// against the real source: the Open-Meteo store is unconditional, and the
+// wttr handler re-issues both follow-up fetches once the area is known.
+function handlerBlock(id) {
+  const idLine = findLine(new RegExp(`id:\\s*${id}\\b`))
+  assert(idLine > 0, `weather handler exists: ${id}`)
+  return innermostContaining(blocks, idLine)
+}
+const dailyBody = lines.slice(handlerBlock('dailyForecastProc').startLine - 1, handlerBlock('dailyForecastProc').endLine).join('\n')
+const tryIdx = dailyBody.search(/\btry\s*\{/)
+const storeIdx = dailyBody.search(/root\.dailyForecastReport\s*=\s*parsed/)
+assert(tryIdx >= 0 && storeIdx > tryIdx, 'weather stores the arriving Open-Meteo response')
+assert(!/\bif\b/.test(dailyBody.slice(tryIdx, storeIdx)), 'weather stores the Open-Meteo response unconditionally')
+const forecastBody = lines.slice(handlerBlock('forecastProc').startLine - 1, handlerBlock('forecastProc').endLine).join('\n')
+assert(forecastBody.includes('root.refreshDailyForecast(parsed)'), 'weather re-issues the Open-Meteo fetch once the area is known')
+assert(forecastBody.includes('root.refreshMet()'), 'weather re-issues the MET fetch once the area is known')
+
+// ---- Model units: coordinates, symbols, slots, and formatting. ----
+assertEqual(weather.metUrl('46.05111', '14.51111'), weather.MET_API_URL + '?lat=46.0511&lon=14.5111', 'weather rounds MET coordinates to 4 decimals')
+assertEqual(weather.metUrl('nope', '14.5'), '', 'weather refuses unparseable MET coordinates')
+assertEqual(
+  weather.pickWetterSymbol([{ precipMm: 0.2, symbol: 'cloudy' }, { precipMm: 1.5, symbol: 'rain' }]),
+  'rain',
+  'weather shows the wetter hour symbol'
+)
+assertEqual(
+  weather.pickWetterSymbol([{ precipMm: 1.5, symbol: 'rain' }, { precipMm: 1.5, symbol: 'heavyrain' }]),
+  'rain',
+  'weather keeps the first symbol on a precipitation tie'
+)
+assertEqual(weather.iconForMetSymbol('clearsky'), weather.iconForCode(113, false), 'weather maps MET symbols onto widget glyphs')
+assertEqual(weather.iconForMetSymbol('partlycloudy_night'), weather.iconForCode(116, true), 'weather keeps MET day/night suffixes')
+assertEqual(weather.iconForMetSymbol('volcano'), weather.iconForCode(119, false), 'weather falls back to cloudy for unknown MET symbols')
+assertEqual(weather.formatSlotTemp(21.4, false), '21°', 'weather formats slot temperatures')
+assertEqual(weather.formatSlotTemp(null, false), weather.MISSING_VALUE, 'weather dashes missing slot temperatures')
+assertEqual(weather.formatRain(2), '2.0', 'weather formats rain amounts')
+assertEqual(weather.formatRain(null), weather.MISSING_VALUE, 'weather dashes missing rain')
+assertEqual(weather.formatChance(80), '80%', 'weather formats chance of rain')
+assertEqual(weather.formatChance(null), weather.MISSING_VALUE, 'weather dashes missing chance')
+assertEqual(weather.formatDayRain(2), '2.0 mm', 'weather formats day rain totals')
+assertEqual(weather.dayRainTotal([{ rainMm: 1 }, { rainMm: null }, { rainMm: 2 }]), 3, 'weather totals day rain over populated slots')
+assertEqual(weather.dayRainTotal([{ rainMm: null }]), null, 'weather totals missing day rain as missing')
+
+const wttrArea = { nearest_area: [{ latitude: '46.05', longitude: '14.51', areaName: [{ value: 'Ljubljana' }] }] }
+assertDeepEqual(
+  weather.forecastCoords(weather.parseLocationFile(''), wttrArea, null),
+  [46.05, 14.51],
+  'weather resolves fetch coordinates from the detected area without a saved location'
+)
+assertDeepEqual(
+  weather.forecastCoords(weather.parseLocationFile('{"name":"X","latitude":1.5,"longitude":2.5}'), wttrArea, null),
+  [1.5, 2.5],
+  'weather prefers saved coordinates over the detected area'
+)
+assertEqual(weather.forecastCoords(weather.parseLocationFile(''), null, null), null, 'weather issues no fetch without coordinates anywhere')
+
+// A Locationforecast-shaped series with only 6-hour data at a quarter start
+// must still populate that quarter through the next_6_hours fallback.
+const quarterStart = Date.parse('2026-09-13T04:00:00Z')
+const fallbackIndex = weather.indexMetTimeseries([{
+  time: new Date(quarterStart).toISOString().slice(0, 13) + ':00:00Z',
+  data: {
+    instant: { details: { air_temperature: 14.0 } },
+    next_6_hours: { summary: { symbol_code: 'rain' }, details: { precipitation_amount: 2.5 } }
+  }
+}])
+const fallbackSlots = weather.buildSixHourSlots(fallbackIndex, {}, '2026-09-13')
+assertEqual(fallbackSlots.length, 4, 'weather builds four 6-hour quarters for a later day')
+assertDeepEqual(fallbackSlots.map((s) => s.label), ['00-06', '06-12', '12-18', '18-24'], 'weather labels quarters in local wall time')
+
+// ---- End to end: the no-saved-location sequence through populated tables.
+// MET instants are UTC; slot boundaries are local wall time
+// (Europe/Ljubljana, UTC+2 in September).
+const H = 3600000
+const TODAY = '2026-09-12'
+const NOW_MS = Date.parse('2026-09-11T22:35:00Z')
+const seriesBase = Date.parse('2026-09-11T20:00:00Z')
+const series = []
+for (let h = 0; h < 100; h++) {
+  const ms = seriesBase + h * H
+  const entry = {
+    time: new Date(ms).toISOString().slice(0, 13) + ':00:00Z',
+    data: {
+      instant: { details: { air_temperature: 12 + (h % 9) } },
+      next_1_hours: {
+        summary: { symbol_code: h % 2 ? 'lightrain' : 'cloudy' },
+        details: { precipitation_amount: (h % 3) * 0.4 }
+      }
+    }
+  }
+  if (h % 6 === 0) {
+    entry.data.next_6_hours = {
+      summary: { symbol_code: 'rain' },
+      details: { precipitation_amount: 1.2 }
+    }
+  }
+  series.push(entry)
+}
+const hourlyTime = []
+const hourlyProb = []
+for (let h = 0; h < 96; h++) {
+  const ms = Date.parse(TODAY + 'T00:00:00') + h * H
+  const d = new Date(ms)
+  const pad = (n) => String(n).padStart(2, '0')
+  hourlyTime.push(`${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:00`)
+  hourlyProb.push((h * 7) % 100)
+}
+const openMeteo = {
+  daily: {
+    time: ['2026-09-12', '2026-09-13', '2026-09-14', '2026-09-15'],
+    temperature_2m_max: [20.1, 21.6, 18.2, 17.9],
+    temperature_2m_min: [12.2, 13.1, 10.8, 9.2],
+    weather_code: [3, 63, 95, 1]
+  },
+  hourly: { time: hourlyTime, precipitation_probability: hourlyProb }
+}
+
+const metIndex = weather.indexMetTimeseries(series)
+const probIndex = weather.indexPrecipitationProbability(openMeteo.hourly)
+const rows = weather.openMeteoDayRows(openMeteo, TODAY)
+assertEqual(rows.length, 4, 'weather yields four day rows starting today')
+assertDeepEqual(rows.map((r) => r.date), ['2026-09-12', '2026-09-13', '2026-09-14', '2026-09-15'], 'weather rows start at today')
+assertEqual(rows[0].isToday, true, 'weather marks the first row as today')
+const todaySlots = weather.buildTwoHourSlots(metIndex, probIndex, NOW_MS, weather.TWO_HOUR_SLOT_COUNT)
+assertEqual(todaySlots.length, 12, 'weather builds 12 two-hour slots for today')
+for (const s of todaySlots) {
+  assert(s.rainMm !== null, `weather populates MET rain for slot ${s.label}`)
+  assert(s.chance !== null, `weather populates Open-Meteo chance for slot ${s.label}`)
+  assert(s.tempC !== null && s.icon, `weather populates temp and icon for slot ${s.label}`)
+}
+const laterSlots = weather.buildSixHourSlots(metIndex, probIndex, '2026-09-13')
+assertEqual(laterSlots.length, 4, 'weather builds four quarters for a later day')
+for (const s of laterSlots) {
+  assert(s.rainMm !== null, `weather populates MET rain for quarter ${s.label}`)
+  assert(s.chance !== null, `weather populates Open-Meteo chance for quarter ${s.label}`)
+}
+JS
+
+# ---- met-fetch.sh: the caching helper behind the MET fetch. ----
+[[ -x "$WEATHER_DIR/met-fetch.sh" ]] || fail "weather MET fetcher is executable"
+pass "weather MET fetcher is executable"
+
+bash -n "$WEATHER_DIR/met-fetch.sh" || fail "weather MET fetcher parses as bash"
+pass "weather MET fetcher parses as bash"
+
+fetch_tmp=$(mktemp -d)
+trap 'rm -rf "$fetch_tmp"' EXIT
+
+output=$("$WEATHER_DIR/met-fetch.sh" 2>/dev/null) && fail "weather MET fetcher rejects missing arguments" "$output"
+[[ $output == *'"status":"error"'* ]] || fail "weather MET fetcher reports usage errors as JSON" "$output"
+pass "weather MET fetcher rejects missing arguments as JSON"
+
+output=$("$WEATHER_DIR/met-fetch.sh" "46.05" "not-a-number" "$fetch_tmp" 2>/dev/null) && fail "weather MET fetcher rejects bad coordinates" "$output"
+pass "weather MET fetcher rejects bad coordinates"
+
+# A primed cache with a fresh check stays local: no network involved.
+mkdir -p "$fetch_tmp/met"
+printf '{}' >"$fetch_tmp/met/body.json"
+now=$(date +%s)
+printf 'meta_lat="46.0500"\nmeta_lon="14.5100"\nlast_fetch="%s"\nexpires=""\nlast_modified=""\n' "$now" >"$fetch_tmp/met/meta"
+output=$("$WEATHER_DIR/met-fetch.sh" "46.05" "14.51" "$fetch_tmp/met" 2>/dev/null) || fail "weather MET fetcher serves a fresh cache without fetching" "$output"
+[[ $output == *'"status":"throttled"'* ]] || fail "weather MET fetcher reports the throttled cache" "$output"
+pass "weather MET fetcher serves a fresh cache without fetching"
+


### PR DESCRIPTION
## What it does

Clicking a day in the weather panel now expands it into an hourly precipitation table:

- **Today** expands to 12 two-hour slots covering the next 24 hours.
- **Later days** (today + up to 3 following days) expand to four 6-hour quarters (00-06 / 06-12 / 12-18 / 18-24).
- Each slot shows an icon, temperature, rain in mm, and chance of rain; each day row shows its total rain. Missing values render as a dash, and the panel carries a `Data: MET Norway, Open-Meteo` credit line.

This is a clean patch against the current stock panel: the four upstream files were byte-identical to the baseline this was developed against (base commit `31bd80da`).

## Data sources (please read)

This adds two network dependencies beyond what the stock panel uses, stated plainly so you can object to either:

- **MET Norway (yr.no) Locationforecast 2.0** supplies rain amounts, temperatures, and icons. It requires an identifying `User-Agent`; I used `omarchy-weather/1.0 https://github.com/omacom/omarchy` — please swap in whatever contact you prefer. Fetching goes through the new `shell/plugins/panels/weather/met-fetch.sh`, which caches under `~/.cache/omarchy/weather/`: at most one request per 30 minutes per coordinate pair, `Expires` honoured, `If-Modified-Since` revalidation (a 304 keeps the cached body). Their terms expect visible credit, which the panel shows.
- **Open-Meteo** supplies *only* the chance-of-rain column: MET Norway publishes no probability of precipitation outside the Nordics. It piggybacks on the existing Open-Meteo fetch (one added `hourly=precipitation_probability` parameter), so no new fetcher or cache.

If a second provider is unacceptable, the honest fallback is hiding the chance column when Open-Meteo is unavailable rather than dropping the rain tables — I kept the requested feature intact and leave that call to you.

## Tests

New `test/shell.d/weather-rain-test.sh` (upstream shell-test conventions, no fixtures needed — data is generated inline in real API shapes):

- Manifest guard: `schemaVersion` present, id `omarchy.weather`, key shape matches stock (guards the outage where a missing `schemaVersion` kept the widget off the bar).
- Structural QML guard: parses block spans, nesting, and effective `visible:` bindings of the real `Panel.qml`, so a day section can never again nest inside the self-hiding fetching indicator; also pins the unconditional Open-Meteo store and the wttr-handler re-issue of both follow-up fetches. Verified it fails against the stock panel.
- End-to-end no-saved-location sequence: coordinates resolve from the detected area (public Ljubljana example point, lat=46.05 lon=14.51), 4 day rows, 12 two-hour slots today and 4 quarters on a later day, all with rain, chance, temp, and icon populated — plus the `next_6_hours` fallback path.
- `met-fetch.sh`: executable, `bash -n` clean, usage/coordinate errors as JSON, fresh-cache serve without network, and a grep asserting no personal identifiers in the plugin.

Also: existing `weather-test.sh` passes unchanged (the `dayIcon` node export it needs is kept), the `qml-text-format` scan is clean, and `qmllint` reports no syntax errors and no new warning classes versus the stock file (only the same unresolved-import noise, scaled with the added code).

Full suite (`./test/all`): 6 pre-existing failures, identical before and after on the untouched base (`bar-icon-geometry`, `config`, `launch-about`, `locate`, `snapper`, `unowned-system-paths`) — 5 reproduce on a pristine base checkout, and `locate` is a `bin/__pycache__` ordering artifact (passes on a clean tree either way). One extra flake in the after-run: `runtime-smoke` failed once on a single `osd` IPC-handler collision and passes in isolation; that target is untouched by this diff.
