### PR TITLE
Fix menu navigation history unconditionally resetting cursor index

### DIFF
--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -726,13 +726,15 @@ Item {
     root.rebuildDisplay()
   }
 
-  function setActiveMenu(id, pushHistory, fromPointer) {
+  function setActiveMenu(id, pushHistory, fromPointer, restoreIndex) {
     panel.freezeCardTop()
     if (!root.item(id)) id = "root"
-    if (pushHistory && id !== root.activeMenu) root.navStack = root.navStack.concat([root.activeMenu])
+    if (pushHistory && id !== root.activeMenu) {
+      root.navStack = root.navStack.concat([{ id: root.activeMenu, index: root.selectedIndex }])
+    }
     root.activeMenu = id
     root.filterText = ""
-    root.selectedIndex = 0
+    root.selectedIndex = restoreIndex !== undefined ? restoreIndex : 0
     root.cursorActive = true
     if (fromPointer) pointerGate.allowInitialSample()
     else root.disarmPointer()
@@ -747,7 +749,11 @@ Item {
     if (root.navStack.length > 0) {
       var previous = root.navStack[root.navStack.length - 1]
       root.navStack = root.navStack.slice(0, root.navStack.length - 1)
-      root.setActiveMenu(previous, false)
+      if (typeof previous === "string") {
+        root.setActiveMenu(previous, false)
+      } else {
+        root.setActiveMenu(previous.id, false, false, previous.index)
+      }
       return true
     }
 


### PR DESCRIPTION
Currently, when navigating backwards through the omarchy menu submenus (e.g., using Left Arrow or Backspace), the cursor position is unconditionally reset to the top of the menu (index 0).

This PR fixes that behavior by modifying the navigation history stack (`navStack`) to store both the menu ID and the `selectedIndex`. When returning to a previous menu, `goBack` now passes the saved index back to `setActiveMenu`, preserving the exact cursor position where the user left off.