### PR TITLE
Keep disabled display backlights off and preserve saved brightness

### DIFF
--- a/bin/omarchy-brightness-display
+++ b/bin/omarchy-brightness-display
@@ -59,10 +59,29 @@ fi
 
 step="$1"
 
+state_file="${XDG_RUNTIME_DIR:-/tmp}/omarchy-brightness-display.saved"
+
 if [[ $step == "off" ]]; then
+  # DPMS disable only blanks the signal — the backlight driver keeps the
+  # panel lit at its last level, showing as a dim glow. Zero the backlight
+  # too, saving the prior value so "on" can restore it.
+  if ! use_apple_display && ! use_ddc_display; then
+    device="$(omarchy-hw-display)" || device=""
+    if [[ -n $device ]]; then
+      backlight_brightness "$device" > "$state_file" 2>/dev/null
+      brightnessctl -d "$device" set 0 >/dev/null 2>&1
+    fi
+  fi
   hyprctl dispatch 'hl.dsp.dpms({ action = "disable" })' >/dev/null 2>&1
   exit 0
 elif [[ $step == "on" ]]; then
+  if ! use_apple_display && ! use_ddc_display; then
+    device="$(omarchy-hw-display)" || device=""
+    if [[ -n $device && -s $state_file ]]; then
+      brightnessctl -d "$device" set "$(cat "$state_file")%" >/dev/null 2>&1
+      rm -f "$state_file"
+    fi
+  fi
   # Skip the dispatch when every active display is already lit: a redundant
   # DPMS enable right after system resume forces another modeset, which blanks
   # the panel for a beat (visible flash at the unlock screen).

--- a/bin/omarchy-hyprland-monitor-internal
+++ b/bin/omarchy-hyprland-monitor-internal
@@ -6,6 +6,7 @@
 TOGGLE="internal-monitor-disable"
 TOGGLE_FLAG="$HOME/.local/state/omarchy/toggles/hypr/$TOGGLE.lua"
 MIRROR_TOGGLE="internal-monitor-mirror"
+BACKLIGHT_STATE="$HOME/.local/state/omarchy/toggles/hypr/internal-monitor-backlight"
 
 INTERNAL=$(omarchy-hyprland-monitor-laptop)
 
@@ -13,9 +14,28 @@ wake() {
   hyprctl dispatch 'hl.dsp.dpms({ action = "enable" })' >/dev/null 2>&1 || true
 }
 
+# `disabled = true` drops the panel's mode but leaves the backlight driver
+# powering it at its last level, so a "disabled" panel still glows. Zero the
+# backlight too, saving the prior level so restore_backlight can put it back.
+dim_backlight() {
+  local device
+  device="$(omarchy-hw-display)" 2>/dev/null || return 0
+  brightnessctl -d "$device" -m 2>/dev/null | awk -F, '{ gsub("%", "", $4); print $4 }' >"$BACKLIGHT_STATE"
+  brightnessctl -d "$device" set 0 >/dev/null 2>&1
+}
+
+restore_backlight() {
+  local device
+  [[ -s $BACKLIGHT_STATE ]] || return 0
+  device="$(omarchy-hw-display)" 2>/dev/null || return 0
+  brightnessctl -d "$device" set "$(<"$BACKLIGHT_STATE")%" >/dev/null 2>&1
+  rm -f "$BACKLIGHT_STATE"
+}
+
 on() {
   if omarchy-hyprland-toggle-enabled $TOGGLE; then
     omarchy-hyprland-toggle $TOGGLE off
+    restore_backlight
     omarchy-notification-send -g 󰍹 "Laptop display enabled"
   fi
 
@@ -44,6 +64,7 @@ off() {
     printf 'hl.monitor({ output = "%s", disabled = true })\n' "$INTERNAL" >"$TOGGLE_FLAG"
     omarchy-notification-send -g 󰍹 "Laptop display disabled"
     hyprctl reload
+    dim_backlight
   fi
 }
 
@@ -55,6 +76,7 @@ recover() {
   omarchy-hyprland-toggle-enabled $TOGGLE || return 0
 
   omarchy-hyprland-toggle $TOGGLE off
+  restore_backlight
   wake
 }
 


### PR DESCRIPTION
This carries forward the implementation from #9189 by @lewapf, with the regression fix described below. The original commits and authorship are preserved. It overlaps #9189; maintainers should choose one implementation, not merge both. The fix can also be incorporated into the original PR.

Repeated `omarchy-brightness-display off` calls overwrite the saved brightness with zero, so `on` restores a dark screen. Preserve the first saved value until restoration succeeds, and retain it if `brightnessctl` fails so a later `on` can retry.


Validation: reproduced `off -> off -> on` restoring zero on the original head; mocked regression and existing brightness tests pass with the fix, including failed-restore retry. Syntax and diff checks pass. `./test/all` ran in a temporary-home sandbox: CLI passed; five shell test files failed (config, network-qr, snapper, theme-install-guards, unowned-system-paths). No laptop/backlight hardware or VM acceptance testing was performed.
