### PR TITLE
Notify on agent limit resets with provider and deadline reconciliation

### DIFF
--- a/shell/plugins/agents/Main.qml
+++ b/shell/plugins/agents/Main.qml
@@ -76,8 +76,70 @@ Item {
 
   function recordsChanged() {
     dataRevision++
+    scheduleLimitResetNotifications()
     scheduleLimitsRetry()
     scheduleSync()
+  }
+
+  // A reset deadline is stable for the lifetime of a rate-limit window. Keep
+  // the deadlines we first see in memory and announce them when they pass;
+  // this stays accurate even when the normal usage refresh is deliberately
+  // infrequent. Deadlines already past when the shell starts are ignored.
+  property var pendingLimitResets: ({})
+
+  function limitResetNotificationsEnabled() {
+    return setting("notifyOnLimitReset", true) !== false
+  }
+
+  function scheduleLimitResetNotifications() {
+    if (!limitResetNotificationsEnabled()) {
+      pendingLimitResets = ({})
+      return
+    }
+
+    var next = Object.assign({}, pendingLimitResets)
+    var now = Date.now()
+    for (var i = 0; i < agents.length; i++) {
+      var record = agents[i] ? agents[i].record : null
+      if (!record || !record.id || !providerEnabled(String(record.id))) continue
+      var limits = Array.isArray(record.limits) ? record.limits : []
+      for (var j = 0; j < limits.length; j++) {
+        var limit = limits[j] || {}
+        var resetAt = String(limit.resetsAt || "")
+        var resetMs = new Date(resetAt).getTime()
+        if (!isFinite(resetMs) || resetMs <= now) continue
+        var label = String(limit.title || limit.label || "Limit")
+        var key = String(record.id) + "\n" + label + "\n" + resetAt
+        next[key] = {
+          deadline: resetMs,
+          providerName: String(record.name || record.id),
+          label: label
+        }
+      }
+    }
+    pendingLimitResets = next
+  }
+
+  function announcePassedLimitResets() {
+    if (!limitResetNotificationsEnabled()) return
+    var now = Date.now()
+    var next = Object.assign({}, pendingLimitResets)
+    for (var key in pendingLimitResets) {
+      var reset = pendingLimitResets[key]
+      if (!reset || reset.deadline > now) continue
+      Quickshell.execDetached(["omarchy-notification-send",
+        reset.providerName + " limit reset",
+        reset.label + " is available again."])
+      delete next[key]
+    }
+    pendingLimitResets = next
+  }
+
+  Timer {
+    interval: 15000
+    running: root.limitResetNotificationsEnabled()
+    repeat: true
+    onTriggered: root.announcePassedLimitResets()
   }
 
   // A collector that could not reach its limits endpoint at all — typically

--- a/shell/plugins/agents/manifest.json
+++ b/shell/plugins/agents/manifest.json
@@ -23,6 +23,7 @@
         "codex": { "enabled": true },
         "fireworks": { "enabled": true }
       },
+      "notifyOnLimitReset": true,
       "refreshIntervalSec": 900,
       "syncMode": "Off",
       "syncDir": "",
@@ -30,6 +31,7 @@
       "syncDeviceId": ""
     },
     "schema": [
+      { "key": "notifyOnLimitReset", "type": "boolean", "label": "Notify when limits reset", "defaultValue": true, "description": "Show a desktop notification when a tracked rate-limit window becomes available again." },
       { "key": "refreshIntervalSec", "type": "integer", "label": "Refresh interval (seconds)", "min": 30, "max": 3600, "step": 30, "defaultValue": 900 },
       { "key": "syncMode", "type": "enum", "label": "Synced aggregation", "options": ["Off", "On"], "defaultValue": "Off", "description": "When On, write this machine's local usage snapshot and merge snapshots from other machines." },
       { "key": "syncDir", "type": "path", "label": "Sync folder", "defaultValue": "", "description": "A folder synced by Syncthing, Dropbox, rsync, etc." },

--- a/test/shell.d/agents-panel-test.sh
+++ b/test/shell.d/agents-panel-test.sh
@@ -7,6 +7,8 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 run_node_test <<'JS'
 const fs = require('fs')
 const panelSource = fs.readFileSync(root + '/shell/plugins/agents/Panel.qml', 'utf8')
+const mainSource = fs.readFileSync(root + '/shell/plugins/agents/Main.qml', 'utf8')
+const manifest = JSON.parse(fs.readFileSync(root + '/shell/plugins/agents/manifest.json', 'utf8'))
 
 assert(/function launchAgent\(\)/.test(panelSource), 'agents panel launches the default agent')
 assert(/root\.bar\.run\("omarchy-agent --pick"\)/.test(panelSource), 'agents panel uses the desktop agent launcher')
@@ -14,4 +16,9 @@ assert(/if \(buttonCode === Qt\.RightButton\) root\.launchAgent\(\)/.test(panelS
 assert(/else if \(buttonCode === Qt\.MiddleButton\) root\.selectProvider\(root\.providerIndex \+ 1\)/.test(panelSource), 'agents middle click still advances the subscription')
 assert(/else root\.toggle\(\)/.test(panelSource), 'agents left click still toggles the panel')
 assert(!/if \(buttonCode === Qt\.RightButton\) root\.refreshNow\(\)/.test(panelSource), 'agents right click no longer refreshes')
+assert(/function scheduleLimitResetNotifications\(\)/.test(mainSource), 'agents schedule future limit resets')
+assert(/function announcePassedLimitResets\(\)/.test(mainSource), 'agents announce passed limit resets')
+assert(/Quickshell\.execDetached\(\["omarchy-notification-send"/.test(mainSource), 'agents use the Omarchy notification helper')
+assertEqual(manifest.barWidget.defaults.notifyOnLimitReset, true, 'agents enable reset notifications by default')
+assert(manifest.barWidget.schema.some(field => field.key === 'notifyOnLimitReset' && field.type === 'boolean'), 'agents expose the reset notification toggle')
 JS


### PR DESCRIPTION
This carries forward the implementation from #9885 by @szalikdev, with the regression fix described below. The original commits and authorship are preserved. It overlaps #9885; maintainers should choose one implementation, not merge both. The fix can also be incorporated into the original PR.

A provider disabled after scheduling can still emit a reset notification, and refreshed reset windows can leave obsolete deadlines queued. Recheck provider enablement when announcing, replace future deadlines from nonempty provider responses, and clear pending state when reset notifications are disabled.


Validation: 26 focused mock-clock assertions pass, including disabled-provider suppression, changed/removed deadlines, empty fetches, refresh-after-deadline, and due-plus-future rollover. Independent review checked the QML integration and notification lifecycle. `./test/all` ran in a temporary-home sandbox: CLI passed; five shell test files failed (config, network-qr, snapper, theme-install-guards, unowned-system-paths). Final focused assertions were rerun after the timer-race correction. Live Quickshell/notification and VM acceptance testing remain outstanding.
