### PR TITLE
Default OMARCHY_PATH and stop advertising sudo for plymouth set

### DIFF
--- a/bin/omarchy-plymouth-set
+++ b/bin/omarchy-plymouth-set
@@ -3,9 +3,15 @@
 # omarchy:summary=Set the Plymouth boot theme colors and logo
 # omarchy:args=<background-hex> <text-hex> <path-to-logo.png>
 # omarchy:examples=omarchy plymouth set '#1d2021' '#ebdbb2' ~/.local/state/omarchy/current/theme/plymouth/logo.png
-# omarchy:requires-sudo=true
 
 set -euo pipefail
+
+# Self-elevates for the publish transaction. Do not advertise requires-sudo: a
+# leading `sudo omarchy plymouth set` strips OMARCHY_PATH and used to half-apply
+# the theme while still rebuilding the initramfs (#10036).
+
+# Session env usually exports this; fall back for non-login / stripped environments.
+: "${OMARCHY_PATH:=/usr/share/omarchy}"
 
 # Build the authoritative theme in a root-owned directory, then publish each
 # fixed destination atomically. The caller opens the selected logo before sudo,

--- a/bin/omarchy-plymouth-set-by-theme
+++ b/bin/omarchy-plymouth-set-by-theme
@@ -2,7 +2,6 @@
 
 # omarchy:summary=Set the Plymouth boot theme from an Omarchy theme
 # omarchy:args=<theme-name>
-# omarchy:requires-sudo=true
 
 # Resolve a theme by name and apply its unlock.png + colors.toml as the
 # Plymouth boot screen via omarchy-plymouth-set.

--- a/test/shell.d/plymouth-set-test.sh
+++ b/test/shell.d/plymouth-set-test.sh
@@ -73,6 +73,22 @@ else
 fi
 pass "the logo descriptor can only be opened by an unprivileged caller"
 
+# OMARCHY_PATH is normally session-exported. When it is unset (sudo env_reset,
+# non-login shells), fall back to the packaged tree instead of expanding paths
+# under /default/... and half-applying a theme.
+if grep -q 'OMARCHY_PATH:=/usr/share/omarchy' "$ROOT/bin/omarchy-plymouth-set"; then
+  pass "omarchy-plymouth-set falls back to /usr/share/omarchy when OMARCHY_PATH is unset"
+else
+  fail "omarchy-plymouth-set must default OMARCHY_PATH to /usr/share/omarchy"
+fi
+
+if grep -q 'omarchy:requires-sudo=true' "$ROOT/bin/omarchy-plymouth-set"; then
+  fail "omarchy-plymouth-set must not advertise requires-sudo (invites sudo and strips OMARCHY_PATH)"
+else
+  pass "omarchy-plymouth-set does not advertise requires-sudo"
+fi
+
+
 # Style > Unlock picks a theme by name and hands the answer to
 # omarchy-launch-floating-terminal-with-presentation, which joins its arguments
 # into a script and runs that with `bash -c`. So the name is shell source


### PR DESCRIPTION
## Summary
- Fall back to `/usr/share/omarchy` when `OMARCHY_PATH` is unset so a stripped environment cannot half-apply Plymouth assets under `/default/...`.
- Drop `requires-sudo` metadata on `omarchy-plymouth-set` (and the by-theme wrapper) so help/json no longer invite a leading `sudo` that clears the session env. Root invocation is still refused; the script self-elevates for publish.

Fixes #10036

## Test plan
- [ ] `./test/shell.d/plymouth-set-test.sh` on Linux
- [ ] `env -u OMARCHY_PATH omarchy plymouth set ...` uses packaged assets
- [ ] `sudo omarchy plymouth set ...` still refuses and does not rebuild initramfs via a half-applied path
- [ ] `omarchy commands --json` no longer marks plymouth set as requires_sudo