### PR TITLE
fix(nightlight): detach hyprsunset stdio to prevent wrapper hang

### DIFF
--- a/bin/omarchy-toggle-nightlight
+++ b/bin/omarchy-toggle-nightlight
@@ -36,7 +36,7 @@ fi
 
 # Ensure hyprsunset is running
 if ! pgrep -x hyprsunset >/dev/null; then
-  setsid uwsm-app -- hyprsunset &
+  setsid uwsm-app -- hyprsunset >/dev/null 2>&1 &
 fi
 
 # Query the current temperature


### PR DESCRIPTION
Closes #11457

Starting `hyprsunset` via `setsid` without redirect leaves it holding the invoker's stdout/stderr. Any wrapper that captures output (e.g. `omasettings` via `head -c 4MB`) blocks forever on the pipe because the long-lived `hyprsunset` keeps the fd open, stalling subsequent settings changes.

Redirect stdio to `/dev/null` so the toggle's pipes close normally.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Pi](https://img.shields.io/badge/pi-0.85.1-000000)