### PR TITLE
Gate lock fingerprint PAM behind the laptop lid

### DIFF
--- a/bin/omarchy-apply-lock
+++ b/bin/omarchy-apply-lock
@@ -43,8 +43,11 @@ EOF
 if [[ -x /usr/bin/fprintd-list ]] &&
   /usr/bin/fprintd-list "$target_user" 2>/dev/null | grep -qi finger; then
   echo "Configuring lock screen fingerprint authentication..."
+  # Same clamshell gate as sudo/polkit / setup-security-fingerprint: lid closed
+  # skips pam_fprintd and this stack fails closed (password is a parallel PAM).
   as_root tee /etc/pam.d/omarchy-lock-fingerprint >/dev/null <<'EOF'
 #%PAM-1.0
+auth       [success=1 default=ignore] pam_exec.so quiet /usr/bin/omarchy-hw-laptop-closed
 auth       required                    pam_fprintd.so
 account    include                     system-local-login
 EOF

--- a/bin/omarchy-setup-security-fingerprint
+++ b/bin/omarchy-setup-security-fingerprint
@@ -58,8 +58,13 @@ EOF
 
 setup_lock_fingerprint_pam() {
   echo "Configuring lock screen for fingerprint authentication..."
-  sudo tee /etc/pam.d/omarchy-lock-fingerprint >/dev/null <<'EOF'
+  # Same clamshell gate as sudo/polkit: lid closed → skip pam_fprintd (fail closed
+  # here — this stack has no password fallback; password runs in a parallel PAM
+  # service). Re-enrollment must keep rewriting the gate so it cannot be wiped.
+  local fprintd_gate="auth      [success=1 default=ignore] pam_exec.so quiet /usr/bin/omarchy-hw-laptop-closed"
+  sudo tee /etc/pam.d/omarchy-lock-fingerprint >/dev/null <<EOF
 #%PAM-1.0
+$fprintd_gate
 auth       required                    pam_fprintd.so
 account    include                     system-local-login
 EOF

--- a/migrations/1789261001.sh
+++ b/migrations/1789261001.sh
@@ -1,0 +1,15 @@
+echo "Gate lock-screen fingerprint auth behind the lid state"
+
+# Existing fingerprint setups write /etc/pam.d/omarchy-lock-fingerprint with
+# pam_fprintd alone. With the lid shut the lock screen still hammers the
+# unreachable reader. Insert the same pam_exec gate sudo/polkit already use.
+# New setups get this from omarchy-setup-security-fingerprint / omarchy-apply-lock.
+
+gate="auth      [success=1 default=ignore] pam_exec.so quiet /usr/bin/omarchy-hw-laptop-closed"
+pam=/etc/pam.d/omarchy-lock-fingerprint
+
+if [[ -f $pam ]] &&
+  grep -q 'pam_fprintd\.so' "$pam" &&
+  ! grep -q 'omarchy-hw-laptop-closed' "$pam"; then
+  sudo sed -i "/pam_fprintd\.so/i $gate" "$pam"
+fi

--- a/test/shell.d/lock-fingerprint-clamshell-gate-test.sh
+++ b/test/shell.d/lock-fingerprint-clamshell-gate-test.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+setup="$ROOT/bin/omarchy-setup-security-fingerprint"
+apply="$ROOT/bin/omarchy-apply-lock"
+
+grep -F 'setup_lock_fingerprint_pam' "$setup" >/dev/null ||
+  fail "setup-security-fingerprint still defines setup_lock_fingerprint_pam"
+
+# Extract the lock PAM writer by grepping the function body for the gate.
+grep -A20 'setup_lock_fingerprint_pam()' "$setup" | grep -Fq 'omarchy-hw-laptop-closed' ||
+  fail "setup_lock_fingerprint_pam writes the clamshell pam_exec gate"
+
+grep -A20 'setup_lock_fingerprint_pam()' "$setup" | grep -Fq 'pam_fprintd.so' ||
+  fail "setup_lock_fingerprint_pam still requires pam_fprintd"
+
+# Gate must come before pam_fprintd in the generated lock stack.
+python3 - "$setup" <<'PY' || fail "lock PAM gate is ordered before pam_fprintd in setup"
+import pathlib, re, sys
+text = pathlib.Path(sys.argv[1]).read_text()
+m = re.search(r"setup_lock_fingerprint_pam\(\) \{(.*?)^\}", text, re.S | re.M)
+body = m.group(1)
+if "omarchy-hw-laptop-closed" not in body:
+    raise SystemExit(1)
+# In the heredoc / tee payload, gate line must appear before pam_fprintd.
+idx_gate = body.find("omarchy-hw-laptop-closed")
+idx_fp = body.find("pam_fprintd.so")
+if idx_gate < 0 or idx_fp < 0 or idx_gate > idx_fp:
+    raise SystemExit(1)
+PY
+pass "setup lock fingerprint PAM includes an ordered clamshell gate"
+
+grep -Fq 'omarchy-hw-laptop-closed' "$apply" ||
+  fail "apply-lock writes the clamshell gate into omarchy-lock-fingerprint"
+# Order inside apply-lock heredoc
+python3 - "$apply" <<'PY' || fail "apply-lock orders the gate before pam_fprintd"
+import pathlib, sys
+text = pathlib.Path(sys.argv[1]).read_text()
+start = text.find("omarchy-lock-fingerprint")
+chunk = text[start:start+800]
+if chunk.find("omarchy-hw-laptop-closed") > chunk.find("pam_fprintd.so"):
+    raise SystemExit(1)
+if "omarchy-hw-laptop-closed" not in chunk:
+    raise SystemExit(1)
+PY
+pass "apply-lock lock fingerprint PAM includes an ordered clamshell gate"
+
+migration="$ROOT/migrations/1789261001.sh"
+[[ -f $migration ]] || fail "migration repairs existing lock fingerprint PAM"
+grep -Fq 'omarchy-lock-fingerprint' "$migration" ||
+  fail "migration targets omarchy-lock-fingerprint"
+grep -Fq 'omarchy-hw-laptop-closed' "$migration" ||
+  fail "migration inserts the laptop-closed gate"
+pass "migration installs the lock fingerprint clamshell gate on existing installs"


### PR DESCRIPTION
## Summary
- Write the same clamshell `pam_exec` / `omarchy-hw-laptop-closed` gate into `omarchy-lock-fingerprint` that sudo and polkit already get.
- Cover both `omarchy-setup-security-fingerprint` and `omarchy-apply-lock`, so re-enrollment cannot wipe the gate.
- Migration repairs existing lock fingerprint PAM stacks. Lid closed → fingerprint skipped → fail closed (password is a separate PAM service).

Fixes #10096.
Fixes #10173.

## Test plan
- [x] `./test/shell.d/lock-fingerprint-clamshell-gate-test.sh`
