### PR TITLE
Preserve menu position and search state when navigating back

### DIFF
--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -1137,7 +1137,7 @@ Item {
             if (root.filterText) root.setFilter("")
             else root.cancel()
             event.accepted = true
-          } else if (event.key === Qt.Key_Left) {
+          } else if (event.key === Qt.Key_Left && !root.dmenuActive) {
             root.goBack()
             event.accepted = true
           } else if (Util.editsFilter(event, root.filterText)) {

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -1134,10 +1134,13 @@ Item {
             if (root.filterText) root.setFilter("")
             else root.cancel()
             event.accepted = true
+          } else if (event.key === Qt.Key_Left) {
+            root.goBack()
+            event.accepted = true
           } else if (Util.editsFilter(event, root.filterText)) {
             root.setFilter(Util.editedFilter(event, root.filterText))
             event.accepted = true
-          } else if ((event.key === Qt.Key_Backspace || event.key === Qt.Key_Left) && !root.filterText) {
+          } else if (event.key === Qt.Key_Backspace && !root.filterText) {
             root.goBack()
             event.accepted = true
           } else if (event.key === Qt.Key_Up) {

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -743,7 +743,10 @@ Item {
   }
 
   function goBack() {
-    if (root.activeMenu === "root") return false
+    if (root.activeMenu === "root") {
+      if (root.filterText) root.setFilter("")
+      return false
+    }
 
     if (root.navStack.length > 0) {
       var previous = root.navStack[root.navStack.length - 1]

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -726,13 +726,14 @@ Item {
     root.rebuildDisplay()
   }
 
-  function setActiveMenu(id, pushHistory, fromPointer) {
+  function setActiveMenu(id, pushHistory, fromPointer, restoredIndex) {
     panel.freezeCardTop()
     if (!root.item(id)) id = "root"
-    if (pushHistory && id !== root.activeMenu) root.navStack = root.navStack.concat([root.activeMenu])
+    if (pushHistory && id !== root.activeMenu)
+      root.navStack = root.navStack.concat([{ id: root.activeMenu, selectedIndex: root.selectedIndex }])
     root.activeMenu = id
     root.filterText = ""
-    root.selectedIndex = 0
+    root.selectedIndex = restoredIndex === undefined ? 0 : restoredIndex
     root.cursorActive = true
     if (fromPointer) pointerGate.allowInitialSample()
     else root.disarmPointer()
@@ -747,7 +748,7 @@ Item {
     if (root.navStack.length > 0) {
       var previous = root.navStack[root.navStack.length - 1]
       root.navStack = root.navStack.slice(0, root.navStack.length - 1)
-      root.setActiveMenu(previous, false)
+      root.setActiveMenu(previous.id, false, false, previous.selectedIndex)
       return true
     }
 

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -732,7 +732,7 @@ Item {
     if (pushHistory && id !== root.activeMenu)
       root.navStack = root.navStack.concat([{ id: root.activeMenu, selectedIndex: root.selectedIndex, filterText: root.filterText }])
     root.activeMenu = id
-    root.filterText = restoredFilter === undefined ? root.filterText : restoredFilter
+    root.filterText = restoredFilter === undefined ? "" : restoredFilter
     root.selectedIndex = restoredIndex === undefined ? 0 : restoredIndex
     root.cursorActive = true
     if (fromPointer) pointerGate.allowInitialSample()

--- a/shell/plugins/menu/Menu.qml
+++ b/shell/plugins/menu/Menu.qml
@@ -726,13 +726,13 @@ Item {
     root.rebuildDisplay()
   }
 
-  function setActiveMenu(id, pushHistory, fromPointer, restoredIndex) {
+  function setActiveMenu(id, pushHistory, fromPointer, restoredIndex, restoredFilter) {
     panel.freezeCardTop()
     if (!root.item(id)) id = "root"
     if (pushHistory && id !== root.activeMenu)
-      root.navStack = root.navStack.concat([{ id: root.activeMenu, selectedIndex: root.selectedIndex }])
+      root.navStack = root.navStack.concat([{ id: root.activeMenu, selectedIndex: root.selectedIndex, filterText: root.filterText }])
     root.activeMenu = id
-    root.filterText = ""
+    root.filterText = restoredFilter === undefined ? root.filterText : restoredFilter
     root.selectedIndex = restoredIndex === undefined ? 0 : restoredIndex
     root.cursorActive = true
     if (fromPointer) pointerGate.allowInitialSample()
@@ -748,7 +748,7 @@ Item {
     if (root.navStack.length > 0) {
       var previous = root.navStack[root.navStack.length - 1]
       root.navStack = root.navStack.slice(0, root.navStack.length - 1)
-      root.setActiveMenu(previous.id, false, false, previous.selectedIndex)
+      root.setActiveMenu(previous.id, false, false, previous.selectedIndex, previous.filterText)
       return true
     }
 

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -495,8 +495,9 @@ assert(
   'menu route changes only accept an initial pointer sample for mouse activation'
 )
 assert(
-  /\(event\.key === Qt\.Key_Backspace \|\| event\.key === Qt\.Key_Left\) && !root\.filterText[\s\S]*root\.goBack\(\)/.test(menuQml),
-  'menu Left key follows empty-filter Backspace navigation'
+  /else if \(event\.key === Qt\.Key_Left\) \{\s*root\.goBack\(\)\s*event\.accepted = true\s*\} else if \(Util\.editsFilter\(event, root\.filterText\)\)/.test(menuQml)
+    && /event\.key === Qt\.Key_Backspace && !root\.filterText[\s\S]*root\.goBack\(\)/.test(menuQml),
+  'menu Left key navigates back while Backspace edits the current search'
 )
 assert(
   /PointerMoveGate\s*\{[\s\S]*id: pointerGate[\s\S]*referenceItem: card[\s\S]*\}/.test(menuQml),

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -495,10 +495,10 @@ assert(
   'menu route changes only accept an initial pointer sample for mouse activation'
 )
 assert(
-  /else if \(event\.key === Qt\.Key_Left\) \{\s*root\.goBack\(\)\s*event\.accepted = true\s*\} else if \(Util\.editsFilter\(event, root\.filterText\)\)/.test(menuQml)
+  /else if \(event\.key === Qt\.Key_Left && !root\.dmenuActive\) \{\s*root\.goBack\(\)\s*event\.accepted = true\s*\} else if \(Util\.editsFilter\(event, root\.filterText\)\)/.test(menuQml)
     && /event\.key === Qt\.Key_Backspace && !root\.filterText[\s\S]*root\.goBack\(\)/.test(menuQml)
     && /function goBack\(\) \{\s*if \(root\.activeMenu === "root"\) \{\s*if \(root\.filterText\) root\.setFilter\(""\)\s*return false/.test(menuQml),
-  'menu Left key returns to an unfiltered start while Backspace edits the current search'
+  'menu Left key returns to an unfiltered start without changing dmenu input'
 )
 assert(
   /PointerMoveGate\s*\{[\s\S]*id: pointerGate[\s\S]*referenceItem: card[\s\S]*\}/.test(menuQml),

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -60,9 +60,10 @@ assert(merged.items.root, 'menu injects root when merging sources')
 
 assertEqual(menu.slugify('Power Saver!'), 'power-saver', 'menu slugifies provider rows')
 assert(
-  /root\.navStack = root\.navStack\.concat\(\[\{ id: root\.activeMenu, selectedIndex: root\.selectedIndex \}\]\)/.test(menuQml)
-    && /root\.setActiveMenu\(previous\.id, false, false, previous\.selectedIndex\)/.test(menuQml),
-  'menu uses navigation history when entering and leaving submenus'
+  /root\.navStack = root\.navStack\.concat\(\[\{ id: root\.activeMenu, selectedIndex: root\.selectedIndex, filterText: root\.filterText \}\]\)/.test(menuQml)
+    && /root\.filterText = restoredFilter === undefined \? root\.filterText : restoredFilter/.test(menuQml)
+    && /root\.setActiveMenu\(previous\.id, false, false, previous\.selectedIndex, previous\.filterText\)/.test(menuQml),
+  'menu restores the selection and search query when leaving a submenu'
 )
 assertEqual(menu.pathFor(merged.items, 'style.theme'), 'Style › Theme picker', 'menu builds item paths')
 assertEqual(menu.parentPathFor(merged.items, 'style.theme'), 'Style', 'menu builds parent paths')
@@ -490,7 +491,7 @@ assert(
   'menu filter changes disarm pointer selection'
 )
 assert(
-  /function setActiveMenu\(id, pushHistory, fromPointer, restoredIndex\)[\s\S]*if \(fromPointer\) pointerGate\.allowInitialSample\(\)\s*else root\.disarmPointer\(\)/.test(menuQml),
+  /function setActiveMenu\(id, pushHistory, fromPointer, restoredIndex, restoredFilter\)[\s\S]*if \(fromPointer\) pointerGate\.allowInitialSample\(\)\s*else root\.disarmPointer\(\)/.test(menuQml),
   'menu route changes only accept an initial pointer sample for mouse activation'
 )
 assert(

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -496,8 +496,9 @@ assert(
 )
 assert(
   /else if \(event\.key === Qt\.Key_Left\) \{\s*root\.goBack\(\)\s*event\.accepted = true\s*\} else if \(Util\.editsFilter\(event, root\.filterText\)\)/.test(menuQml)
-    && /event\.key === Qt\.Key_Backspace && !root\.filterText[\s\S]*root\.goBack\(\)/.test(menuQml),
-  'menu Left key navigates back while Backspace edits the current search'
+    && /event\.key === Qt\.Key_Backspace && !root\.filterText[\s\S]*root\.goBack\(\)/.test(menuQml)
+    && /function goBack\(\) \{\s*if \(root\.activeMenu === "root"\) \{\s*if \(root\.filterText\) root\.setFilter\(""\)\s*return false/.test(menuQml),
+  'menu Left key returns to an unfiltered start while Backspace edits the current search'
 )
 assert(
   /PointerMoveGate\s*\{[\s\S]*id: pointerGate[\s\S]*referenceItem: card[\s\S]*\}/.test(menuQml),

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -61,9 +61,9 @@ assert(merged.items.root, 'menu injects root when merging sources')
 assertEqual(menu.slugify('Power Saver!'), 'power-saver', 'menu slugifies provider rows')
 assert(
   /root\.navStack = root\.navStack\.concat\(\[\{ id: root\.activeMenu, selectedIndex: root\.selectedIndex, filterText: root\.filterText \}\]\)/.test(menuQml)
-    && /root\.filterText = restoredFilter === undefined \? root\.filterText : restoredFilter/.test(menuQml)
+    && /root\.filterText = restoredFilter === undefined \? "" : restoredFilter/.test(menuQml)
     && /root\.setActiveMenu\(previous\.id, false, false, previous\.selectedIndex, previous\.filterText\)/.test(menuQml),
-  'menu restores the selection and search query when leaving a submenu'
+  'menu restores each menu\'s selection and search query when leaving a submenu'
 )
 assertEqual(menu.pathFor(merged.items, 'style.theme'), 'Style › Theme picker', 'menu builds item paths')
 assertEqual(menu.parentPathFor(merged.items, 'style.theme'), 'Style', 'menu builds parent paths')

--- a/test/shell.d/menu-test.sh
+++ b/test/shell.d/menu-test.sh
@@ -59,6 +59,11 @@ assertEqual(merged.items['style.theme'].order, 2, 'menu preserves original order
 assert(merged.items.root, 'menu injects root when merging sources')
 
 assertEqual(menu.slugify('Power Saver!'), 'power-saver', 'menu slugifies provider rows')
+assert(
+  /root\.navStack = root\.navStack\.concat\(\[\{ id: root\.activeMenu, selectedIndex: root\.selectedIndex \}\]\)/.test(menuQml)
+    && /root\.setActiveMenu\(previous\.id, false, false, previous\.selectedIndex\)/.test(menuQml),
+  'menu uses navigation history when entering and leaving submenus'
+)
 assertEqual(menu.pathFor(merged.items, 'style.theme'), 'Style › Theme picker', 'menu builds item paths')
 assertEqual(menu.parentPathFor(merged.items, 'style.theme'), 'Style', 'menu builds parent paths')
 assert(menu.isDescendantOf(merged.items, 'style.theme', 'style'), 'menu detects descendants')
@@ -485,7 +490,7 @@ assert(
   'menu filter changes disarm pointer selection'
 )
 assert(
-  /function setActiveMenu\(id, pushHistory, fromPointer\)[\s\S]*if \(fromPointer\) pointerGate\.allowInitialSample\(\)\s*else root\.disarmPointer\(\)/.test(menuQml),
+  /function setActiveMenu\(id, pushHistory, fromPointer, restoredIndex\)[\s\S]*if \(fromPointer\) pointerGate\.allowInitialSample\(\)\s*else root\.disarmPointer\(\)/.test(menuQml),
   'menu route changes only accept an initial pointer sample for mouse activation'
 )
 assert(


### PR DESCRIPTION
Re-open of #7800 (closed by the automated duplication check against #7074). Same branch and commits; GitHub does not let the author reopen a PR after a maintainer close.

## Why it changed

I liked exploring the menus with the keyboard and got annoyed the menu selection got reset on me and I couldn't go back a menu without backspacing an entire search.

#7074 and this PR both restore the selected row on `goBack()`. That is the overlap. This PR also restores per-level search state and changes Left-key navigation.

## What changes

Improves keyboard navigation in the Omarchy menu:

- Returning with `Left` or Backspace restores the previous menu’s selected row.
- Each menu level keeps its own search query:
  - entering a submenu starts with an empty search;
  - returning restores the parent menu’s search.
- `Left` always navigates back, including while a search query is active.
- At the top-level menu, `Left` clears the active search and returns to the normal starting view.
- Backspace continues to edit an active search; with an empty search it navigates back.
- dmenu input/select is unchanged (`!root.dmenuActive`).

## Difference from #7074

#7074 restores `{ id, index }` and still clears `filterText` on every menu change. Left/Backspace stay as they are today.

This PR restores `{ id, selectedIndex, filterText }`, and Left always goes back in regular menu mode.

Example: filter root to `st`, open Style, then go back. #7074 clears the search and applies the filtered index to the unfiltered list, so you land on a different row with the query gone. This PR restores both the query and the matching row.

| Behavior | #7074 | This PR (#7800 / #12759) |
|---|---|---|
| Restore selected row on back | yes | yes |
| Restore that menu’s search query | no | yes |
| Left while a search is typed | inert until the query is empty | always goes back (dmenu excluded) |
| Backspace with a search | edits the query | edits the query |
| Left on the top-level menu with a search | unchanged | clears search, unfiltered start |

## Validation

- `bash test/shell.d/menu-test.sh`
- `qmllint shell/plugins/menu/Menu.qml`
