### PR TITLE
Keep update stay-awake state out of shared /tmp

### DIFF
--- a/bin/omarchy-update-stay-awake
+++ b/bin/omarchy-update-stay-awake
@@ -6,7 +6,32 @@
 
 set -e
 
-state_dir="${XDG_RUNTIME_DIR:-/tmp/omarchy-$UID}/omarchy-update-stay-awake"
+# Inhibit pid + idle-owner tokens must not land under a predictable name in
+# world-writable /tmp. XDG_RUNTIME_DIR is already 0700 when the session set it;
+# without one, use a private state dir we create/repair ourselves (same shape as
+# the screenrecording tip-ready fix) rather than a predictable /tmp name.
+private_root() {
+  local root mode
+
+  if [[ -n ${XDG_RUNTIME_DIR:-} ]]; then
+    printf '%s\n' "$XDG_RUNTIME_DIR"
+    return 0
+  fi
+
+  root="${XDG_STATE_HOME:-$HOME/.local/state}/omarchy"
+  mkdir -p "$root" || return 1
+  chmod 700 "$root" || return 1
+  [[ -O $root ]] || return 1
+  mode=$(stat -c '%a' "$root" 2>/dev/null || stat -f '%Lp' "$root")
+  [[ $mode == 700 ]] || return 1
+  printf '%s\n' "$root"
+}
+
+state_root=$(private_root) || {
+  echo "Failed to resolve a private state directory for update stay-awake." >&2
+  exit 1
+}
+state_dir="$state_root/omarchy-update-stay-awake"
 idle_owner_file="$state_dir/idle-owner"
 inhibit_pid_file="$state_dir/inhibit-pid"
 stay_awake_state="$HOME/.local/state/omarchy/indicators/stay-awake"
@@ -88,6 +113,7 @@ start() {
 
   stop
   mkdir -p "$state_dir"
+  chmod 700 "$state_dir" 2>/dev/null || true
 
   if omarchy-cmd-present systemd-inhibit; then
     if (( EUID != 0 )); then

--- a/test/shell.d/update-stay-awake-path-test.sh
+++ b/test/shell.d/update-stay-awake-path-test.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+stub_bin="$tmp/bin"
+mkdir -p "$stub_bin" "$tmp/home" "$tmp/run" "$tmp/state"
+
+cat >"$stub_bin/omarchy-cmd-present" <<'SH'
+#!/bin/bash
+[[ $1 == systemd-inhibit ]] && exit 1
+exit 1
+SH
+
+cat >"$stub_bin/omarchy-toggle-idle" <<'SH'
+#!/bin/bash
+exit 0
+SH
+
+chmod +x "$stub_bin"/*
+export PATH="$stub_bin:$PATH"
+export HOME="$tmp/home"
+unset XDG_RUNTIME_DIR
+export XDG_STATE_HOME="$tmp/state"
+
+script="$ROOT/bin/omarchy-update-stay-awake"
+
+# Tip still names /tmp/omarchy-$UID; the tip-ready body must not.
+if grep -q '/tmp/omarchy-\$UID\|/tmp/omarchy-$UID' "$script"; then
+  fail "stay-awake no longer falls back to /tmp/omarchy-\$UID"
+fi
+pass "stay-awake source does not name /tmp/omarchy-\$UID"
+
+# Without XDG_RUNTIME_DIR, start must stage under the private state home.
+bash "$script" start >/dev/null
+
+state_dir="$XDG_STATE_HOME/omarchy/omarchy-update-stay-awake"
+[[ -d $state_dir ]] || fail "creates state under XDG_STATE_HOME/omarchy" "$(find "$tmp" -type d)"
+pass "creates state under XDG_STATE_HOME/omarchy"
+
+mode=$(stat -c '%a' "$XDG_STATE_HOME/omarchy" 2>/dev/null || stat -f '%Lp' "$XDG_STATE_HOME/omarchy")
+[[ $mode == 700 ]] || fail "private root is mode 0700" "mode=$mode"
+pass "private root is mode 0700"
+
+[[ ! -e /tmp/omarchy-$UID/omarchy-update-stay-awake ]] ||
+  fail "does not create /tmp/omarchy-\$UID/omarchy-update-stay-awake"
+pass "does not create /tmp/omarchy-\$UID/omarchy-update-stay-awake"
+
+# With XDG_RUNTIME_DIR set, prefer it.
+export XDG_RUNTIME_DIR="$tmp/run"
+bash "$script" stop >/dev/null 2>&1 || true
+bash "$script" start >/dev/null
+[[ -d $XDG_RUNTIME_DIR/omarchy-update-stay-awake ]] ||
+  fail "prefers XDG_RUNTIME_DIR when set"
+pass "prefers XDG_RUNTIME_DIR when set"


### PR DESCRIPTION
## Summary
- `omarchy-update-stay-awake` no longer falls back to predictable `/tmp/omarchy-$UID`.
- Prefer `XDG_RUNTIME_DIR`; otherwise a private 0700 owner-checked directory under `XDG_STATE_HOME`/`~/.local/state/omarchy`.

Fixes #11595.

## Test plan
- [x] `./test/shell.d/update-stay-awake-path-test.sh`
