### PR TITLE
Disable unprivileged TTY line-discipline autoload

### DIFF
--- a/etc/sysctl.d/99-omarchy-sysctl.conf
+++ b/etc/sysctl.d/99-omarchy-sysctl.conf
@@ -34,3 +34,9 @@ vm.dirty_bytes=268435456
 
 # With bursts bounded above, the flusher can wake every 15s instead of 5s.
 vm.dirty_writeback_centisecs=1500
+
+# Block unprivileged processes from autoloading obscure TTY line-discipline
+# modules via TIOCSETD — a recurring local privilege-escalation surface
+# (n_hdlc/CVE-2017-2636, n_gsm/CVE-2023-6546). Root, systemd and udev still
+# autoload normally, so btattach/ldattach/pppd are unaffected.
+dev.tty.ldisc_autoload=0

--- a/migrations/1789261000.sh
+++ b/migrations/1789261000.sh
@@ -1,0 +1,9 @@
+echo "Disable unprivileged TTY line-discipline autoload"
+
+# Package updates deliver etc/sysctl.d/99-omarchy-sysctl.conf with
+# dev.tty.ldisc_autoload=0, but existing boots keep the prior runtime value
+# until the next reboot unless we load the file now. Apply only our drop-in
+# so an unrelated invalid key elsewhere cannot fail the migration.
+if [[ -r /etc/sysctl.d/99-omarchy-sysctl.conf ]]; then
+  sudo sysctl -p /etc/sysctl.d/99-omarchy-sysctl.conf >/dev/null 2>&1 || true
+fi

--- a/test/shell.d/sysctl-ldisc-autoload-test.sh
+++ b/test/shell.d/sysctl-ldisc-autoload-test.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Omarchy ships hardening-adjacent sysctls in etc/sysctl.d/.
+# dev.tty.ldisc_autoload=0 must stay present so unprivileged TIOCSETD cannot
+# cold-load obscure line-discipline modules.
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+conf="$ROOT/etc/sysctl.d/99-omarchy-sysctl.conf"
+[[ -f $conf ]] || fail "99-omarchy-sysctl.conf is packaged under etc/sysctl.d"
+
+grep -Eq '^[[:space:]]*dev\.tty\.ldisc_autoload[[:space:]]*=[[:space:]]*0[[:space:]]*$' "$conf" ||
+  fail "99-omarchy-sysctl.conf sets dev.tty.ldisc_autoload=0" "$(grep ldisc "$conf" || true)"
+
+! grep -Eq '^[[:space:]]*dev\.tty\.ldisc_autoload[[:space:]]*=[[:space:]]*1[[:space:]]*$' "$conf" ||
+  fail "99-omarchy-sysctl.conf must not set ldisc_autoload=1"
+
+pass "sysctl drop-in disables unprivileged TTY ldisc autoload"
+
+migration="$ROOT/migrations/1789261000.sh"
+[[ -f $migration ]] || fail "a migration applies the ldisc_autoload drop-in on existing installs"
+grep -q '99-omarchy-sysctl.conf' "$migration" ||
+  fail "migration loads the omarchy sysctl drop-in specifically"
+grep -q 'sysctl -p' "$migration" ||
+  fail "migration applies the drop-in at runtime rather than only on next boot"
+
+pass "migration reapplies the sysctl drop-in without waiting for reboot"


### PR DESCRIPTION
## Summary
- Set `dev.tty.ldisc_autoload=0` in the shipped sysctl drop-in so unprivileged `TIOCSETD` cannot cold-load obscure TTY line-discipline modules (KSPP; n_hdlc/CVE-2017-2636, n_gsm/CVE-2023-6546).
- Migration applies the drop-in at update time so existing boots do not wait for reboot.

Fixes #9295.

## Test plan
- [x] `./test/shell.d/sysctl-ldisc-autoload-test.sh`
