### PR TITLE
Keep capture-region markers out of shared /tmp

### DIFF
--- a/bin/omarchy-capture-region
+++ b/bin/omarchy-capture-region
@@ -20,8 +20,32 @@
 #   --match-monitor print "monitor:NAME" instead when the picked geometry
 #                   exactly matches a monitor
 
-FULLSCREEN_MARKER="${XDG_RUNTIME_DIR:-/tmp}/omarchy-capture-region-fullscreen"
-WINDOW_MARKER="${XDG_RUNTIME_DIR:-/tmp}/omarchy-capture-region-window"
+# Fullscreen/window markers must not sit at fixed names in world-writable /tmp.
+# Prefer XDG_RUNTIME_DIR; otherwise a private 0700 owner-checked state dir.
+private_marker_root() {
+  local root mode
+
+  if [[ -n ${XDG_RUNTIME_DIR:-} ]]; then
+    printf '%s\n' "$XDG_RUNTIME_DIR"
+    return 0
+  fi
+
+  root="${XDG_STATE_HOME:-$HOME/.local/state}/omarchy"
+  mkdir -p "$root" || return 1
+  chmod 700 "$root" || return 1
+  [[ -O $root ]] || return 1
+  mode=$(stat -c '%a' "$root" 2>/dev/null || stat -f '%Lp' "$root")
+  [[ $mode == 700 ]] || return 1
+  printf '%s\n' "$root"
+}
+
+marker_root=$(private_marker_root) || {
+  echo "Failed to resolve a private directory for capture-region markers." >&2
+  exit 1
+}
+mkdir -p "$marker_root"
+FULLSCREEN_MARKER="$marker_root/omarchy-capture-region-fullscreen"
+WINDOW_MARKER="$marker_root/omarchy-capture-region-window"
 
 # accounting for portrait/transformed displays
 JQ_MONITOR_GEO='

--- a/test/shell.d/capture-region-marker-path-test.sh
+++ b/test/shell.d/capture-region-marker-path-test.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+script="$ROOT/bin/omarchy-capture-region"
+
+if grep -Fq '${XDG_RUNTIME_DIR:-/tmp}/omarchy-capture-region-fullscreen' "$script"; then
+  fail "capture-region fullscreen marker no longer falls back to /tmp"
+fi
+if grep -Fq '${XDG_RUNTIME_DIR:-/tmp}/omarchy-capture-region-window' "$script"; then
+  fail "capture-region window marker no longer falls back to /tmp"
+fi
+
+grep -Fq 'private_marker_root' "$script" || fail "capture-region resolves a private marker root"
+grep -Fq 'XDG_STATE_HOME' "$script" || fail "capture-region falls back to XDG_STATE_HOME when runtime dir is unset"
+grep -Fq 'chmod 700' "$script" || fail "capture-region enforces mode 0700 on the private marker root"
+pass "capture-region marker paths avoid world-writable /tmp"


### PR DESCRIPTION
## Summary
- `omarchy-capture-region` fullscreen/window markers no longer fall back to fixed names in world-writable `/tmp`.
- Prefer `XDG_RUNTIME_DIR`; otherwise a private 0700 owner-checked state directory.

Fixes #11597.

## Test plan
- [x] `./test/shell.d/capture-region-marker-path-test.sh`
