### PR TITLE
Derive publicBarConfig() from shellConfig to fix one-step-late plugin APIs

### DIFF
--- a/shell/shell.qml
+++ b/shell/shell.qml
@@ -324,7 +324,14 @@ ShellRoot {
   }
 
   function publicBarConfig() {
-    return JSON.parse(JSON.stringify(shell.barConfig || {}))
+    // Derive from shellConfig directly instead of the derived barConfig
+    // binding: inside onShellConfigChanged, dependent bindings have not
+    // re-evaluated yet, so reading the derived binding here (via
+    // syncPluginApis) returns the previous bar config. Mirrors
+    // publicIdleConfigFor().
+    var config = shell.shellConfig && Util.isPlainObject(shell.shellConfig.bar)
+      ? shell.shellConfig.bar : builtinShellConfig.bar
+    return JSON.parse(JSON.stringify(config || {}))
   }
 
   function barConfigFor(manifest) {

--- a/test/shell.d/fixtures/plugin-bar-config-freshness/shell.qml
+++ b/test/shell.d/fixtures/plugin-bar-config-freshness/shell.qml
@@ -1,0 +1,80 @@
+import QtQuick
+import Quickshell
+
+// Regression fixture for https://github.com/omacom/omarchy/issues/11505.
+// Mirrors shell.qml's shellConfig -> barConfig chain: a derived `barConfig`
+// binding plus the two candidate readers. Drives sequential writes and records
+// what each reader returns from inside onShellConfigChanged, where QML has
+// not re-evaluated dependent bindings yet.
+ShellRoot {
+  id: root
+
+  readonly property string resultPath: Quickshell.env("OMARCHY_QML_TEST_RESULT")
+  property var failures: []
+  property var observations: []
+
+  property var shellConfig: ({ bar: { v: 0 } })
+  readonly property var barConfig: shellConfig && shellConfig.bar ? shellConfig.bar : ({})
+
+  // Pre-fix publicBarConfig() shape: reads the derived binding (stale here).
+  function bindingBarConfig() {
+    return JSON.parse(JSON.stringify(root.barConfig || {}))
+  }
+
+  // Fixed publicBarConfig() shape (mirrors publicIdleConfigFor): derives from
+  // shellConfig directly, so it cannot observe the stale binding.
+  function directBarConfig() {
+    var config = root.shellConfig && root.shellConfig.bar ? root.shellConfig.bar : ({})
+    return JSON.parse(JSON.stringify(config))
+  }
+
+  function fail(message) {
+    failures.push(String(message))
+  }
+
+  function shellQuote(value) {
+    return "'" + String(value).replace(/'/g, "'\\''") + "'"
+  }
+
+  function writeResult() {
+    var lagObserved = false
+    for (var i = 0; i < observations.length; i++) {
+      if (observations[i].viaBinding !== observations[i].actual) lagObserved = true
+    }
+    if (!lagObserved)
+      fail("expected the derived barConfig binding to lag inside onShellConfigChanged (bug premise); observations=" + JSON.stringify(observations))
+    var payload = JSON.stringify({
+      ok: failures.length === 0,
+      failures: failures,
+      observations: observations
+    })
+    if (resultPath) {
+      Quickshell.execDetached(["bash", "-lc", "printf '%s' " + shellQuote(payload) + " > " + shellQuote(resultPath)])
+    }
+  }
+
+  onShellConfigChanged: {
+    var actual = (shellConfig && shellConfig.bar) ? shellConfig.bar.v : -1
+    var viaBinding = bindingBarConfig().v
+    var viaDirect = directBarConfig().v
+    observations.push({ actual: actual, viaBinding: viaBinding, viaDirect: viaDirect })
+    if (viaDirect !== actual)
+      fail("direct derivation lagged: direct=" + viaDirect + " actual=" + actual)
+  }
+
+  Timer {
+    interval: 1
+    running: true
+    repeat: false
+    onTriggered: {
+      shellConfig = { bar: { v: 1 } }
+      shellConfig = { bar: { v: 2 } }
+      shellConfig = { bar: { v: 3 } }
+      Qt.callLater(function() {
+        if (observations.length < 3)
+          fail("expected 3 config observations, saw " + observations.length)
+        root.writeResult()
+      })
+    }
+  }
+}

--- a/test/shell.d/plugin-bar-config-freshness-test.sh
+++ b/test/shell.d/plugin-bar-config-freshness-test.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+TMPDIR=""
+QS_PID=""
+
+cleanup() {
+  if [[ -n $QS_PID ]] && kill -0 "$QS_PID" 2>/dev/null; then
+    kill "$QS_PID" 2>/dev/null || true
+    wait "$QS_PID" 2>/dev/null || true
+  fi
+  if [[ -n $TMPDIR && -d $TMPDIR ]]; then
+    rm -rf "$TMPDIR"
+  fi
+}
+trap cleanup EXIT
+
+shell_qml="$ROOT/shell/shell.qml"
+
+# Normalize horizontal and vertical whitespace so the wiring assertions survive
+# harmless QML reflow. Same technique as plugin-auth-boundary-test.sh.
+qml_matches() {
+  local file=$1
+  local pattern=$2
+
+  tr '\n\r\t' '   ' < "$file" | grep -Eq "$pattern"
+}
+
+# Regression guard for https://github.com/omacom/omarchy/issues/11505:
+# publicBarConfig() must derive from shellConfig directly (like
+# publicIdleConfigFor does), never from the derived barConfig binding, which
+# is still stale inside onShellConfigChanged when syncPluginApis() runs.
+qml_matches "$shell_qml" 'function publicBarConfig\(\) *\{[^}]*shell\.shellConfig\.bar' ||
+  fail "publicBarConfig derives bar config from shellConfig directly (#11505)"
+qml_matches "$shell_qml" 'function publicBarConfig\(\) *\{[^}]*shell\.barConfig' &&
+  fail "publicBarConfig reads the stale derived barConfig binding (#11505)"
+pass "publicBarConfig derives from shellConfig, not the derived binding"
+
+# Both affected readers flow through publicBarConfig(), so the one fix covers
+# them: scoped plugin shell APIs and bar-entry shell APIs in syncPluginApis().
+qml_matches "$shell_qml" 'shellApi\.barConfig = shell\.publicBarConfig\(\)' ||
+  fail "scoped plugin shell APIs refresh barConfig through publicBarConfig"
+qml_matches "$shell_qml" '_pluginBarEntryShellApis\[entryKey\]\.barConfig = shell\.publicBarConfig\(\)' ||
+  fail "bar-entry shell APIs refresh barConfig through publicBarConfig"
+pass "both plugin API maps refresh barConfig through publicBarConfig"
+
+# barConfigFor() still routes third-party callers through publicBarConfig().
+# Its first-party branch returns the shell.barConfig binding, which is only
+# read from onBarConfigChanged and Loader onLoaded - both run after bindings
+# re-evaluate, so that branch is unaffected by #11505.
+qml_matches "$shell_qml" '\? *shell\.barConfig *: *shell\.publicBarConfig\(\)' ||
+  fail "barConfigFor routes third-party callers through publicBarConfig"
+pass "barConfigFor routes third-party callers through publicBarConfig"
+
+require_compositor "plugin bar config freshness test"
+
+if ! command -v quickshell >/dev/null 2>&1; then
+  pass "quickshell not installed; skipping plugin bar config freshness test"
+  exit 0
+fi
+
+require_command jq
+
+TMPDIR=$(mktemp -d)
+result="$TMPDIR/result.json"
+log="$TMPDIR/quickshell.log"
+config_dir="$TMPDIR/plugin-bar-config-freshness"
+mkdir -p "$config_dir" "$TMPDIR/home"
+cp "$SHELL_TEST_DIR/fixtures/plugin-bar-config-freshness/shell.qml" "$config_dir/shell.qml"
+
+# Quickshell aborts through qFatal() when its connection drops; keep that
+# abort from writing a core (same rationale as require_compositor).
+ulimit -c 0 2>/dev/null || true
+
+OMARCHY_PATH="$ROOT" \
+OMARCHY_QML_TEST_RESULT="$result" \
+HOME="$TMPDIR/home" \
+XDG_CONFIG_HOME="$TMPDIR/home/.config" \
+XDG_CACHE_HOME="$TMPDIR/home/.cache" \
+XDG_STATE_HOME="$TMPDIR/home/.local/state" \
+PATH="$ROOT/bin:$PATH" \
+  quickshell -p "$config_dir" --no-color >"$log" 2>&1 &
+QS_PID=$!
+
+for _ in {1..80}; do
+  [[ -s $result ]] && break
+  if ! kill -0 "$QS_PID" 2>/dev/null; then
+    sed -n '1,220p' "$log" >&2
+    fail "plugin bar config freshness quickshell exited before writing result"
+  fi
+  sleep 0.1
+done
+
+[[ -s $result ]] || {
+  sed -n '1,220p' "$log" >&2
+  fail "plugin bar config freshness test timed out"
+}
+
+if ! jq -e '.ok == true' "$result" >/dev/null; then
+  printf 'Plugin bar config freshness result:\n' >&2
+  jq . "$result" >&2
+  printf 'Plugin bar config freshness log:\n' >&2
+  sed -n '1,220p' "$log" >&2
+  fail "plugin services observe fresh bar config inside onShellConfigChanged"
+fi
+
+pass "plugin services observe fresh bar config inside onShellConfigChanged"


### PR DESCRIPTION
Fixes #11505

Plugin services received `shell.json` bar changes one change late: `syncPluginApis()` runs from inside `onShellConfigChanged`, where the derived `barConfig` binding has not re-evaluated yet, so `publicBarConfig()` snapshotted the previous config.

Root-cause analysis and suggested fix credit: the issue reporter. I verified the report empirically first - the minimal repro prints `handler sees 0 actual 1` / `handler sees 1 actual 2`, i.e. the binding lags exactly one change behind `shellConfig` inside the handler.

Choice of fix: I took the reporter's primary suggestion (derive from `shellConfig` directly, mirroring `publicIdleConfigFor()`) over the `onBarConfigChanged` / `Qt.callLater` alternative. Deriving directly removes the ordering dependency instead of working around it: every caller gets fresh data regardless of call context. Deferring would split update timing - `_syncServices()` runs synchronously in the same `pluginsChanged` emission and creates scoped APIs via `publicBarConfig()`, so a deferred refresh would still race service creation.

How each affected reader is handled (all flow through the one fixed function):

- `syncPluginApis()` `shellApi.barConfig = shell.publicBarConfig()` - fixed (fresh now).
- `syncPluginApis()` `_pluginBarEntryShellApis[entryKey].barConfig = shell.publicBarConfig()` - fixed the same way.
- `barConfigFor()` line-332 ternary - its third-party branch delegates to `publicBarConfig()`, fixed. Its first-party branch returns the `shell.barConfig` binding, but that branch is only read from `onBarConfigChanged` and Loader `onLoaded`, both of which run after bindings re-evaluate, so it was never stale and is unchanged.

Unaffected paths: bar widgets already work through `onBarConfigChanged` / `applySettingsDelta()` (covered by the passing `bar-widget-contract` suite); `publicIdleConfigFor()` already derives from `shellConfig` and is untouched.

Validation:

- New `test/shell.d/plugin-bar-config-freshness-test.sh` (+ fixture `test/shell.d/fixtures/plugin-bar-config-freshness/shell.qml`, following the `plugin-auth-boundary` static-wiring + runtime-fixture convention): fails on current `quattro` (`not ok - publicBarConfig derives bar config from shellConfig directly`), passes after the fix. The runtime fixture's pre-fix observations show the binding lag (`viaBinding` one step behind `actual`) while direct derivation always equals `actual`.
- `qmllint` on `shell/shell.qml` and the new fixture: exit 0, warning counts identical in kind to the pre-existing file/fixture baseline.
- Full `./test/all`: the only failures (6 files: missing `omarchy-pkgs` checkout, geometry/animation environment cases, a binary-fixture decode) fail identically on the untouched base.
