### PR TITLE
Fix legacy Intel VA-API driver detection

### DIFF
--- a/install/hardware/intel/video-acceleration.sh
+++ b/install/hardware/intel/video-acceleration.sh
@@ -1,11 +1,10 @@
 # This installs hardware video acceleration for Intel GPUs
 
 if INTEL_GPU=$(lspci | grep -iE 'vga|3d|display' | grep -i 'intel'); then
-  # HD Graphics / Iris / Xe / Arc / Non-Arc Panther Lake use intel-media-driver + VPL
-  if [[ ${INTEL_GPU,,} =~ (hd\ graphics|uhd\ graphics|xe|iris|arc|panther\ lake) ]]; then
-    omarchy-pkg-add intel-media-driver libvpl vpl-gpu-rt
-  elif [[ ${INTEL_GPU,,} =~ "gma" ]]; then
-    # Older generations from 2008 to ~2014-2017 use libva-intel-driver
+  # Intel generations before Broadwell use the legacy i965 driver.
+  if [[ ${INTEL_GPU,,} =~ (gma|ironlake|sandy\ bridge|2nd\ gen\ core|ivy\ bridge|3rd\ gen\ core|haswell|crystal\ well|4th\ gen\ core) ]]; then
     omarchy-pkg-add libva-intel-driver
+  elif [[ ${INTEL_GPU,,} =~ (hd\ graphics|uhd\ graphics|xe|iris|arc|panther\ lake) ]]; then
+    omarchy-pkg-add intel-media-driver libvpl vpl-gpu-rt
   fi
 fi

--- a/test/shell.d/intel-video-acceleration-test.sh
+++ b/test/shell.d/intel-video-acceleration-test.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+
+mkdir -p "$test_dir/bin"
+
+cat >"$test_dir/bin/lspci" <<'EOF'
+#!/bin/bash
+printf '%s\n' "$LSPCI_OUTPUT"
+EOF
+
+cat >"$test_dir/bin/omarchy-pkg-add" <<'EOF'
+#!/bin/bash
+printf '%s\n' "$*" >>"$PACKAGE_LOG"
+EOF
+
+chmod +x "$test_dir/bin/lspci" "$test_dir/bin/omarchy-pkg-add"
+
+run_installer() {
+  local lspci_output=$1
+
+  : >"$test_dir/packages"
+  PATH="$test_dir/bin:$PATH" \
+    LSPCI_OUTPUT="$lspci_output" \
+    PACKAGE_LOG="$test_dir/packages" \
+    bash "$ROOT/install/hardware/intel/video-acceleration.sh"
+}
+
+run_installer "00:02.0 VGA compatible controller: Intel Corporation Haswell-ULT Integrated Graphics Controller (rev 09)"
+[[ $(<"$test_dir/packages") == "libva-intel-driver" ]] || fail "Haswell uses the legacy Intel VA-API driver"
+pass "Haswell uses the legacy Intel VA-API driver"
+
+run_installer "00:02.0 VGA compatible controller: Intel Corporation Ivy Bridge mobile GT2 [HD Graphics 4000] (rev 09)"
+[[ $(<"$test_dir/packages") == "libva-intel-driver" ]] || fail "Ivy Bridge HD Graphics uses the legacy Intel VA-API driver"
+pass "Ivy Bridge HD Graphics uses the legacy Intel VA-API driver"
+
+run_installer "00:02.0 VGA compatible controller: Intel Corporation Broadwell-U GT2 [HD Graphics 5500] (rev 09)"
+[[ $(<"$test_dir/packages") == "intel-media-driver libvpl vpl-gpu-rt" ]] || fail "Broadwell uses the current Intel media driver"
+pass "Broadwell uses the current Intel media driver"
+
+run_installer "00:02.0 VGA compatible controller: Intel Corporation Unknown Integrated Graphics Controller (rev 09)"
+[[ ! -s $test_dir/packages ]] || fail "an unknown Intel GPU keeps the existing no-op behavior"
+pass "an unknown Intel GPU keeps the existing no-op behavior"
+
+run_installer "01:00.0 VGA compatible controller: Advanced Micro Devices, Inc. [AMD/ATI] Device"
+[[ ! -s $test_dir/packages ]] || fail "non-Intel graphics installs no Intel media driver"
+pass "non-Intel graphics installs no Intel media driver"


### PR DESCRIPTION
Intel VA-API selection currently keys off product branding: any `HD Graphics` or `Iris` name gets the Broadwell+ `intel-media-driver`, while only `GMA` reaches the legacy `libva-intel-driver`. This sends Ivy Bridge HD Graphics to the wrong driver and leaves devices reported by `lspci` as `Haswell-ULT Integrated Graphics Controller` without either driver.

Classify known pre-Broadwell generations before the existing modern Intel check. The regression test covers the Haswell MacBook string, Ivy Bridge HD Graphics, Broadwell, an unknown Intel device, and a non-Intel device. Unknown devices retain the existing no-op behavior.

Fixes #7866.
Addresses the Haswell driver-selection problem described in #8388.

Validation:

```text
bash test/shell.d/intel-video-acceleration-test.sh
ok - Haswell uses the legacy Intel VA-API driver
ok - Ivy Bridge HD Graphics uses the legacy Intel VA-API driver
ok - Broadwell uses the current Intel media driver
ok - an unknown Intel GPU keeps the existing no-op behavior
ok - non-Intel graphics installs no Intel media driver
```

Also passed `bash -n` for both changed shell files and `git diff --check`.
