### PR TITLE
Shield pacman transactions from desktop session teardown

### DIFF
--- a/bin/omarchy-channel-set
+++ b/bin/omarchy-channel-set
@@ -85,7 +85,7 @@ fi
 
 omarchy-refresh-pacman "$pacman_channel"
 # --ask 4 accepts omarchy <-> omarchy-dev replacement prompts without file overwrites.
-sudo env OMARCHY_UPDATE_PACMAN=1 pacman -S --needed --noconfirm --ask 4 "${packages[@]}"
+omarchy-update-pacman -S --needed --noconfirm --ask 4 "${packages[@]}"
 
 if [[ -z $dev_checkout ]]; then
   omarchy-dev-unlink --no-reboot

--- a/bin/omarchy-channel-set
+++ b/bin/omarchy-channel-set
@@ -72,6 +72,10 @@ case "$channel" in
     ;;
 esac
 
+# A failure past this point leaves the channel switch half-applied, so say how
+# to pick it back up rather than dying silently under set -e.
+trap 'echo -e "\nThe channel switch did not complete. Review the error above, then rerun: omarchy-channel-set '"$channel"'" >&2' ERR
+
 if [[ -z $dev_checkout && $OMARCHY_PATH != "/usr/share/omarchy" ]]; then
   leaving_dev=1
 fi

--- a/bin/omarchy-launch-floating-terminal-with-presentation
+++ b/bin/omarchy-launch-floating-terminal-with-presentation
@@ -8,6 +8,7 @@
 source omarchy-restart-gum
 
 cmd="$*"
-presentation_script="omarchy-show-logo; $cmd; if (( \$? != 130 )); then omarchy-show-done; fi"
+# 130 is the user bailing with Ctrl-C; anything else gets the Done/Failed prompt.
+presentation_script="omarchy-show-logo; $cmd; code=\$?; if (( code != 130 )); then omarchy-show-done \$code; fi"
 
 exec setsid uwsm-app -- xdg-terminal-exec --app-id=org.omarchy.terminal --title=Omarchy -e bash -c "$presentation_script"

--- a/bin/omarchy-pkg-aur-install
+++ b/bin/omarchy-pkg-aur-install
@@ -24,6 +24,7 @@ if [[ -n $pkg_names ]]; then
   source omarchy-sudo-keepalive
 
   echo "$pkg_names" | sed 's/^/aur\//' | tr '\n' ' ' | xargs yay -S --noconfirm
+  code=$?
   sudo updatedb --prune-bind-mounts=no --add-prunepaths=/.snapshots
-  omarchy-show-done
+  omarchy-show-done $code
 fi

--- a/bin/omarchy-pkg-install
+++ b/bin/omarchy-pkg-install
@@ -22,5 +22,5 @@ if [[ -n $pkg_names ]]; then
 
   # Convert newline-separated selections to space-separated for pacman
   echo "$pkg_names" | tr '\n' ' ' | xargs sudo pacman -S --noconfirm
-  omarchy-show-done
+  omarchy-show-done $?
 fi

--- a/bin/omarchy-pkg-remove
+++ b/bin/omarchy-pkg-remove
@@ -20,5 +20,5 @@ pkg_names=$(yay -Qqe | fzf "${fzf_args[@]}")
 if [[ -n $pkg_names ]]; then
   # Convert newline-separated selections to space-separated for yay
   echo "$pkg_names" | tr '\n' ' ' | xargs sudo pacman -Rns --noconfirm
-  omarchy-show-done
+  omarchy-show-done $?
 fi

--- a/bin/omarchy-refresh-pacman
+++ b/bin/omarchy-refresh-pacman
@@ -23,4 +23,4 @@ sudo cp -f "$OMARCHY_PATH/default/pacman/mirrorlist-$channel" /etc/pacman.d/mirr
 omarchy-hook pre-refresh-pacman
 
 # Reset all package DBs and then update
-sudo env OMARCHY_UPDATE_PACMAN=1 pacman -Syyuu --noconfirm
+omarchy-update-pacman -Syyuu --noconfirm

--- a/bin/omarchy-reinstall-pkgs
+++ b/bin/omarchy-reinstall-pkgs
@@ -11,8 +11,8 @@ set -e
 omarchy-refresh-pacman
 
 # Downgrade any packages to the stable setup
-sudo env OMARCHY_UPDATE_PACMAN=1 pacman -Suu --noconfirm
+omarchy-update-pacman -Suu --noconfirm
 
 # Ensure all packages are installed
 mapfile -t packages < <(grep -v '^#' "$OMARCHY_PATH/install/omarchy-base.packages" | grep -v '^$')
-sudo env OMARCHY_UPDATE_PACMAN=1 pacman -Syu --noconfirm --needed "${packages[@]}"
+omarchy-update-pacman -Syu --noconfirm --needed "${packages[@]}"

--- a/bin/omarchy-show-done
+++ b/bin/omarchy-show-done
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-# omarchy:summary=Display a "Done!" message and wait for user to press any key.
+# omarchy:summary=Display a "Done!" or "Failed!" message and wait for user to press any key.
+# omarchy:args=[exit-code]
+
+code="${1:-0}"
 
 # The device node is there whether or not a terminal is behind it, so opening
 # it is the only test that means anything.
@@ -13,6 +16,10 @@ while read -rsn 1 -t 0.1 _ </dev/tty; do :; done
 
 # Prompt on the terminal rather than stdout, or a caller that redirects us
 # leaves the user waiting on a prompt they were never shown.
-printf '\n\033[32m● \033[0mDone! Press any key to close...' >/dev/tty
+if (( code == 0 )); then
+  printf '\n\033[32m● \033[0mDone! Press any key to close...' >/dev/tty
+else
+  printf '\n\033[31m● \033[0mFailed (exit code %d)! Press any key to close...' "$code" >/dev/tty
+fi
 read -rsn 1 </dev/tty
 echo >/dev/tty

--- a/bin/omarchy-update-pacman
+++ b/bin/omarchy-update-pacman
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# omarchy:summary=Run a pacman transaction for the Omarchy update flow, shielded from desktop session teardown.
+# omarchy:args=<pacman-args>
+# omarchy:hidden=true
+# omarchy:requires-sudo=true
+
+# Upgrading systemd runs its post_upgrade scriptlet mid-transaction, which
+# reexecs both the system manager and every user manager. A pacman running
+# inside a user-session scope can be SIGKILLed by that reexec, abandoning the
+# transaction halfway. Registering the transaction as a PID 1 scope keeps it
+# out of the user manager's cgroups entirely, and system scopes survive the
+# system manager's own reexec.
+scope=()
+if [[ -d /run/systemd/system && ! -L /run/systemd/system ]]; then
+  scope=(systemd-run --scope --quiet --collect)
+fi
+
+# LC_ALL passes through so callers that parse pacman's stderr can pin the locale.
+env_args=(OMARCHY_UPDATE_PACMAN=1)
+if [[ -n ${LC_ALL:-} ]]; then
+  env_args+=(LC_ALL="$LC_ALL")
+fi
+
+exec sudo env "${env_args[@]}" "${scope[@]}" pacman "$@"

--- a/bin/omarchy-update-system-pkgs
+++ b/bin/omarchy-update-system-pkgs
@@ -10,7 +10,7 @@ set -e
 # a stream, because an upgrade without --noconfirm prompts on stderr. The
 # handler has already said why, so no heading here either.
 if [[ ${OMARCHY_UPDATE_CONFLICT:-} == 1 && ${OMARCHY_UPDATE_INTERACTIVE:-} == 1 ]]; then
-  exec sudo env OMARCHY_UPDATE_PACMAN=1 pacman -Syu --overwrite '/usr/share/omarchy/*'
+  exec omarchy-update-pacman -Syu --overwrite '/usr/share/omarchy/*'
 fi
 
 echo -e "\e[32m\nUpdate system packages\e[0m"
@@ -23,7 +23,7 @@ trap 'rm -f "$errors"' EXIT
 #
 # Progress bars stay on stdout. Errors are on stderr, kept for the conflict
 # handler below; LC_ALL=C is what keeps them parseable in any locale.
-if sudo env LC_ALL=C OMARCHY_UPDATE_PACMAN=1 pacman -Syu --noconfirm \
+if LC_ALL=C omarchy-update-pacman -Syu --noconfirm \
   --overwrite '/usr/share/omarchy/*' 2>"$errors"; then
   cat "$errors" >&2
   exit 0

--- a/docs/update-process.md
+++ b/docs/update-process.md
@@ -82,13 +82,18 @@ Omarchy update command, the hook exits non-zero with `AbortOnFail`, which stops
 the transaction before packages are changed.
 
 `omarchy-update-system-pkgs`, `omarchy-refresh-pacman`, `omarchy-reinstall-pkgs`,
-`omarchy-channel-set`, and the v4 upgrader run pacman through:
+and `omarchy-channel-set` run pacman through the hidden `omarchy-update-pacman`
+helper (the v4 upgrader sets `OMARCHY_UPDATE_PACMAN=1` directly):
 
 ```bash
-env OMARCHY_UPDATE_PACMAN=1 pacman ...
+sudo env OMARCHY_UPDATE_PACMAN=1 systemd-run --scope --quiet --collect pacman ...
 ```
 
-so the guard allows Omarchy-owned update flows. A user can intentionally bypass
+so the guard allows Omarchy-owned update flows. The `systemd-run --scope`
+wrapper registers the transaction as a PID 1 scope: upgrading systemd reexecs
+the system and user managers mid-transaction, and a pacman left inside a
+user-session scope can be SIGKILLed by that reexec. On unbooted systems (such
+as the installer chroot) the helper runs pacman directly. A user can intentionally bypass
 the guard with:
 
 ```bash
@@ -272,12 +277,13 @@ scripts.
 | `omarchy-update-confirm` | Gum confirmation copy for `omarchy update`. | **Question.** Could be inlined into `omarchy-update`; separate file only helps keep copy isolated. |
 | `omarchy-update-dev` | Fast-forwards the active dev-linked checkout from its configured upstream; no-ops for package-backed installs. | **Keep.** Runs before package updates so a checkout conflict stops the update before system mutation. |
 | `omarchy-update-keyring` | Ensures Omarchy keyring and Arch keyring are current before the main transaction. | **Keep, but review.** It uses targeted `pacman -Sy` for keyring bootstrapping; acceptable for this special case but should remain tightly scoped. |
-| `omarchy-update-system-pkgs` | Runs `sudo env OMARCHY_UPDATE_PACMAN=1 pacman -Syu --noconfirm` with `--overwrite '/usr/share/omarchy/*'`, capturing stderr to a report file; on failure it execs `omarchy-update-system-pkgs-when-conflicted`. | **Keep for now.** Small leaf command, clear/testable. |
+| `omarchy-update-system-pkgs` | Runs `omarchy-update-pacman -Syu --noconfirm` with `--overwrite '/usr/share/omarchy/*'`, capturing stderr to a report file; on failure it execs `omarchy-update-system-pkgs-when-conflicted`. | **Keep for now.** Small leaf command, clear/testable. |
 | `omarchy-update-system-pkgs-when-conflicted` | Hidden conflict handler: quarantines unowned conflicting files under `/var/lib/omarchy/replaced`, retries the upgrade once, restores files the upgrade didn't claim, and hands package-vs-package conflicts to an interactive pacman run (never under `-y`). | **Keep internal/hidden.** Keeps conflict recovery out of the happy path. |
 | `omarchy-update-pkg-prune` | Trims the pacman cache to two versions per package (`paccache -rk2`) before the snapshot, keeping the offline downgrade path while capping snapshot growth. | **Keep internal/hidden.** |
 | `omarchy-update-requires-free-space` | Aborts the update below a 10 GiB free-space threshold on `/`; silently skipped when free space cannot be determined; `OMARCHY_UPDATE_FORCE=1` bypasses. | **Keep internal/hidden.** |
 | `omarchy-migrate` | Public migration command. Waits for pacman, then runs all pending migrations for the current user. Supports `--pending`. | **Keep.** This replaces the discarded `omarchy-update-user-finalize` name and no longer needs `--force`. |
 | `omarchy-update-pacman-guard` | ALPM pre-transaction guard that aborts direct `pacman -Syu` style upgrades unless Omarchy set `OMARCHY_UPDATE_PACMAN=1` or the user explicitly set `OMARCHY_ALLOW_DIRECT_PACMAN=1`. | **Keep internal/hidden.** This is what nudges users back to `omarchy update`. |
+| `omarchy-update-pacman` | Hidden helper that runs a guard-approved pacman transaction as a PID 1 scope (`systemd-run --scope`) so a mid-transaction systemd reexec cannot kill it; runs pacman directly when not booted under systemd. | **Keep internal/hidden.** Single place that owns how Omarchy invokes pacman for system mutation. |
 | `omarchy-migrate-notify` | Internal login-time notification helper. Uses `omarchy-migrate --pending` and shows a notification only when this user has pending migrations. | **Keep internal/hidden.** Clear name now that the public command is `omarchy-migrate`. |
 | `omarchy-update-user-notify` | Hidden compatibility wrapper for `omarchy-migrate-notify`. | **Temporary.** Keep only for old callers. |
 | `omarchy-update-available` | Update checker for shell widget and post-update refresh. | **Keep.** Could eventually be renamed `omarchy-update-check`, but current name matches widget semantics. |

--- a/test/shell.d/channel-test.sh
+++ b/test/shell.d/channel-test.sh
@@ -31,6 +31,12 @@ for arg in "$@"; do printf "\t%s" "$arg" >>"$OMARCHY_CHANNEL_TEST_LOG"; done
 printf "\n" >>"$OMARCHY_CHANNEL_TEST_LOG"
 '
 
+write_stub omarchy-update-pacman '#!/bin/bash
+printf "update-pacman" >>"$OMARCHY_CHANNEL_TEST_LOG"
+for arg in "$@"; do printf "\t%s" "$arg" >>"$OMARCHY_CHANNEL_TEST_LOG"; done
+printf "\n" >>"$OMARCHY_CHANNEL_TEST_LOG"
+'
+
 write_stub omarchy-dev-unlink '#!/bin/bash
 printf "unlink" >>"$OMARCHY_CHANNEL_TEST_LOG"
 for arg in "$@"; do printf "\t%s" "$arg" >>"$OMARCHY_CHANNEL_TEST_LOG"; done
@@ -106,7 +112,7 @@ assert_log_line() {
 
 run_channel stable
 assert_log_line $'refresh\tstable' "stable refreshes the stable pacman channel"
-assert_log_line $'sudo\tenv\tOMARCHY_UPDATE_PACMAN=1\tpacman\t-S\t--needed\t--noconfirm\t--ask\t4\tomarchy\tomarchy-settings' "stable installs stable Omarchy packages"
+assert_log_line $'update-pacman\t-S\t--needed\t--noconfirm\t--ask\t4\tomarchy\tomarchy-settings' "stable installs stable Omarchy packages"
 assert_log_line $'unlink\t--no-reboot' "stable restores the package-backed Omarchy path without an early reboot prompt"
 assert_log_line $'update\t-y\tOMARCHY_PATH=/usr/share/omarchy' "stable runs the normal update pipeline from the package-backed path"
 if grep -q $'^state\tset\treboot-required$' "$log_file"; then
@@ -116,17 +122,17 @@ pass "stable does not require reboot when already package-backed"
 
 run_channel rc
 assert_log_line $'refresh\trc' "rc refreshes the rc pacman channel"
-assert_log_line $'sudo\tenv\tOMARCHY_UPDATE_PACMAN=1\tpacman\t-S\t--needed\t--noconfirm\t--ask\t4\tomarchy\tomarchy-settings' "rc installs rc Omarchy packages"
+assert_log_line $'update-pacman\t-S\t--needed\t--noconfirm\t--ask\t4\tomarchy\tomarchy-settings' "rc installs rc Omarchy packages"
 assert_log_line $'unlink\t--no-reboot' "rc restores the package-backed Omarchy path without an early reboot prompt"
 assert_log_line $'update\t-y\tOMARCHY_PATH=/usr/share/omarchy' "rc runs the normal update pipeline from the package-backed path"
 
 OMARCHY_TEST_PATH="$ROOT" run_channel edge
 assert_log_line $'refresh\tedge' "edge refreshes the edge pacman channel"
-assert_log_line $'sudo\tenv\tOMARCHY_UPDATE_PACMAN=1\tpacman\t-S\t--needed\t--noconfirm\t--ask\t4\tomarchy-dev\tomarchy-settings-dev' "edge installs development Omarchy packages"
+assert_log_line $'update-pacman\t-S\t--needed\t--noconfirm\t--ask\t4\tomarchy-dev\tomarchy-settings-dev' "edge installs development Omarchy packages"
 assert_log_line $'unlink\t--no-reboot' "edge unlinks dev without an early reboot prompt"
 assert_log_line $'state\tset\treboot-required' "edge marks reboot required when leaving dev"
 assert_log_line $'update\t-y\tOMARCHY_PATH=/usr/share/omarchy' "edge runs the normal update pipeline from the package-backed path"
-[[ $(grep -E '^(unlink|state|update)' "$log_file") == $'unlink\t--no-reboot\nstate\tset\treboot-required\nupdate\t-y\tOMARCHY_PATH=/usr/share/omarchy' ]] ||
+[[ $(grep -E $'^(unlink|state|update)\t' "$log_file") == $'unlink\t--no-reboot\nstate\tset\treboot-required\nupdate\t-y\tOMARCHY_PATH=/usr/share/omarchy' ]] ||
   fail "edge defers the reboot prompt until the update restart stage" "$(cat "$log_file")"
 pass "edge defers the reboot prompt until the update restart stage"
 
@@ -146,12 +152,12 @@ rmdir "$checkout"
 run_channel dev
 assert_log_line $'gum\tconfirm\t--default=false\tSwitch to dev channel?' "dev asks for confirmation"
 assert_log_line $'refresh\tedge' "dev refreshes the edge pacman channel"
-assert_log_line $'sudo\tenv\tOMARCHY_UPDATE_PACMAN=1\tpacman\t-S\t--needed\t--noconfirm\t--ask\t4\tomarchy-dev\tomarchy-settings-dev' "dev installs development Omarchy packages"
+assert_log_line $'update-pacman\t-S\t--needed\t--noconfirm\t--ask\t4\tomarchy-dev\tomarchy-settings-dev' "dev installs development Omarchy packages"
 assert_log_line $'git\tclone\thttps://github.com/basecamp/omarchy.git\t'"$checkout" "dev clones the source checkout to ~/omarchy"
 assert_log_line $'link\t'"$checkout"$'\t--no-reboot' "dev links ~/omarchy without an early reboot prompt"
 assert_log_line $'state\tset\treboot-required' "dev defers the reboot prompt to the update pipeline"
 assert_log_line $'update\t-y\tOMARCHY_PATH='"$checkout" "dev runs the normal update pipeline from the source checkout"
-[[ $(grep -E '^(git|link|state|refresh|sudo|update)' "$log_file") == $'git\tclone\thttps://github.com/basecamp/omarchy.git\t'"$checkout"$'\nlink\t'"$checkout"$'\t--no-reboot\nstate\tset\treboot-required\nrefresh\tedge\nsudo\tenv\tOMARCHY_UPDATE_PACMAN=1\tpacman\t-S\t--needed\t--noconfirm\t--ask\t4\tomarchy-dev\tomarchy-settings-dev\nupdate\t-y\tOMARCHY_PATH='"$checkout" ]] ||
+[[ $(grep -E '^(git|link|state|refresh|sudo|update)' "$log_file") == $'git\tclone\thttps://github.com/basecamp/omarchy.git\t'"$checkout"$'\nlink\t'"$checkout"$'\t--no-reboot\nstate\tset\treboot-required\nrefresh\tedge\nupdate-pacman\t-S\t--needed\t--noconfirm\t--ask\t4\tomarchy-dev\tomarchy-settings-dev\nupdate\t-y\tOMARCHY_PATH='"$checkout" ]] ||
   fail "dev activates the checkout before changing or updating packages" "$(cat "$log_file")"
 pass "dev activates the checkout before changing or updating packages"
 

--- a/test/shell.d/update-file-conflict-test.sh
+++ b/test/shell.d/update-file-conflict-test.sh
@@ -15,6 +15,14 @@ cat >"$stub_bin/sudo" <<'STUB'
 exec "$@"
 STUB
 
+# omarchy-update-pacman wraps the transaction in a real PID 1 scope; the tests
+# must stay inside the fixture, so drop the wrapper's options and run the command.
+cat >"$stub_bin/systemd-run" <<'STUB'
+#!/bin/bash
+while [[ $1 == -* ]]; do shift; done
+exec "$@"
+STUB
+
 # Fails the first -Syu with the report under test, then succeeds unless the case
 # asked for the retry to fail too.
 cat >"$stub_bin/pacman" <<'STUB'
@@ -40,7 +48,7 @@ fi
 echo "upgrade complete"
 STUB
 
-chmod +x "$stub_bin/sudo" "$stub_bin/pacman"
+chmod +x "$stub_bin/sudo" "$stub_bin/systemd-run" "$stub_bin/pacman"
 
 replaced="$test_tmp/replaced"
 

--- a/test/shell.d/update-package-conflict-test.sh
+++ b/test/shell.d/update-package-conflict-test.sh
@@ -17,6 +17,14 @@ cat >"$stub_bin/sudo" <<'STUB'
 exec "$@"
 STUB
 
+# omarchy-update-pacman wraps the transaction in a real PID 1 scope; the tests
+# must stay inside the fixture, so drop the wrapper's options and run the command.
+cat >"$stub_bin/systemd-run" <<'STUB'
+#!/bin/bash
+while [[ $1 == -* ]]; do shift; done
+exec "$@"
+STUB
+
 # Fails the first -Syu with the report under test, then succeeds. Every call
 # records its arguments and which of its streams reached a terminal: pacman puts
 # its questions on stderr once it is not running --noconfirm, so a retry meant
@@ -39,7 +47,7 @@ fi
 echo "upgrade complete"
 STUB
 
-chmod +x "$stub_bin/sudo" "$stub_bin/pacman"
+chmod +x "$stub_bin/sudo" "$stub_bin/systemd-run" "$stub_bin/pacman"
 
 # Everything a blocked qemu-common upgrade leaves on stderr, and no more. The
 # ":: ... Remove qemu-block-gluster? [y/N]" pacman asked is deliberately absent:

--- a/test/shell.d/update-pacman-test.sh
+++ b/test/shell.d/update-pacman-test.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+mkdir -p "$stub_bin"
+
+cat >"$stub_bin/sudo" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$*" >"$SUDO_CALL_LOG"
+STUB
+chmod +x "$stub_bin/sudo"
+
+run_helper() {
+  PATH="$stub_bin:$PATH" SUDO_CALL_LOG="$test_tmp/call" "$ROOT/bin/omarchy-update-pacman" "$@"
+}
+
+# The scope wrapper only applies on a systemd-booted host, so expect what the
+# helper's own booted check would decide for this machine.
+if [[ -d /run/systemd/system && ! -L /run/systemd/system ]]; then
+  expected_scope="systemd-run --scope --quiet --collect "
+else
+  expected_scope=""
+fi
+
+run_helper -Syu --noconfirm
+[[ $(cat "$test_tmp/call") == "env OMARCHY_UPDATE_PACMAN=1 ${expected_scope}pacman -Syu --noconfirm" ]] ||
+  fail "helper composes the guarded pacman invocation" "$(cat "$test_tmp/call")"
+pass "helper composes the guarded pacman invocation"
+
+LC_ALL=C run_helper -Syu
+[[ $(cat "$test_tmp/call") == "env OMARCHY_UPDATE_PACMAN=1 LC_ALL=C ${expected_scope}pacman -Syu" ]] ||
+  fail "helper forwards LC_ALL to the transaction" "$(cat "$test_tmp/call")"
+pass "helper forwards LC_ALL to the transaction"


### PR DESCRIPTION
## What happened

A `omarchy-channel-set dev` run died partway through `pacman -Syyuu` (15 of 133 packages in), yet the floating terminal closed on a green "Done!". The machine was left half-switched: dev-linked with the edge pacman.conf, but with 118 packages not upgraded, no post-transaction hooks run (mkinitcpio, nvidia), the omarchy-dev packages never installed, and no restart offer.

## Root cause

The upgrade batch included systemd 261.2 → 261.3. Arch's systemd `post_upgrade` scriptlet runs `systemctl --system daemon-reexec` plus a reload of every `user@*.service` **mid-transaction**. The journal shows PID 1 re-executing, then the user manager re-executing, and two seconds later pacman — which was running inside the user-session terminal scope (`app-Hyprland-xdg-terminal-exec-*.scope`) — received SIGKILL. No OOM (kernel or oomd) was involved.

Two omarchy gaps compounded it:

1. `omarchy-launch-floating-terminal-with-presentation` showed the green "Done!" for any exit code except 130, so the kill (exit 137) presented as success.
2. `omarchy-channel-set` runs under `set -e`, so the failure silently skipped the rest of the switch — including `omarchy-update -y`, the path that offers the restart.

## The fix

- **New hidden `omarchy-update-pacman` helper**: runs guard-approved pacman transactions as a PID 1 scope via `systemd-run --scope --quiet --collect`, keeping them out of the user manager's cgroups. System scopes survive the system manager's own reexec, and the transaction now also survives its terminal window closing. Falls back to plain pacman when not booted under systemd (installer chroot). All Omarchy-owned mutation sites route through it: `omarchy-refresh-pacman`, `omarchy-update-system-pkgs` (both paths), `omarchy-reinstall-pkgs`, `omarchy-channel-set`. The v4 upgrader is left alone since it must run in more exotic environments.
- **Failure-aware presentation**: `omarchy-show-done` takes the command's exit code and renders a red "Failed (exit code N)!" prompt when it is non-zero; the wrapper and the pkg install/remove pickers pass it through.
- **Resumable channel switch**: `omarchy-channel-set` traps ERR once it starts mutating the system and tells the user to rerun `omarchy-channel-set <channel>`.

## Testing

- `./test/cli` passes.
- `channel-test.sh` (updated to stub the new helper and keep asserting the mutation ordering) and `update-pacman-guard-test.sh` pass. The full `./test/shell` run currently hangs on the machine this was written on because `omarchy-migrate` is waiting on the stale `/var/lib/pacman/db.lck` the killed transaction left behind — the incident this PR fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
