### PR TITLE
fix: Match 1Password’s new window class to preserve floating behavior

### DIFF
--- a/default/hypr/apps/1password.lua
+++ b/default/hypr/apps/1password.lua
@@ -1,1 +1,1 @@
-o.window("^(1[p|P]assword)$", { no_screen_share = true, tag = "+floating-window" })
+o.window("^(1[pP]assword|com\\.onepassword\\.OnePassword)$", { no_screen_share = true, tag = "+floating-window" })


### PR DESCRIPTION
After today's 1Password update, its window class changed to `com.onepassword.OnePassword`, so Omarchy's existing rule no longer applied floating behavior.

I patched the window rule to include this new class while preserving compatibility with the previous class.